### PR TITLE
handle composite client error

### DIFF
--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -114,7 +114,7 @@ const useDydxClientContext = () => {
     }): Promise<Candle[]> => {
       try {
         const { candles } =
-          (await compositeClient!.indexerClient.markets.getPerpetualMarketCandles(
+          (await compositeClient?.indexerClient.markets.getPerpetualMarketCandles(
             marketId,
             RESOLUTION_MAP[resolution],
             fromIso,

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -46,6 +46,7 @@ class AbacusStateManager {
   websocket: AbacusWebsocket;
   stateNotifier: AbacusStateNotifier;
   abacusFormatter: AbacusFormatter;
+  chainTransactionClient: AbacusChainTransaction;
 
   constructor() {
     this.store = undefined;
@@ -53,12 +54,13 @@ class AbacusStateManager {
     this.stateNotifier = new AbacusStateNotifier();
     this.websocket = new AbacusWebsocket();
     this.abacusFormatter = new AbacusFormatter();
+    this.chainTransactionClient = new AbacusChainTransaction();
 
     const ioImplementations = new IOImplementations(
       // @ts-ignore
       new AbacusRest(),
       this.websocket,
-      new AbacusChainTransaction(),
+      this.chainTransactionClient,
       null,
       new AbacusThreading(),
       new CoroutineTimer(),
@@ -155,6 +157,7 @@ class AbacusStateManager {
   setStore = (store: RootStore) => {
     this.store = store;
     this.stateNotifier.setStore(store);
+    this.chainTransactionClient.setStore(store);
   };
 
   setAccount = (walletAddress: string) => {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,5 +1,7 @@
 export const log = (location: string, error: Error, metadata?: any) => {
-  // console.warn(error);
+  if (import.meta.env.MODE !== 'production') {
+    console.warn('telemetry/log:', { location, error, metadata });
+  }
 
   const customEvent = new CustomEvent('dydx:log', {
     detail: {
@@ -16,7 +18,10 @@ export const log = (location: string, error: Error, metadata?: any) => {
 globalThis.addEventListener('unhandledrejection', (event) => {
   event.preventDefault();
 
-  log('window/onunhandledrejection', new Error(`Promise rejected and uncaught; reason: ${event.reason}`));
+  log(
+    'window/onunhandledrejection',
+    new Error(`Promise rejected and uncaught; reason: ${event.reason}`)
+  );
 });
 
 // Log rejected Promises that are caught late (handler attached at a later time)
@@ -25,7 +30,10 @@ globalThis.addEventListener(
   (event) => {
     event.preventDefault();
 
-    log('window/onrejectionhandled', new Error(`Promise rejected and caught late; reason: ${event.reason}`));
+    log(
+      'window/onrejectionhandled',
+      new Error(`Promise rejected and caught late; reason: ${event.reason}`)
+    );
   },
   false
 );

--- a/src/views/dialogs/ExchangeOfflineDialog.tsx
+++ b/src/views/dialogs/ExchangeOfflineDialog.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import styled, { AnyStyledComponent } from 'styled-components';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import { AbacusApiStatus } from '@/constants/abacus';
+import { DialogTypes } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
 import { CLIENT_NETWORK_CONFIGS } from '@/constants/networks';
 import { UNICODE } from '@/constants/unicode';
-
-import { STRING_KEYS } from '@/constants/localization';
 import { useApiState, useStringGetter } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
 
@@ -17,6 +17,7 @@ import { NetworkSelectMenu } from '@/views/menus/NetworkSelectMenu';
 import { closeDialog } from '@/state/dialogs';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
+import { getActiveDialog } from '@/state/dialogsSelectors';
 
 type ElementProps = {
   preventClose?: boolean;
@@ -28,13 +29,18 @@ export const ExchangeOfflineDialog = ({ preventClose, setIsOpen }: ElementProps)
   const stringGetter = useStringGetter();
   const { status, statusErrorMessage } = useApiState();
   const selectedNetwork = useSelector(getSelectedNetwork);
+  const activeDialog = useSelector(getActiveDialog, shallowEqual);
 
   const showTestnetMaintenanceMessage =
     import.meta.env.MODE === 'production' &&
     CLIENT_NETWORK_CONFIGS[selectedNetwork].dydxChainId === 'dydx-testnet-2';
 
   useEffect(() => {
-    if (status === AbacusApiStatus.NORMAL && !showTestnetMaintenanceMessage) {
+    if (
+      activeDialog?.type === DialogTypes.ExchangeOffline &&
+      status === AbacusApiStatus.NORMAL &&
+      !showTestnetMaintenanceMessage
+    ) {
       dispatch(closeDialog());
     }
   }, [status, selectedNetwork]);


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Add try/catch when initializing the composite client in the ChainTransactionProtocol.
- handle error within try/catch
- trigger exchange offline dialog if composite client fails to initialize

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<ExchangeOfflineDialog>`
  * `closeDialog` if the `activeDialog` is `DialogTypes.ExchangeOffline`

## Functions

* `lib/abacus/dydxChainTransactions`
  * initialize client within `try/catch`
  * open `ExchangeOffline` dialog if client fails to initialize

* `lib/abacus`
  * setStore for `chainTransactionClient`

* `lib/telemetry`
  * console.warn on non production builds 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
