### PR TITLE
Update Abacus v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "@cosmjs/tendermint-rpc": "^0.31.0",
-    "@dydxprotocol/v4-abacus": "^0.5.12",
+    "@dydxprotocol/v4-abacus": "^0.6.0",
     "@dydxprotocol/v4-client-js": "^0.36.1",
     "@dydxprotocol/v4-localization": "^0.1.12",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^0.31.0
     version: 0.31.0
   '@dydxprotocol/v4-abacus':
-    specifier: ^0.5.12
-    version: 0.5.12
+    specifier: ^0.6.0
+    version: 0.6.0
   '@dydxprotocol/v4-client-js':
     specifier: ^0.36.1
     version: 0.36.1
@@ -979,8 +979,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@0.5.12:
-    resolution: {integrity: sha512-OigoIjGtp0az1elkP84nc9qKYBVg5Fg4QEJFDn7J7oiUqVvwNggYNfnDsX77D8+K4DJ/rtbi2yZYsDE8OZMSoQ==}
+  /@dydxprotocol/v4-abacus@0.6.0:
+    resolution: {integrity: sha512-FxkDs3d3xh76H+ue8N94BUBrswnlVVPH2xQHp+JPmXCIeuaz7CRDiDj+f2zJfRUKzTqTeOwuBpHr/nQNfChAoQ==}
     dev: false
 
   /@dydxprotocol/v4-client-js@0.36.1:

