### PR TITLE
Analytics: add performance metrics

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -85,6 +85,8 @@ export enum AnalyticsEvent {
   // Trading
   TradeOrderTypeSelected = 'TradeOrderTypeSelected',
   TradePlaceOrder = 'TradePlaceOrder',
+  TradePlaceOrderConfirmed = 'TradePlaceOrderConfirmed',
+  TradeCancelOrderConfirmed = 'TradeCancelOrderConfirmed',
 }
 
 export type AnalyticsEventData<T extends AnalyticsEvent> =
@@ -94,6 +96,12 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
   : T extends AnalyticsEvent.NetworkStatus ?
     {
       status: typeof AbacusApiStatus['name'];
+      /** Last time indexer node was queried successfully */
+      lastSuccessfulIndexerRpcQuery?: number;
+      /** Time elapsed since indexer node was queried successfully */
+      elapsedTime?: number;
+      blockHeight?: number;
+      indexerBlockHeight?: number;
     }
 
   // Navigation
@@ -151,6 +159,19 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
     SubaccountPlaceOrderPayload & {
       isClosePosition: boolean;
     }
-
+  : T extends AnalyticsEvent.TradePlaceOrderConfirmed ?
+    {
+      /** roundtrip time between user placing an order and confirmation from indexer (client → validator → indexer → client) */
+      roundtripMs: number;
+      /** URL/IP of node the order was sent to */
+      validator: string;
+    }
+  : T extends AnalyticsEvent.TradeCancelOrderConfirmed ?
+    {
+      /** roundtrip time between user canceling an order and confirmation from indexer (client → validator → indexer → client) */
+      roundtripMs: number;
+      /** URL/IP of node the order was sent to */
+      validator: string;
+    }
   :
-    {};
+    never;

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -235,8 +235,10 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
         execution: OrderExecution;
         postOnly: boolean;
         reduceOnly: boolean;
-      }) =>
-        await compositeClient?.placeOrder(
+      }) => {
+        const startTimestamp = performance.now();
+
+        const result = await compositeClient?.placeOrder(
           subaccount,
           marketId,
           type,
@@ -249,7 +251,17 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
           execution,
           postOnly,
           reduceOnly
-        ),
+        );
+
+        const endTimestamp = performance.now();
+
+        track(AnalyticsEvent.TradePlaceOrderConfirmed, {
+          roundtripMs: endTimestamp - startTimestamp,
+          validator: compositeClient!.validatorClient.config.restEndpoint,
+        });
+
+        return result;
+      },
 
       cancelOrderForSubaccount: async ({
         subaccount,
@@ -265,15 +277,27 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
         clobPairId: number;
         goodTilBlock?: number;
         goodTilBlockTime?: number;
-      }) =>
-        await compositeClient?.cancelOrder(
+      }) => {
+        const startTimestamp = performance.now();
+
+        const result = await compositeClient?.cancelOrder(
           subaccount,
           clientId,
           orderFlags,
           clobPairId,
           goodTilBlock,
           goodTilBlockTime
-        ),
+        )
+
+        const endTimestamp = performance.now();
+
+        track(AnalyticsEvent.TradeCancelOrderConfirmed, {
+          roundtripMs: endTimestamp - startTimestamp,
+          validator: compositeClient!.validatorClient.config.restEndpoint,
+        });
+
+        return result;
+      },
     }),
     [compositeClient]
   );

--- a/src/lib/abacus/websocket.ts
+++ b/src/lib/abacus/websocket.ts
@@ -11,6 +11,8 @@ import {
 import { subscriptionsByChannelId } from '@/lib/tradingView/dydxfeed/cache';
 import { mapCandle } from '@/lib/tradingView/utils';
 
+import { lastSuccessfulWebsocketRequestByOrigin } from '@/hooks/useAnalytics';
+
 import { log } from '../telemetry';
 
 const RECONNECT_INTERVAL_MS = 10_000;
@@ -154,6 +156,8 @@ class AbacusWebsocket implements Omit<AbacusWebsocketProtocol, '__doNotUseOrImpl
             this.receivedCallback(m.data);
           }
         }
+
+        lastSuccessfulWebsocketRequestByOrigin[new URL(this.url!).origin] = Date.now();
       } catch (error) {
         log('AbacusWebsocketProtocol/onmessage', error);
       }


### PR DESCRIPTION
Monitor network reliably + latency more closely by tracking the last time an indexer RPC call is successful as well as the round trip time for order placements.

---

## Hooks

* `hooks/useAnalytics`
  * `AnalyticsEvent.NetworkStatus`: send the timestamp of the last successful RPC query to an indexer node, as well as the block heights according to indexer and validator

* `hooks/useSubaccounts`
  * `AnalyticsEvent.TradePlaceOrderConfirmed` / `AnalyticsEvent.TradeCancelOrderConfirmed`: track the roundtrip time for placing/canceling orders (client → validator → indexer → client)

## Functions

* `lib/abacus`
  * track the timestamps of successful REST/WebSocket calls by URL origin

## Constants/Types

* `constants/analytics`
  * New: `AnalyticsEvent.TradePlaceOrderConfirmed` / `AnalyticsEvent.TradeCancelOrderConfirmed`