### PR TITLE
Update `dev2` validator IP address

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -121,7 +121,7 @@
                }
             ],
             "validators": [
-               "http://35.75.227.118"
+               "http://54.92.118.111"
             ],
             "0xsquid": "https://testnet.api.0xsquid.com"
          },


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

New `dev2` ap-ne-1 validator IP address is `54.92.118.111`. It was previously `35.75.227.118`.

<!-- Overall purpose of the PR -->

Update `dev2` validator IP address.