### PR TITLE
fix trading view error

### DIFF
--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -44,7 +44,7 @@ export const useTradingView = ({
   const hasMarkets = marketIds.length > 0;
 
   useEffect(() => {
-    if (hasMarkets && isClientConnected) {
+    if (hasMarkets && isClientConnected && marketId) {
       const widgetOptions = getWidgetOptions();
       const widgetOverrides = getWidgetOverrides(appTheme);
       const options = {
@@ -75,7 +75,7 @@ export const useTradingView = ({
       tvWidgetRef.current = null;
       setIsChartReady(false);
     };
-  }, [getCandlesForDatafeed, isClientConnected, hasMarkets, selectedLocale, selectedNetwork]);
+  }, [getCandlesForDatafeed, isClientConnected, hasMarkets, selectedLocale, selectedNetwork, marketId]);
 
   return { savedResolution };
 };

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -75,7 +75,7 @@ export const useTradingView = ({
       tvWidgetRef.current = null;
       setIsChartReady(false);
     };
-  }, [getCandlesForDatafeed, isClientConnected, hasMarkets, selectedLocale, selectedNetwork, marketId]);
+  }, [getCandlesForDatafeed, isClientConnected, hasMarkets, selectedLocale, selectedNetwork, !!marketId]);
 
   return { savedResolution };
 };

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -107,8 +107,8 @@ export const getHydratedTradingData = ({
   perpetualMarkets?: Record<string, PerpetualMarket>;
 }) => ({
   ...data,
-  asset: assets && perpetualMarkets && assets[perpetualMarkets[data.marketId].assetId],
-  stepSizeDecimals: perpetualMarkets?.[data.marketId].configs?.stepSizeDecimals,
-  tickSizeDecimals: perpetualMarkets?.[data.marketId].configs?.tickSizeDecimals,
+  asset: assets && perpetualMarkets && assets[perpetualMarkets[data.marketId]?.assetId],
+  stepSizeDecimals: perpetualMarkets?.[data.marketId]?.configs?.stepSizeDecimals,
+  tickSizeDecimals: perpetualMarkets?.[data.marketId]?.configs?.tickSizeDecimals,
   ...('side' in data && { orderSide: convertAbacusOrderSide(data.side) }),
 });

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -161,7 +161,7 @@ const getFillsTableColumnDef = ({
                 }[orderSide],
               })}
             </Styled.Side>
-            <Output type={OutputType.Text} value={asset.id} />
+            <Output type={OutputType.Text} value={asset?.id} />
           </Styled.TableCell>
         ),
       },


### PR DESCRIPTION
there can be a state where `marketId` is missing, abd `options`'s `symbol` is undefined which caused trading view to fail and crash the app. 