### PR TITLE
Abort key derivation if second signature fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "@cosmjs/tendermint-rpc": "^0.31.0",
-    "@dydxprotocol/v4-abacus": "^0.7.6",
+    "@dydxprotocol/v4-abacus": "^1.0.3",
     "@dydxprotocol/v4-client-js": "^0.40.3",
     "@dydxprotocol/v4-localization": "^0.1.32",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^0.31.0
     version: 0.31.0
   '@dydxprotocol/v4-abacus':
-    specifier: ^0.7.6
-    version: 0.7.6
+    specifier: ^1.0.3
+    version: 1.0.3
   '@dydxprotocol/v4-client-js':
     specifier: ^0.40.3
     version: 0.40.3
@@ -979,8 +979,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@0.7.6:
-    resolution: {integrity: sha512-FdDXRaFMfxhyrJJs0dNrb1KG6X95lPHelua1yCn/SVgzwGaAqlJczrzmdh98INntuRAgIxOu69R5mCGyekumyg==}
+  /@dydxprotocol/v4-abacus@1.0.3:
+    resolution: {integrity: sha512-GuX37/DMMNSke8ZFcw52II7IVJfUgVGHqoi1Uw2cUb+hgIjjSG3OtbyRWedm5r6nqWq8BNLOexI0VVFB6OMVYg==}
     dev: false
 
   /@dydxprotocol/v4-client-js@0.40.3:

--- a/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
+++ b/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
@@ -130,12 +130,14 @@ export const GenerateKeys = ({
           }
         }
       } catch (error) {
+        setStatus(EvmDerivedAccountStatus.NotDerived);
         const { message } = parseWalletError({ error, stringGetter });
 
         if (message) {
           track(AnalyticsEvent.OnboardingWalletIsNonDeterministic);
           setError(message);
         }
+        return;
       }
 
       await setWalletFromEvmSignature(signature);


### PR DESCRIPTION
- Update abacus to fix usdc balance
- abort key derivation if second signature fails/don't match

## Views

* `src/views/dialogs/OnboardingDialog/GenerateKeys.tsx`
  * return if second signature fails, also set state back to NotDerived
 
## Packages

* `@dydxprotocol/v4-abacus`
  * updated: ^0.7.6 -> ^1.0.3
