### PR TITLE
Add script to inject iOS app ID to public/.well-known/apple-app-site-association

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -32,12 +32,14 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
-          STATUS_PAGE_SCRIPT_URI: ${{ secrets.STATUS_PAGE_SCRIPT_URI }}
+          STATUS_PAGE_SCRIPT_URI: ${{ Isecrets.STATUS_PAGE_SCRIPT_UR }}
+          IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
         run: |
           pnpm run build
           pnpm run build:inject-amplitude
           pnpm run build:inject-bugsnag
           pnpm run build:inject-statuspage
+          sh scripts/inject-ios-app-id.sh
 
       - name: Upload to IPFS via web3.storage
         uses: dydxprotocol/add-to-web3@v1

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
-          STATUS_PAGE_SCRIPT_URI: ${{ Isecrets.STATUS_PAGE_SCRIPT_UR }}
+          STATUS_PAGE_SCRIPT_URI: ${{ secrets.STATUS_PAGE_SCRIPT_UR }}
           IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
         run: |
           pnpm run build

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -39,7 +39,7 @@ jobs:
           pnpm run build:inject-amplitude
           pnpm run build:inject-bugsnag
           pnpm run build:inject-statuspage
-          sh scripts/inject-ios-app-id.sh
+          sh scripts/inject-app-deeplinks.sh
 
       - name: Upload to IPFS via web3.storage
         uses: dydxprotocol/add-to-web3@v1

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
-          STATUS_PAGE_SCRIPT_URI: ${{ secrets.STATUS_PAGE_SCRIPT_UR }}
+          STATUS_PAGE_SCRIPT_URI: ${{ secrets.STATUS_PAGE_SCRIPT_URI }}
           IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
         run: |
           pnpm run build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:inject-app-deeplinks": "sh scripts/inject-app-deeplinks.sh",
     "build:inject-amplitude": "node scripts/inject-amplitude.js",
     "build:inject-bugsnag": "node scripts/inject-bugsnag.js",
     "build:inject-statuspage": "node scripts/inject-statuspage.js",

--- a/scripts/inject-app-deeplinks.sh
+++ b/scripts/inject-app-deeplinks.sh
@@ -17,3 +17,5 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     sed -i "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source
 fi
+
+cat $source

--- a/scripts/inject-app-deeplinks.sh
+++ b/scripts/inject-app-deeplinks.sh
@@ -12,4 +12,8 @@ if [ -z "$app_id" ]; then
   exit 1
 fi
 
-sed -i '' "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source
+else
+    sed -i "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source
+fi

--- a/scripts/inject-app-deeplinks.sh
+++ b/scripts/inject-app-deeplinks.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+source="public/.well-known/apple-app-site-association"
+if [ ! -f "$source" ]; then
+  echo "Error: $source file not found"
+  exit 1
+fi
+
+app_id=$IOS_APP_ID
+if [ -z "$app_id" ]; then
+  echo "Error: IOS_APP_ID is empty"
+  exit 1
+fi
+
+sed -i '' "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source

--- a/scripts/inject-app-deeplinks.sh
+++ b/scripts/inject-app-deeplinks.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source="public/.well-known/apple-app-site-association"
+source="dist/.well-known/apple-app-site-association"
 if [ ! -f "$source" ]; then
   echo "Error: $source file not found"
   exit 1
@@ -17,5 +17,3 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     sed -i "s/{PLACE_YOUR_APP_ID_HERE}/$app_id/g" $source
 fi
-
-cat $source


### PR DESCRIPTION
It needs to have the actual app ID during deployment for the deeplinks to work.

