### PR TITLE
Do not poll evm unless addressOrDenom is provided

### DIFF
--- a/src/hooks/useAccountBalance.ts
+++ b/src/hooks/useAccountBalance.ts
@@ -37,10 +37,10 @@ type UseAccountBalanceProps = {
  * 0xSquid uses this 0x address as the chain's default token.
  * @todo We will need to add additional logic here if we 'useAccountBalance' on non-Squid related forms.
  */
-const CHAIN_DEFAULT_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+export const CHAIN_DEFAULT_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
 export const useAccountBalance = ({
-  addressOrDenom = CHAIN_DEFAULT_TOKEN_ADDRESS,
+  addressOrDenom,
   assetSymbol,
   bech32AddrPrefix,
   chainId,

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -14,7 +14,7 @@ import { NumberSign } from '@/constants/numbers';
 import type { EvmAddress } from '@/constants/wallets';
 
 import { useAccounts, useDebounce, useStringGetter } from '@/hooks';
-import { useAccountBalance } from '@/hooks/useAccountBalance';
+import { useAccountBalance, CHAIN_DEFAULT_TOKEN_ADDRESS } from '@/hooks/useAccountBalance';
 import { useLocalNotifications } from '@/hooks/useLocalNotifications';
 import { NATIVE_TOKEN_ADDRESS, useSquid } from '@/hooks/useSquid';
 import { useWalletConnection } from '@/hooks/useWalletConnection';
@@ -86,7 +86,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
 
   // Async Data
   const { balance, queryStatus, isQueryFetching } = useAccountBalance({
-    addressOrDenom: sourceToken?.address || undefined,
+    addressOrDenom: sourceToken?.address || CHAIN_DEFAULT_TOKEN_ADDRESS,
     assetSymbol: sourceToken?.symbol || undefined,
     chainId: chainId,
     decimals: sourceToken?.decimals || undefined,


### PR DESCRIPTION
## Hooks

* `hooks/useAccountBalance`
  * evmQuery/useBalance was being open unnecessarily by `AccountMenu`
  * Change it so that evmQuery is only enabled if addressOrDenom is explicitly provided
