### PR TITLE
TRCL-3099 : update apple app site association file

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -8,67 +8,43 @@
                 ],
                 "components": [
                     {
-                        "/": "/trade/*"
+                        "/": "/"
                     },
                     {
-                        "/": "/r/*"
+                        "/": "/#/"
                     },
                     {
-                        "/": "/portfolio/overview"
+                        "/": "*/markets"
                     },
                     {
-                        "/": "/portfolio/positions"
+                        "/": "*/trade"
                     },
                     {
-                        "/": "/portfolio/orders"
+                        "/": "*/trade/*"
                     },
                     {
-                        "/": "/portfolio/fees"
+                        "/": "*/portfolio"
                     },
                     {
-                        "/": "/portfolio/history"
+                        "/": "*/portfolio/overview"
                     },
                     {
-                        "/": "/portfolio/history/trades"
+                        "/": "*/portfolio/positions"
                     },
                     {
-                        "/": "/portfolio/history/transfers"
+                        "/": "*/portfolio/orders"
                     },
                     {
-                        "/": "/portfolio/history/funding"
+                        "/": "*/portfolio/fees"
                     },
                     {
-                        "/": "/rewards"
+                        "/": "*/portfolio/history/trades"
                     },
                     {
-                        "/": "/my-profile"
+                        "/": "*/portfolio/history/transfers"
                     },
                     {
-                        "/": "/rankings/hedgies"
-                    },
-                    {
-                        "/": "/rankings/competition"
-                    },
-                    {
-                        "/": "/rankings/diamond"
-                    },
-                    {
-                        "/": "/rankings/platinum"
-                    },
-                    {
-                        "/": "/rankings/gold"
-                    },
-                    {
-                        "/": "/rankings/silver"
-                    },
-                    {
-                        "/": "/rankings/bronze"
-                    },
-                    {
-                        "/": "/rankings/pnl-absolute"
-                    },
-                    {
-                        "/": "/rankings/pnl-percent"
+                        "/": "*/portfolio/history/funding"
                     },
                     {
                         "/": "/walletsegue",


### PR DESCRIPTION
<!-- Overall purpose of the PR -->
From v3->v4, the URL path schema has changed such that all url paths are now "#" prefixed. In order for the association file to perform properly, the URL path a user navigates to on their device must match a path specified in the association file. Because all of our v4 paths have the "/#/" prefix, there were no matches and thus the iOS device would not route to the app, instead, always the website.

As an example you can tap these links from your iOS device with a v4 build on it:
1. https://v4.testnet.dydx.exchange/trade
2. https://v4.testnet.dydx.exchange/#/trade/ETH-USD

#1 will route to the app (note it will crash due to a bug, separate work item tracked here: [TRCL-3100 : universal links are crashing the app](https://linear.app/dydx/issue/TRCL-3100/universal-links-are-crashing-the-app))
#2 will route to the website.

after this pr, both #1 and #2 will route to the app.

confirmed working will apple diagnostic tool:

https://github.com/dydxprotocol/v4-web/assets/3445394/039ff9c8-63f6-4874-a10b-a01e80317a81


