### PR TITLE
reorder header, center align header, update collapse caret icons

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -80,7 +80,7 @@ Styled.TriggerIcon = styled.span`
   width: var(--trigger-icon-width);
 
   display: inline-flex;
-  transition: transform 0.3s var(--ease-out-expo);
+  transition: rotate 0.3s var(--ease-out-expo);
   color: var(--trigger-icon-color);
 
   ${Styled.Trigger}[data-state='open'] & {

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -525,6 +525,9 @@ Styled.NavItem = styled(NavItem)<{ orientation: 'horizontal' | 'vertical' }>`
 `;
 
 Styled.Icon = styled(Icon)`
+  height: 0.75em;
+  transition: rotate 0.3s var(--ease-out-expo);
+
   ${Styled.List}[data-orientation="menu"] & {
     rotate: -0.25turn;
   }

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -24,6 +24,7 @@ import { openDialog } from '@/state/dialogs';
 
 import { headerMixins } from '@/styles/headerMixins';
 import { layoutMixins } from '@/styles/layoutMixins';
+import breakpoints from '@/styles/breakpoints';
 
 export const HeaderDesktop = () => {
   const stringGetter = useStringGetter();
@@ -35,24 +36,24 @@ export const HeaderDesktop = () => {
       group: 'navigation',
       items: [
         {
-          value: 'MARKET',
-          label: stringGetter({ key: STRING_KEYS.MARKET }),
-          href: AppRoute.Markets,
-        },
-        {
           value: 'TRADE',
           label: stringGetter({ key: STRING_KEYS.TRADE }),
           href: AppRoute.Trade,
         },
         {
-          value: chainTokenLabel,
-          label: chainTokenLabel,
-          href: `/${chainTokenLabel}`,
-        },
-        {
           value: 'PORTFOLIO',
           label: stringGetter({ key: STRING_KEYS.PORTFOLIO }),
           href: AppRoute.Portfolio,
+        },
+        {
+          value: 'MARKETS',
+          label: stringGetter({ key: STRING_KEYS.MARKETS }),
+          href: AppRoute.Markets,
+        },
+        {
+          value: chainTokenLabel,
+          label: chainTokenLabel,
+          href: `/${chainTokenLabel}`,
         },
         {
           value: 'MORE',
@@ -150,12 +151,15 @@ const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.Header = styled.header`
   --header-horizontal-padding-mobile: 0.5rem;
+  --trigger-height: 2.25rem;
   --logo-width: 3.5rem;
 
   ${layoutMixins.container}
   ${layoutMixins.stickyHeader}
   ${layoutMixins.scrollSnapItem}
   backdrop-filter: none;
+
+  height: var(--page-currentHeaderHeight);
 
   grid-area: Header;
 
@@ -169,6 +173,14 @@ Styled.Header = styled.header`
     )
     var(--border-width) 1fr var(--border-width) auto;
 
+  @media ${breakpoints.tablet} {
+    --trigger-height: 3rem;
+  }
+
+  @media ${breakpoints.mobile} {
+    --navBefore-width: 7rem;
+  }
+
   font-size: 0.9375rem;
 
   :before {
@@ -179,6 +191,7 @@ Styled.Header = styled.header`
 Styled.NavigationMenu = styled(NavigationMenu)`
   & {
     --navigationMenu-height: var(--stickyArea-topHeight);
+    --navigationMenu-item-height: var(--trigger-height);
   }
 
   ${layoutMixins.scrollArea}

--- a/src/views/TransferStatus.tsx
+++ b/src/views/TransferStatus.tsx
@@ -168,7 +168,7 @@ Styled.TriggerIcon = styled.span`
   width: 0.75em;
 
   display: inline-flex;
-  transition: transform 0.3s var(--ease-out-expo);
+  transition: rotate 0.3s var(--ease-out-expo);
 
   ${Styled.Trigger}[data-state='open'] & {
     rotate: -0.5turn;


### PR DESCRIPTION
1. Reorder header so it's trade > portfolio > markets > chain token
2. center align header items
3. make caret icon smaller
4. transition should be on `rotate` instead of `transform` if it's rotating

<img width="1230" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/b736c1c3-08b6-40b2-b439-897d465a9bbc">
