### PR TITLE
18 for adv4tnt, 6 for uusdc

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -42,14 +42,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -102,14 +102,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -161,14 +161,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -220,14 +220,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -279,14 +279,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -342,14 +342,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -405,14 +405,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -470,14 +470,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -534,14 +534,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -598,14 +598,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -662,14 +662,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -726,14 +726,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },
@@ -791,14 +791,14 @@
             "chain": {
                "name": "DYDX",
                "denom": "adv4tnt",
-               "exponents": 18,
+               "decimals": 18,
                "image": "/currencies/dydx.png"
             },
             "usdc": {
                "name": "USDC",
                "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                "gasDenom": "uusdc",
-               "exponents": 6,
+               "decimals": 6,
                "image": "/currencies/usdc.png"
             }
          },


### PR DESCRIPTION
<!-- Overall purpose of the PR -->

Deployer has the freedom to define the chain token and its exponents, and we want to have the flexibility to handle different exponents in Abacus and v4-client