### PR TITLE
Added tokenDenom to the configs. Also changed the environments payload to a map from list

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -25,7 +25,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydxprotocol-testnet",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -50,7 +61,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydxprotocol-testnet",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -74,7 +96,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydxprotocol-testnet",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -98,7 +131,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydxprotocol-testnet",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -122,7 +166,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydxprotocol-testnet",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -150,7 +205,18 @@
          "ethereumChainId":"5",
          "dydxChainId":"dydx-testnet-3",
          "isMainNet":false,
-         "tokenDenom":"dv4tnt",
+         "tokens":{
+            "chain": {
+               "name": "DYDX",
+               "denom": "dv4tnt",
+               "image": "/currencies/dydx.png"
+            },
+            "usdc": {
+               "name": "USDC",
+               "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+               "image": "/currencies/usdc.png"
+            }
+         },
          "endpoints":{
             "indexers":[
                {
@@ -160,7 +226,6 @@
             ],
             "validators":[
                "https://dydx-testnet.nodefleet.org",
-               "https://dydx-testnet-archive.allthatnode.com:26657/XZvMM41hESf8PJrEQiTzbCOMVyFca79R",
                "https://test-dydx.kingnodes.com/"
             ],
             "0xsquid":"https://squid-api-git-main-cosmos-testnet-0xsquid.vercel.app",


### PR DESCRIPTION
This comes from onboarding team meeting - we cannot have hard coded token denom in v4-client, and not sure what the mainNet denom would be.

Added to the configs. We will need to modify v4-client, web app and iOS app separately to pass the denom from Abacus into v4-client.