### PR TITLE
show loading state instead of "Unavailable" for place order button

### DIFF
--- a/src/views/dialogs/TradeDialog.tsx
+++ b/src/views/dialogs/TradeDialog.tsx
@@ -37,7 +37,7 @@ export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) =>
   const selectedTradeType = getSelectedTradeType(type);
   const { typeOptions } = useSelector(getInputTradeOptions, shallowEqual) ?? {};
 
-  const allTradeTypeItems = typeOptions?.toArray()?.map(({ type, stringKey }) => ({
+  const allTradeTypeItems = (typeOptions?.toArray() ?? []).map(({ type, stringKey }) => ({
     value: type,
     label: stringGetter({
       key: stringKey as StringKey,

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -322,7 +322,6 @@ export const TradeForm = ({
           summary={summary ?? undefined}
           currentStep={currentStep}
           showDeposit={inputAlert?.errorAction === TradeInputErrorAction.DEPOSIT}
-          showConnectWallet={inputAlert?.errorAction === TradeInputErrorAction.CONNECT_WALLET}
         />
       </Styled.Footer>
     </Styled.TradeForm>

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -7,9 +7,8 @@ import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { TRADE_TYPE_STRINGS, MobilePlaceOrderSteps } from '@/constants/trade';
 
-import { useStringGetter } from '@/hooks';
+import { useStringGetter, useTokenConfigs } from '@/hooks';
 
-import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Output, OutputType, ShowSign } from '@/components/Output';
 import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
@@ -47,6 +46,7 @@ export const PlaceOrderButtonAndReceipt = ({
 }: ElementProps) => {
   const stringGetter = useStringGetter();
   const dispatch = useDispatch();
+  const { chainTokenLabel } = useTokenConfigs();
 
   const canAccountTrade = useSelector(calculateCanAccountTrade);
   const subaccountNumber = useSelector(getSubaccountId);
@@ -88,7 +88,14 @@ export const PlaceOrderButtonAndReceipt = ({
           {/* <AssetIcon symbol="DYDX" /> */}
         </>
       ),
-      value: <Output type={OutputType.Asset} value={reward} useGrouping tag={reward ? "Dv4TNT" : ''} />,
+      value: (
+        <Output
+          type={OutputType.Asset}
+          value={reward}
+          useGrouping
+          tag={reward ? chainTokenLabel : ''}
+        />
+      ),
       tooltip: 'max-reward',
     },
     {
@@ -105,13 +112,9 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonStatesPerStep = {
     [MobilePlaceOrderSteps.EditOrder]: {
-      buttonTextStringKey: shouldEnableTrade
-        ? STRING_KEYS.PREVIEW_ORDER
-        : actionStringKey
-        ? actionStringKey
-        : STRING_KEYS.UNAVAILABLE,
+      buttonTextStringKey: shouldEnableTrade ? STRING_KEYS.PREVIEW_ORDER : actionStringKey,
       buttonAction: ButtonAction.Primary,
-      buttonState: { isDisabled: !shouldEnableTrade },
+      buttonState: { isDisabled: !shouldEnableTrade, isLoading: hasMissingData },
     },
 
     [MobilePlaceOrderSteps.PreviewOrder]: {
@@ -137,7 +140,7 @@ export const PlaceOrderButtonAndReceipt = ({
     ? ButtonAction.Destroy
     : orderSideAction;
 
-  let buttonTextStringKey = STRING_KEYS.UNAVAILABLE;
+  let buttonTextStringKey;
   if (currentStep) {
     buttonTextStringKey = buttonStatesPerStep[currentStep].buttonTextStringKey;
   } else if (shouldEnableTrade) {
@@ -148,7 +151,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonState = currentStep
     ? buttonStatesPerStep[currentStep].buttonState
-    : { isDisabled: !shouldEnableTrade || isLoading, isLoading };
+    : { isDisabled: !shouldEnableTrade || isLoading, isLoading: isLoading || hasMissingData };
 
   return (
     <WithDetailsReceipt detailItems={items}>

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -112,7 +112,11 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonStatesPerStep = {
     [MobilePlaceOrderSteps.EditOrder]: {
-      buttonTextStringKey: shouldEnableTrade ? STRING_KEYS.PREVIEW_ORDER : actionStringKey,
+      buttonTextStringKey: shouldEnableTrade
+        ? STRING_KEYS.PREVIEW_ORDER
+        : actionStringKey
+        ? actionStringKey
+        : STRING_KEYS.UNAVAILABLE,
       buttonAction: ButtonAction.Primary,
       buttonState: { isDisabled: !shouldEnableTrade, isLoading: hasMissingData },
     },
@@ -140,7 +144,7 @@ export const PlaceOrderButtonAndReceipt = ({
     ? ButtonAction.Destroy
     : orderSideAction;
 
-  let buttonTextStringKey;
+  let buttonTextStringKey = STRING_KEYS.UNAVAILABLE;
   if (currentStep) {
     buttonTextStringKey = buttonStatesPerStep[currentStep].buttonTextStringKey;
   } else if (shouldEnableTrade) {
@@ -151,7 +155,10 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonState = currentStep
     ? buttonStatesPerStep[currentStep].buttonState
-    : { isDisabled: !shouldEnableTrade || isLoading, isLoading: isLoading || hasMissingData };
+    : {
+        isDisabled: !shouldEnableTrade || isLoading,
+        isLoading: isLoading || hasMissingData,
+      };
 
   return (
     <WithDetailsReceipt detailItems={items}>


### PR DESCRIPTION
issue: trade / place order button shows "Unavailable" when we're waiting for indexer to return subaccount response as validation that trade is enabled

fix: show a loading state instead of "unavailable" text during onboarding

<img width="450" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/50fd0164-b7d9-4a0e-9722-876324be0558">