--- a/src/components/Table/MarketTableCell.tsx
+++ b/src/components/Table/MarketTableCell.tsx
@@ -24,7 +24,7 @@ export const MarketTableCell = ({
     slotLeft={
       <>
         {showFavorite && <Icon iconName={IconName.Star} />}
-        <Styled.AssetIcon symbol={asset?.symbol} />
+        <Styled.AssetIcon symbol={asset?.id} />
       </>
     }
   >

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -6,6 +6,7 @@ import { STRING_KEYS } from './localization';
 export type Nullable<T> = T | null | undefined;
 
 // ------ V4 Protocols ------ //
+export const AbacusAppConfig = Abacus.exchange.dydx.abacus.state.manager.AppConfigs;
 export const IOImplementations = Abacus.exchange.dydx.abacus.utils.IOImplementations;
 export const UIImplementations = Abacus.exchange.dydx.abacus.utils.UIImplementations;
 export type AbacusDYDXChainTransactionsProtocol = Omit<

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -6,7 +6,7 @@ export const AVAILABLE_ENVIRONMENTS =
     ? environments.deployments.TESTNET
     : environments.deployments.DEV;
 
+export const CURRENT_ABACUS_DEPLOYMENT = import.meta.env.MODE === 'production' ? 'TESTNET' : 'DEV';
 export const ENVIRONMENT_CONFIG_MAP = environments.environments;
 export type DydxNetwork = keyof typeof ENVIRONMENT_CONFIG_MAP;
-
 export const DEFAULT_APP_ENVIRONMENT = AVAILABLE_ENVIRONMENTS.default as DydxNetwork;

--- a/src/constants/networks.tsx
+++ b/src/constants/networks.tsx
@@ -1,29 +1,12 @@
-import { ENDPOINTS, DEV_ENDPOINTS } from '@dydxprotocol/v4-localization';
+import environments from '../../public/configs/env.json';
 
-export const NETWORK_ENDPOINTS = import.meta.env.MODE === 'production' ? ENDPOINTS : DEV_ENDPOINTS;
+// TODO: Update for Mainnet deployment
+export const AVAILABLE_ENVIRONMENTS =
+  import.meta.env.MODE === 'production'
+    ? environments.deployments.TESTNET
+    : environments.deployments.DEV;
 
-export const CLIENT_NETWORK_CONFIGS: Record<
-  string,
-  (typeof NETWORK_ENDPOINTS.environments)[number]
-> = Object.fromEntries(
-  NETWORK_ENDPOINTS.environments.map((environment) => [environment.environment, environment])
-);
+export const ENVIRONMENT_CONFIG_MAP = environments.environments;
+export type DydxNetwork = keyof typeof ENVIRONMENT_CONFIG_MAP;
 
-export const DEFAULT_APP_ENVIRONMENT = NETWORK_ENDPOINTS.defaultEnvironment;
-
-export enum DydxV4Network {
-  V4Mainnet = 'dydxprotocol-mainnet',
-  V4Staging = 'dydxprotocol-staging',
-  V4Testnet2 = 'dydxprotocol-testnet',
-  V4Local = 'dydxprotocol-dev',
-}
-
-export type DydxNetwork = keyof typeof CLIENT_NETWORK_CONFIGS;
-
-export function isDydxV4Network(network: any): boolean {
-  return CLIENT_NETWORK_CONFIGS[network]?.version === 'v4';
-}
-
-export function isValidDydxNetwork(network: any): boolean {
-  return Object.keys(CLIENT_NETWORK_CONFIGS).includes(network);
-}
+export const DEFAULT_APP_ENVIRONMENT = AVAILABLE_ENVIRONMENTS.default as DydxNetwork;

--- a/src/hooks/useAccountBalance.ts
+++ b/src/hooks/useAccountBalance.ts
@@ -7,7 +7,7 @@ import { formatUnits } from 'viem';
 
 import { USDC_DENOM, DYDX_DENOM } from '@dydxprotocol/v4-client-js';
 
-import { CLIENT_NETWORK_CONFIGS } from '@/constants/networks';
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 import { QUANTUM_MULTIPLIER } from '@/constants/numbers';
 import { EvmAddress } from '@/constants/wallets';
 
@@ -52,16 +52,14 @@ export const useAccountBalance = ({
 
   const selectedNetwork = useSelector(getSelectedNetwork);
   const balances = useSelector(getBalances, shallowEqual);
-  const evmChainId = Number(CLIENT_NETWORK_CONFIGS[selectedNetwork].ethereumChainId);
+  const evmChainId = Number(ENVIRONMENT_CONFIG_MAP[selectedNetwork].ethereumChainId);
 
   const evmQuery = useBalance({
     enabled: Boolean(!isCosmosChain && addressOrDenom?.startsWith('0x')),
     address: evmAddress,
     chainId: typeof chainId === 'number' ? chainId : Number(evmChainId),
     token:
-      addressOrDenom === CHAIN_DEFAULT_TOKEN_ADDRESS
-        ? undefined
-        : (addressOrDenom as EvmAddress),
+      addressOrDenom === CHAIN_DEFAULT_TOKEN_ADDRESS ? undefined : (addressOrDenom as EvmAddress),
     watch: true,
   });
 
@@ -98,7 +96,7 @@ export const useAccountBalance = ({
   const nativeTokenBalance = MustBigNumber(nativeTokenCoinBalance?.amount)
     .div(QUANTUM_MULTIPLIER)
     .toNumber();
-  
+
   const usdcCoinBalance = balances?.[USDC_DENOM];
   const usdcBalance = MustBigNumber(usdcCoinBalance?.amount).div(QUANTUM_MULTIPLIER).toNumber();
 

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -1,4 +1,3 @@
-import { isDydxV4Network } from '@/constants/networks';
 import { WalletType } from '@/constants/wallets';
 
 import { isTruthy } from '@/lib/isTruthy';
@@ -11,7 +10,7 @@ export const useDisplayedWallets = () => {
   return [
     WalletType.MetaMask,
 
-    import.meta.env.MODE !== 'production' && isDydxV4Network(selectedNetwork) && WalletType.Keplr,
+    import.meta.env.MODE !== 'production' && WalletType.Keplr,
 
     WalletType.WalletConnect2,
     WalletType.WalletConnect,

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { LocalStorageKey } from '@/constants/localStorage';
 
-import { DEFAULT_APP_ENVIRONMENT, DydxNetwork, isValidDydxNetwork } from '@/constants/networks';
+import { DEFAULT_APP_ENVIRONMENT, type DydxNetwork } from '@/constants/networks';
 
 import { useLocalStorage } from '@/hooks';
 
@@ -18,7 +18,6 @@ export const useInitializePage = () => {
   const [localStorageNetwork] = useLocalStorage<DydxNetwork>({
     key: LocalStorageKey.SelectedNetwork,
     defaultValue: DEFAULT_APP_ENVIRONMENT,
-    validateFn: isValidDydxNetwork, // backwards compatibility
   });
 
   useEffect(() => {

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -46,7 +46,7 @@ export const useMarketsData = (
       return filtered.filter(
         ({ asset }) =>
           asset.name?.toLocaleLowerCase().includes(searchFilter.toLowerCase()) ||
-          asset.symbol?.toLocaleLowerCase().includes(searchFilter.toLowerCase())
+          asset.id?.toLocaleLowerCase().includes(searchFilter.toLowerCase())
       );
     }
     return filtered;

--- a/src/hooks/useSquid.tsx
+++ b/src/hooks/useSquid.tsx
@@ -2,11 +2,11 @@ import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Squid } from '@0xsquid/sdk';
 
-import { CLIENT_NETWORK_CONFIGS, isDydxV4Network } from '@/constants/networks';
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
 
-export const NATIVE_TOKEN_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
 export enum SQUID_ERROR_TYPES {
   NotFoundError = 'NotFoundError',
@@ -24,10 +24,7 @@ const useSquidContext = () => {
   };
 
   const squid = useMemo(
-    () =>
-      isDydxV4Network(selectedNetwork)
-        ? new Squid({ baseUrl: CLIENT_NETWORK_CONFIGS[selectedNetwork]?.endpoints['0xsquid'] })
-        : undefined,
+    () => new Squid({ baseUrl: ENVIRONMENT_CONFIG_MAP[selectedNetwork]?.endpoints['0xsquid'] }),
     [selectedNetwork]
   );
 
@@ -41,7 +38,7 @@ const useSquidContext = () => {
 };
 
 type SquidContextType = ReturnType<typeof useSquidContext>;
-const SquidContext = createContext<SquidContextType>(undefined);
+const SquidContext = createContext<SquidContextType | undefined>(undefined);
 SquidContext.displayName = '0xSquid';
 
 export const SquidProvider = ({ ...props }) => (

--- a/src/lib/abacus/filesystem.ts
+++ b/src/lib/abacus/filesystem.ts
@@ -1,5 +1,4 @@
 import type { AbacusFileSystemProtocol, FileLocation, Nullable } from '@/constants/abacus';
-import { NETWORK_ENDPOINTS } from '@/constants/networks';
 
 export const ENDPOINTS_PATH =
   import.meta.env.MODE === 'production'
@@ -8,10 +7,6 @@ export const ENDPOINTS_PATH =
 
 class AbacusFileSystem implements AbacusFileSystemProtocol {
   readTextFile(location: FileLocation, path: string): Nullable<string> {
-    if (path === ENDPOINTS_PATH) {
-      return JSON.stringify(NETWORK_ENDPOINTS);
-    }
-
     return null;
   }
 

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -22,6 +22,7 @@ import {
   UIImplementations,
   CoroutineTimer,
   TransferType,
+  AbacusAppConfig,
 } from '@/constants/abacus';
 
 import { DEFAULT_MARKETID } from '@/constants/markets';
@@ -80,8 +81,9 @@ class AbacusStateManager {
     );
 
     this.stateManager = new AsyncAbacusStateManager(
-      import.meta.env.SHARED_RESOURCES_URI,
-      ENDPOINTS_PATH,
+      '',
+      'DEV',
+      AbacusAppConfig.Companion.forWeb,
       ioImplementations,
       uiImplementations,
       // @ts-ignore

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -26,7 +26,7 @@ import {
 } from '@/constants/abacus';
 
 import { DEFAULT_MARKETID } from '@/constants/markets';
-import { type DydxNetwork } from '@/constants/networks';
+import { CURRENT_ABACUS_DEPLOYMENT, type DydxNetwork } from '@/constants/networks';
 
 import type { RootStore } from '@/state/_store';
 
@@ -82,7 +82,7 @@ class AbacusStateManager {
 
     this.stateManager = new AsyncAbacusStateManager(
       '',
-      'DEV',
+      CURRENT_ABACUS_DEPLOYMENT,
       AbacusAppConfig.Companion.forWeb,
       ioImplementations,
       uiImplementations,

--- a/src/lib/abacus/stateNotification.ts
+++ b/src/lib/abacus/stateNotification.ts
@@ -76,7 +76,7 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
 
       if (changes.has(Changes.accountBalances)) {
         if (updatedState.account?.balances) {
-          const balances: Record<string, AccountBalance> = {}
+          const balances: Record<string, AccountBalance> = {};
           for (const { k, v } of updatedState.account.balances.toArray()) {
             balances[k] = v;
           }

--- a/src/pages/trade/MarketSelectorAndStats.tsx
+++ b/src/pages/trade/MarketSelectorAndStats.tsx
@@ -12,12 +12,12 @@ import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 
 export const MarketSelectorAndStats = ({ className }: { className?: string }) => {
-  const { symbol = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
+  const { id = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
   const currentMarketId = useSelector(getCurrentMarketId);
 
   return (
     <Styled.Container className={className}>
-      <MarketsDropdown currentMarketId={currentMarketId} symbol={symbol} />
+      <MarketsDropdown currentMarketId={currentMarketId} symbol={id} />
 
       <VerticalSeparator />
 

--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -2,7 +2,6 @@ import { createSelector } from 'reselect';
 
 import { SubaccountPosition } from '@/constants/abacus';
 import { OnboardingState, OnboardingSteps } from '@/constants/account';
-import { isDydxV4Network } from '@/constants/networks';
 
 import {
   getExistingOpenPositions,
@@ -11,8 +10,6 @@ import {
   getSubaccountId,
   getUncommittedOrderClientIds,
 } from '@/state/accountSelectors';
-
-import { getSelectedNetwork } from '@/state/appSelectors';
 
 export const calculateOnboardingStep = createSelector(
   [getOnboardingState, getOnboardingGuards],
@@ -35,9 +32,9 @@ export const calculateOnboardingStep = createSelector(
  * @description calculate whether an account is in a state where they can trade
  */
 export const calculateCanAccountTrade = createSelector(
-  [getOnboardingState, getSelectedNetwork],
-  (onboardingState: OnboardingState, selectedNetwork: string) => {
-    return onboardingState === OnboardingState.AccountConnected && isDydxV4Network(selectedNetwork);
+  [getOnboardingState],
+  (onboardingState: OnboardingState) => {
+    return onboardingState === OnboardingState.AccountConnected;
   }
 );
 

--- a/src/state/app.ts
+++ b/src/state/app.ts
@@ -3,11 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AbacusApiState } from '@/constants/abacus';
 import { LocalStorageKey } from '@/constants/localStorage';
 
-import {
-  DEFAULT_APP_ENVIRONMENT,
-  isValidDydxNetwork,
-  type DydxNetwork,
-} from '@/constants/networks';
+import { DEFAULT_APP_ENVIRONMENT, type DydxNetwork } from '@/constants/networks';
 
 import { getLocalStorage } from '@/lib/localStorage';
 
@@ -23,7 +19,6 @@ const initialState: AppState = {
   selectedNetwork: getLocalStorage({
     key: LocalStorageKey.SelectedNetwork,
     defaultValue: DEFAULT_APP_ENVIRONMENT,
-    validateFn: isValidDydxNetwork,
   }),
 };
 

--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -24,7 +24,7 @@ export const MarketDetails: React.FC = () => {
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
   const { configs, market } = useSelector(getCurrentMarketData, shallowEqual) || {};
-  const { symbol, name, resources } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
+  const { id, name, resources } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
 
   if (!configs) return null;
 
@@ -75,7 +75,7 @@ export const MarketDetails: React.FC = () => {
           useGrouping
           value={stepSize}
           type={OutputType.Asset}
-          tag={symbol}
+          tag={id}
           fractionDigits={stepSizeDecimals}
         />
       ),
@@ -88,7 +88,7 @@ export const MarketDetails: React.FC = () => {
           useGrouping
           value={minOrderSize}
           type={OutputType.Asset}
-          tag={symbol}
+          tag={id}
           fractionDigits={stepSizeDecimals}
         />
       ),
@@ -132,7 +132,7 @@ export const MarketDetails: React.FC = () => {
       <Styled.Header>
         <Styled.WrapRow>
           <Styled.MarketTitle>
-            <AssetIcon symbol={symbol} />
+            <AssetIcon symbol={id} />
             {name}
           </Styled.MarketTitle>
           {isTablet && <Styled.MarketLinks />}

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -45,7 +45,7 @@ const defaultMarketStatistics = Object.values(MarketStats);
 export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) => {
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
-  const { symbol = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
+  const { id = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
   const { tickSizeDecimals } = useSelector(getCurrentMarketConfig, shallowEqual) ?? {};
   const midMarketPrice = useSelector(getCurrentMarketMidMarketPrice);
   const lastMidMarketPrice = useRef(midMarketPrice);
@@ -116,7 +116,7 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
                   <Styled.Output
                     type={OutputType.Number}
                     value={value}
-                    tag={symbol}
+                    tag={id}
                     fractionDigits={LARGE_TOKEN_DECIMALS}
                   />
                 );

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -63,9 +63,9 @@ const MarketsDropdownContent = ({ onRowAction }: { onRowAction?: (market: string
                 renderCell: ({ asset }) => (
                   <Styled.MarketName isFavorited={false}>
                     {/* TRCL-1693 <Icon iconName={IconName.Star} /> */}
-                    <AssetIcon symbol={asset.symbol} />
+                    <AssetIcon symbol={asset.id} />
                     <h2>{asset.name}</h2>
-                    <Tag>{asset.symbol}</Tag>
+                    <Tag>{asset.id}</Tag>
                   </Styled.MarketName>
                 ),
               },

--- a/src/views/PositionInfo.tsx
+++ b/src/views/PositionInfo.tsx
@@ -68,7 +68,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
   const isLoading = useSelector(calculateIsAccountLoading);
 
   const { stepSizeDecimals, tickSizeDecimals } = currentMarketConfigs || {};
-  const { symbol } = currentMarketAssetData || {};
+  const { id } = currentMarketAssetData || {};
   const { type: dialogType } = activeDialog || {};
   const { type: tradeBoxDialogType } = activeTradeBoxDialog || {};
 
@@ -188,7 +188,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
       label: STRING_KEYS.LIQUIDATION_PRICE,
       tooltip: 'liquidation-price',
       tooltipParams: {
-        SYMBOL: symbol || '',
+        SYMBOL: id || '',
       },
       fractionDigits: tickSizeDecimals,
       hasInvalidNewValue: Boolean(newLeverageIsInvalid),
@@ -326,7 +326,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
             notionalTotal={notionalTotal?.current}
             postOrderSize={size?.postOrder}
             stepSizeDecimals={stepSizeDecimals}
-            symbol={symbol || undefined}
+            symbol={id || undefined}
             tickSizeDecimals={tickSizeDecimals}
             showNarrowVariation={showNarrowVariation}
             isLoading={isLoading}
@@ -370,7 +370,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
           notionalTotal={notionalTotal?.current}
           postOrderSize={size?.postOrder}
           stepSizeDecimals={stepSizeDecimals}
-          symbol={symbol || undefined}
+          symbol={id || undefined}
           tickSizeDecimals={tickSizeDecimals}
           isLoading={isLoading}
         />

--- a/src/views/charts/DepthChart.tsx
+++ b/src/views/charts/DepthChart.tsx
@@ -98,7 +98,7 @@ export const DepthChart = ({
   // Chart data
 
   const orderbook = useSelector(getCurrentMarketOrderbook, shallowEqual);
-  const { symbol = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
+  const { id = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
   const { stepSizeDecimals, tickSizeDecimals } =
     useSelector(getCurrentMarketConfig, shallowEqual) ?? {};
 
@@ -393,7 +393,7 @@ export const DepthChart = ({
                         ? chartPointAtPointer.size
                         : tooltipData!.nearestDatum?.datum.depth
                     }
-                    tag={symbol}
+                    tag={id}
                     accentColor={
                       {
                         [DepthChartSeries.Asks]: 'var(--color-negative)',
@@ -476,7 +476,7 @@ export const DepthChart = ({
                                     type={OutputType.Asset}
                                     value={chartPointAtPointer.size}
                                     fractionDigits={stepSizeDecimals}
-                                    tag={symbol}
+                                    tag={id}
                                     useGrouping={false}
                                   />
                                 ),
@@ -543,7 +543,7 @@ export const DepthChart = ({
                                     type={OutputType.Asset}
                                     value={nearestDatum?.datum.depth}
                                     fractionDigits={stepSizeDecimals}
-                                    tag={symbol}
+                                    tag={id}
                                     useGrouping={false}
                                   />
                                 ),

--- a/src/views/dialogs/ClosePositionDialog.tsx
+++ b/src/views/dialogs/ClosePositionDialog.tsx
@@ -28,7 +28,7 @@ type ElementProps = {
 };
 
 export const ClosePositionDialog = ({ setIsOpen }: ElementProps) => {
-  const { symbol } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
+  const { id } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
   const { isTablet } = useBreakpoints();
   const stringGetter = useStringGetter();
 
@@ -46,7 +46,7 @@ export const ClosePositionDialog = ({ setIsOpen }: ElementProps) => {
   } = {
     [MobilePlaceOrderSteps.EditOrder]: {
       title: <CloseOrderHeader />,
-      slotIcon: <AssetIcon symbol={symbol} />,
+      slotIcon: <AssetIcon symbol={id} />,
     },
     [MobilePlaceOrderSteps.PreviewOrder]: {
       title: (

--- a/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
@@ -19,7 +19,7 @@ import { MustBigNumber } from '@/lib/numbers';
 
 type ElementProps = {
   fillId: string;
-  setIsOpen?: (open: boolean) => void;
+  setIsOpen: (open: boolean) => void;
 };
 
 export const FillDetailsDialog = ({ fillId, setIsOpen }: ElementProps) => {
@@ -94,7 +94,7 @@ export const FillDetailsDialog = ({ fillId, setIsOpen }: ElementProps) => {
 
   return (
     <DetailsDialog
-      slotIcon={<Styled.AssetIcon symbol={asset.symbol} />}
+      slotIcon={<Styled.AssetIcon symbol={asset.id} />}
       title={resources.typeStringKey && stringGetter({ key: resources.typeStringKey })}
       items={detailItems}
       setIsOpen={setIsOpen}

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -194,7 +194,7 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
 
   return (
     <DetailsDialog
-      slotIcon={<Styled.AssetIcon symbol={asset.symbol} />}
+      slotIcon={<Styled.AssetIcon symbol={asset.id} />}
       title={!resources.typeStringKey ? '' : stringGetter({ key: resources.typeStringKey })}
       slotFooter={
         isAccountViewOnly ? null : isOrderStatusClearable(status) ? (

--- a/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
+++ b/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
@@ -9,7 +9,7 @@ import { AlertType } from '@/constants/alerts';
 import { AnalyticsEvent } from '@/constants/analytics';
 import { ButtonAction } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
-import { CLIENT_NETWORK_CONFIGS } from '@/constants/networks';
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 import { DydxAddress, SIGN_TYPED_DATA } from '@/constants/wallets';
 
 import { useAccounts, useBreakpoints, useDydxClient, useStringGetter } from '@/hooks';
@@ -55,7 +55,7 @@ export const GenerateKeys = ({
   // 1. Switch network
   const selectedNetwork = useSelector(getSelectedNetwork);
 
-  const chainId = Number(CLIENT_NETWORK_CONFIGS[selectedNetwork].ethereumChainId);
+  const chainId = Number(ENVIRONMENT_CONFIG_MAP[selectedNetwork].ethereumChainId);
 
   const { isMatchingNetwork, matchNetwork, isSwitchingNetwork } = useMatchingEvmNetwork({
     chainId,

--- a/src/views/dialogs/TradeDialog.tsx
+++ b/src/views/dialogs/TradeDialog.tsx
@@ -3,7 +3,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import styled, { AnyStyledComponent, css } from 'styled-components';
 
 import { TradeInputField } from '@/constants/abacus';
-import { STRING_KEYS } from '@/constants/localization';
+import { STRING_KEYS, StringKey } from '@/constants/localization';
 import { TradeTypes, TRADE_TYPE_STRINGS, MobilePlaceOrderSteps } from '@/constants/trade';
 
 import { useBreakpoints, useStringGetter } from '@/hooks';
@@ -31,7 +31,7 @@ type ElementProps = {
 export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) => {
   const { isMobile } = useBreakpoints();
   const stringGetter = useStringGetter();
-  const { symbol } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
+  const { id } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
   const currentTradeData = useSelector(getInputTradeData, shallowEqual);
   const { type } = currentTradeData || {};
   const selectedTradeType = getSelectedTradeType(type);
@@ -40,9 +40,9 @@ export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) =>
   const allTradeTypeItems = typeOptions?.toArray()?.map(({ type, stringKey }) => ({
     value: type,
     label: stringGetter({
-      key: stringKey,
+      key: stringKey as StringKey,
     }),
-    slotBefore: <AssetIcon symbol={symbol} />,
+    slotBefore: <AssetIcon symbol={id} />,
   }));
 
   const [currentStep, setCurrentStep] = useState<MobilePlaceOrderSteps>(

--- a/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
@@ -4,7 +4,7 @@ import styled, { type AnyStyledComponent } from 'styled-components';
 
 import { ButtonAction, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
-import { CLIENT_NETWORK_CONFIGS } from '@/constants/networks';
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 import { useAccounts, useStringGetter, useSubaccount } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
 
@@ -65,7 +65,7 @@ export const TestnetDepositForm = ({ onDeposit, onError }: DepositFormProps) => 
           key: STRING_KEYS.CREDITED_WITH,
           params: {
             AMOUNT_USD:
-              CLIENT_NETWORK_CONFIGS[selectedNetwork].ethereumChainId === 'dydxprotocol-testnet'
+              ENVIRONMENT_CONFIG_MAP[selectedNetwork].ethereumChainId === 'dydxprotocol-testnet'
                 ? 1000
                 : 100,
           },

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -80,7 +80,7 @@ export const ClosePositionForm = ({
   const { closePosition } = useSubaccount();
 
   const market = useSelector(getCurrentMarketId);
-  const { symbol } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
+  const { id } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
   const { stepSizeDecimals } = useSelector(getCurrentMarketConfig, shallowEqual) || {};
   const { size: sizeData, summary } = useSelector(getInputClosePositionData, shallowEqual) || {};
   const { size, percent } = sizeData || {};
@@ -193,7 +193,7 @@ export const ClosePositionForm = ({
         label={
           <>
             {stringGetter({ key: STRING_KEYS.AMOUNT })}
-            {symbol && <Tag>{symbol}</Tag>}
+            {id && <Tag>{id}</Tag>}
           </>
         }
         decimals={stepSizeDecimals || TOKEN_DECIMALS}

--- a/src/views/forms/TradeForm/PositionPreview.tsx
+++ b/src/views/forms/TradeForm/PositionPreview.tsx
@@ -21,7 +21,7 @@ type ElementProps = {
 export const PositionPreview = ({ showNarrowVariation }: ElementProps) => {
   const stringGetter = useStringGetter();
 
-  const { symbol } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
+  const { id } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
   const { configs, oraclePrice } = useSelector(getCurrentMarketData, shallowEqual) || {};
   const { size: positionSize } = useSelector(getCurrentMarketPositionData, shallowEqual) || {};
   const { stepSizeDecimals, tickSizeDecimals } = configs || {};
@@ -29,12 +29,12 @@ export const PositionPreview = ({ showNarrowVariation }: ElementProps) => {
   return (
     <Styled.PositionPreviewContainer>
       <Styled.YourPosition>
-        {!showNarrowVariation && <AssetIcon symbol={symbol} />}
+        {!showNarrowVariation && <AssetIcon symbol={id} />}
         <span>
           {stringGetter({
             key: STRING_KEYS.YOUR_MARKET_POSITION,
             params: {
-              MARKET: showNarrowVariation ? '' : <strong>{symbol ?? ''}</strong>,
+              MARKET: showNarrowVariation ? '' : <strong>{id ?? ''}</strong>,
             },
           })}
         </span>
@@ -44,7 +44,7 @@ export const PositionPreview = ({ showNarrowVariation }: ElementProps) => {
         oraclePrice={oraclePrice}
         postOrderSize={positionSize?.postOrder}
         stepSizeDecimals={stepSizeDecimals}
-        symbol={symbol || undefined}
+        symbol={id || undefined}
         tickSizeDecimals={tickSizeDecimals}
         showNarrowVariation={showNarrowVariation}
       />

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -40,7 +40,7 @@ export const TradeSizeInputs = () => {
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
 
-  const { symbol } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
+  const { id } = useSelector(getCurrentMarketAssetData, shallowEqual) || {};
   const inputTradeSizeData = useSelector(getInputTradeSizeData, shallowEqual);
   const currentTradeInputOptions = useSelector(getInputTradeOptions, shallowEqual);
 
@@ -94,7 +94,7 @@ export const TradeSizeInputs = () => {
       shape={ButtonShape.Square}
     >
       <Icon iconName={IconName.Trade} />
-      {showUSDCInputOnTablet ? 'USD' : symbol}
+      {showUSDCInputOnTablet ? 'USD' : id}
     </Styled.ToggleButton>
   );
 
@@ -105,10 +105,10 @@ export const TradeSizeInputs = () => {
       onInput={onSizeInput}
       label={
         <>
-          <WithTooltip tooltip="order-amount" stringParams={{ SYMBOL: symbol ?? '' }} side="right">
+          <WithTooltip tooltip="order-amount" stringParams={{ SYMBOL: id ?? '' }} side="right">
             {stringGetter({ key: STRING_KEYS.AMOUNT })}
           </WithTooltip>
-          {symbol && <Tag>{symbol}</Tag>}
+          {id && <Tag>{id}</Tag>}
         </>
       }
       slotRight={isTablet && inputToggleButton}
@@ -126,11 +126,7 @@ export const TradeSizeInputs = () => {
       decimals={tickSizeDecimals || USD_DECIMALS}
       label={
         <>
-          <WithTooltip
-            tooltip="order-amount-usd"
-            stringParams={{ SYMBOL: symbol ?? '' }}
-            side="right"
-          >
+          <WithTooltip tooltip="order-amount-usd" stringParams={{ SYMBOL: id ?? '' }} side="right">
             {stringGetter({ key: STRING_KEYS.AMOUNT })}
           </WithTooltip>
           <Tag>USD</Tag>

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -11,9 +11,13 @@ import { TransferInputField, TransferType } from '@/constants/abacus';
 import { AlertType } from '@/constants/alerts';
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
-import { CLIENT_NETWORK_CONFIGS } from '@/constants/networks';
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 import { NumberSign, QUANTUM_MULTIPLIER } from '@/constants/numbers';
-import { DYDX_CHAIN_ASSET_COIN_DENOM, DYDX_CHAIN_ASSET_TAGS, DydxChainAsset } from '@/constants/wallets';
+import {
+  DYDX_CHAIN_ASSET_COIN_DENOM,
+  DYDX_CHAIN_ASSET_TAGS,
+  DydxChainAsset,
+} from '@/constants/wallets';
 
 import {
   useAccountBalance,
@@ -60,7 +64,11 @@ export const TransferForm = ({
   const stringGetter = useStringGetter();
   const { freeCollateral } = useSelector(getSubaccount, shallowEqual) || {};
   const { dydxAddress } = useAccounts();
-  const { address: recipientAddress, size, fee } = useSelector(getTransferInputs, shallowEqual) || {};
+  const {
+    address: recipientAddress,
+    size,
+    fee,
+  } = useSelector(getTransferInputs, shallowEqual) || {};
   const { transfer } = useSubaccount();
   const { nativeTokenBalance, usdcBalance } = useAccountBalance();
   const { selectedNetwork } = useSelectedNetwork();
@@ -193,7 +201,7 @@ export const TransferForm = ({
 
   const networkOptions = [
     {
-      chainId: CLIENT_NETWORK_CONFIGS[selectedNetwork].dydxChainId,
+      chainId: ENVIRONMENT_CONFIG_MAP[selectedNetwork].dydxChainId,
       label: (
         <Styled.InlineRow>
           <AssetIcon symbol="DYDX" /> {stringGetter({ key: STRING_KEYS.DYDX_CHAIN })}
@@ -283,7 +291,7 @@ export const TransferForm = ({
         />
         <Styled.NetworkSelectMenu
           label={stringGetter({ key: STRING_KEYS.NETWORK })}
-          value={CLIENT_NETWORK_CONFIGS[selectedNetwork].dydxChainId}
+          value={ENVIRONMENT_CONFIG_MAP[selectedNetwork].dydxChainId}
           slotTriggerAfter={null}
         >
           {networkOptions.map(({ chainId, label }) => (

--- a/src/views/menus/useGlobalCommands.tsx
+++ b/src/views/menus/useGlobalCommands.tsx
@@ -129,15 +129,13 @@ export const useGlobalCommands = (): MenuConfig<string, string> => {
         {
           value: NavItems.NavigateToMarket,
           label: 'Navigate to Market',
-          subitems: joinedPerpetualMarketsAndAssets.map(
-            ({ market = '', name = '', symbol = '' }) => ({
-              value: market, // `${market}|${name}`,
-              slotBefore: <AssetIcon symbol={symbol} />,
-              label: name,
-              tag: symbol, // <abbr>{symbol}</abbr>,
-              onSelect: () => navigate(`/trade/${market}`),
-            })
-          ),
+          subitems: joinedPerpetualMarketsAndAssets.map(({ market = '', name = '', id = '' }) => ({
+            value: market,
+            slotBefore: <AssetIcon symbol={id} />,
+            label: name,
+            tag: id,
+            onSelect: () => navigate(`/trade/${market}`),
+          })),
         },
       ],
     },

--- a/src/views/menus/useNetworks.tsx
+++ b/src/views/menus/useNetworks.tsx
@@ -1,13 +1,13 @@
 import { type MenuItem } from '@/constants/menus';
-import { type DydxNetwork, NETWORK_ENDPOINTS } from '@/constants/networks';
-import { useStringGetter } from '@/hooks';
+import {
+  AVAILABLE_ENVIRONMENTS,
+  type DydxNetwork,
+  ENVIRONMENT_CONFIG_MAP,
+} from '@/constants/networks';
 
-export const useNetworks = (): MenuItem<DydxNetwork>[] => {
-  const stringGetter = useStringGetter();
-
-  return NETWORK_ENDPOINTS.environments.map(({ stringKey, environment }) => ({
-    key: environment,
-    label: stringGetter({ key: stringKey }),
-    value: environment,
+export const useNetworks = (): MenuItem<DydxNetwork>[] =>
+  (AVAILABLE_ENVIRONMENTS.environments as DydxNetwork[]).map((dydxNetwork) => ({
+    key: dydxNetwork,
+    label: ENVIRONMENT_CONFIG_MAP[dydxNetwork].name,
+    value: dydxNetwork,
   }));
-};

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -89,8 +89,8 @@ const getFillsTableColumnDef = ({
         label: `${stringGetter({ key: STRING_KEYS.TYPE })} / ${stringGetter({
           key: STRING_KEYS.AMOUNT,
         })}`,
-        renderCell: ({ resources, size, stepSizeDecimals, asset: { symbol } }) => (
-          <TableCell stacked slotLeft={<Styled.AssetIcon symbol={symbol} />}>
+        renderCell: ({ resources, size, stepSizeDecimals, asset: { id } }) => (
+          <TableCell stacked slotLeft={<Styled.AssetIcon symbol={id} />}>
             <span>
               {resources.typeStringKey ? stringGetter({ key: resources.typeStringKey }) : null}
             </span>
@@ -161,7 +161,7 @@ const getFillsTableColumnDef = ({
                 }[orderSide],
               })}
             </Styled.Side>
-            <Output type={OutputType.Text} value={asset.symbol} />
+            <Output type={OutputType.Text} value={asset.id} />
           </Styled.TableCell>
         ),
       },
@@ -325,9 +325,7 @@ export const FillsTable = ({
     if (hasUnseenFillUpdates) dispatch(viewedFills());
   }, [hasUnseenFillUpdates]);
 
-  const symbol = currentMarket
-    ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.symbol
-    : null;
+  const symbol = currentMarket ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.id : null;
 
   const fillsData = fills.map((fill: SubaccountFill) =>
     getHydratedTradingData({

--- a/src/views/tables/FundingPaymentsTable.tsx
+++ b/src/views/tables/FundingPaymentsTable.tsx
@@ -12,7 +12,10 @@ import { MarketTableCell } from '@/components/Table/MarketTableCell';
 import { Output, OutputType } from '@/components/Output';
 import { Table, TableCell, type ColumnDef } from '@/components/Table';
 
-import { getCurrentMarketFundingPayments, getSubaccountFundingPayments } from '@/state/accountSelectors';
+import {
+  getCurrentMarketFundingPayments,
+  getSubaccountFundingPayments,
+} from '@/state/accountSelectors';
 import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
@@ -111,7 +114,7 @@ export const FundingPaymentsTable = ({
                   type={OutputType.Asset}
                   value={Math.abs(positionSize)}
                   fractionDigits={stepSizeDecimals}
-                  tag={asset.symbol}
+                  tag={asset.id}
                 />
                 <Styled.Output
                   type={OutputType.Text}

--- a/src/views/tables/LiveTrades.tsx
+++ b/src/views/tables/LiveTrades.tsx
@@ -43,7 +43,7 @@ export const LiveTrades = ({ className, histogramSide = 'left' }: StyleProps) =>
   const currentMarketConfig = useSelector(getCurrentMarketConfig, shallowEqual);
   const currentMarketLiveTrades = useSelector(getCurrentMarketLiveTrades, shallowEqual) || [];
 
-  const { symbol = '' } = currentMarketAssetData ?? {};
+  const { id = '' } = currentMarketAssetData ?? {};
   const { stepSizeDecimals, tickSizeDecimals } = currentMarketConfig || {};
 
   const rows = currentMarketLiveTrades.map(
@@ -84,7 +84,7 @@ export const LiveTrades = ({ className, histogramSide = 'left' }: StyleProps) =>
         columnKey: 'size',
         getCellValue: (row: RowData) => row.size,
         label: stringGetter({ key: STRING_KEYS.SIZE }),
-        tag: symbol,
+        tag: id,
         renderCell: (row: RowData) => (
           <Styled.SizeOutput
             type={OutputType.Asset}
@@ -111,7 +111,7 @@ export const LiveTrades = ({ className, histogramSide = 'left' }: StyleProps) =>
       },
       !isTablet && timeColumn,
     ].filter(isTruthy);
-  }, [stepSizeDecimals, tickSizeDecimals, symbol, histogramSide, stringGetter]);
+  }, [stepSizeDecimals, tickSizeDecimals, id, histogramSide, stringGetter]);
 
   return (
     <Styled.LiveTradesTable

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -37,9 +37,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               columnKey: 'market',
               getCellValue: (row) => row.market,
               label: stringGetter({ key: STRING_KEYS.MARKET }),
-              renderCell: ({ asset, id }) => (
-                <Styled.MarketTableCell asset={asset} marketId={id} />
-              ),
+              renderCell: ({ asset, id }) => <Styled.MarketTableCell asset={asset} marketId={id} />,
             },
             {
               columnKey: 'price',
@@ -144,7 +142,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                     fractionDigits={LARGE_TOKEN_DECIMALS}
                     type={OutputType.Number}
                     value={row.openInterest}
-                    tag={row.asset?.symbol}
+                    tag={row.asset?.id}
                   />
                   <Output
                     type={OutputType.Fiat}

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -72,13 +72,13 @@ const getPositionsTableColumnDef = ({
         getCellValue: (row) => row.id,
         label: stringGetter({ key: STRING_KEYS.DETAILS }),
         renderCell: ({ id, asset, leverage, resources, size }) => (
-          <TableCell stacked slotLeft={<Styled.AssetIcon symbol={asset?.symbol} />}>
+          <TableCell stacked slotLeft={<Styled.AssetIcon symbol={asset?.id} />}>
             <Styled.HighlightOutput
               type={OutputType.Asset}
               value={size?.current}
               fractionDigits={TOKEN_DECIMALS}
               showSign={ShowSign.None}
-              tag={asset?.symbol}
+              tag={asset?.id}
             />
             <Styled.InlineRow>
               <Styled.PositionSide>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Update web app to `v4-abacus@0.6.0` and use new `public/configs`.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketDetails>`, `<MarketStatsDetail>`, `<MarketsDropdown>`, `<PositionInfo>`, `<DepthChart>`, `<ClosePositionDialog>`, `<FillDetailsDialog>`, `<OrderDetailsDialog>`, `<TradeDialog>`, `<ClosePositionForm>`, `<PositionPreview>`, `<TradeSizeInputs>`, `useGlobalCommands`, `<FillsTable>`, `<FundingPaymentsTable>`, `<LiveTrades>`, `<MarketsTable>`, `<PositionsTable>` `<MarketSelectorAndStats>`
  * Abacus change: Market Assets data no longer has deprecated `symbol`. Use `id` in place of  `symbol`

* `<GenerateKeys>`, `<TestnetDepositForm>`, `<TransferForm>`, `useNetworks`
  * Updated `const CLIENT_NETWORK_CONFIGS` -> `ENVIRONMENT_CONFIG_MAP`

## Components

* `<MarketTableCell>`
  * Abacus change: Market Assets data no longer has deprecated `symbol`. Use `id` in place of `symbol`.

## Constants/Types

* `constants/abacus`
  * New `AbacusAppConfig` type
* `constants/networks`
  * Use environments from the deployer's `public` directory
  * Remove methods that we no longer need since we are deprecating the connection to v3 network

## Library

* `lib/abacus`
  * Update params for new `AsyncAbacusStateManager` constructor

## Hooks

* `hooks/useAccountBalance`, `hooks/useDisplayedWallets`, `hooks/useInitializePage`
  * Remove deleted network methods
 
*`hooks/useMarketsData`
  * Abacus change: Market Assets data no longer has deprecated `symbol`. Use `id` in place of `symbol`.

* `hooks/useSquid`
   * Updated `const CLIENT_NETWORK_CONFIGS` -> `ENVIRONMENT_CONFIG_MAP`

## State

* `app`, `accountCalculators
  * remove deleted methods

## Packages

* `@dydxprotocol/v4-abacus`
  * <!-- explain changes to packages -->
  * updated: v0.5.12 -> v0.6.0

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
