### PR TITLE
Handle negative free collateral + buying power

### DIFF
--- a/src/pages/portfolio/AccountDetailsAndHistory.tsx
+++ b/src/pages/portfolio/AccountDetailsAndHistory.tsx
@@ -131,7 +131,7 @@ export const AccountDetailsAndHistory = () => {
       key: 'BuyingPower',
       labelKey: STRING_KEYS.BUYING_POWER,
       type: OutputType.Fiat,
-      value: buyingPower?.current,
+      value: MustBigNumber(buyingPower?.current).lt(0) ? undefined : buyingPower?.current, // show '-' when buying power is negative
     },
   ].filter(isTruthy);
 

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -151,7 +151,10 @@ export const AccountInfoConnectedState = () => {
               ),
               label: stringGetter({ key: STRING_KEYS.BUYING_POWER }),
               type: OutputType.Fiat,
-              value: buyingPower,
+              value:
+                MustBigNumber(buyingPower?.current).lt(0) && buyingPower?.postOrder === null
+                  ? undefined
+                  : buyingPower,
             },
           ].map(
             ({

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useState, type ReactNode } from 'react';
-import styled, { type AnyStyledComponent,  } from 'styled-components';
+import styled, { type AnyStyledComponent } from 'styled-components';
 import { shallowEqual, useSelector } from 'react-redux';
 import type { RouteData } from '@0xsquid/sdk';
 
@@ -31,6 +31,8 @@ import { WithReceipt } from '@/components/WithReceipt';
 
 import { getSubaccountBuyingPower, getSubaccountEquity } from '@/state/accountSelectors';
 import { getTransferInputs } from '@/state/inputsSelectors';
+
+import { MustBigNumber } from '@/lib/numbers';
 
 import { SlippageEditor } from '../SlippageEditor';
 
@@ -131,7 +133,7 @@ export const DepositButtonAndReceipt = ({
       value: (
         <DiffOutput
           type={OutputType.Fiat}
-          value={buyingPower}
+          value={MustBigNumber(buyingPower).lt(0) ? undefined : buyingPower}
           newValue={newBuyingPower}
           sign={NumberSign.Positive}
           withDiff={Boolean(newBuyingPower) && buyingPower !== newBuyingPower}

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -36,6 +36,7 @@ import { truncateAddress } from '@/lib/wallet';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 import { headerMixins } from '@/styles/headerMixins';
+import { MustBigNumber } from '@/lib/numbers';
 
 export const AccountMenu = () => {
   const stringGetter = useStringGetter();
@@ -48,6 +49,8 @@ export const AccountMenu = () => {
   const { usdcLabel, chainTokenLabel } = useTokenConfigs();
 
   const { evmAddress, walletType, dydxAddress, hdKey } = useAccounts();
+
+  const usdcBalance = freeCollateral?.current || 0;
 
   const onRecoverKeys = () => {
     dispatch(openDialog({ type: DialogTypes.Onboarding }));
@@ -122,7 +125,11 @@ export const AccountMenu = () => {
                   </Styled.label>
                   <Styled.BalanceOutput type={OutputType.Asset} value={nativeTokenBalance} />
                 </div>
-                <AssetActions asset={DydxChainAsset.CHAINTOKEN} dispatch={dispatch} />
+                <AssetActions
+                  asset={DydxChainAsset.CHAINTOKEN}
+                  dispatch={dispatch}
+                  hasBalance={nativeTokenBalance.gt(0)}
+                />
               </div>
               <div>
                 <div>
@@ -135,11 +142,16 @@ export const AccountMenu = () => {
                   </Styled.label>
                   <Styled.BalanceOutput
                     type={OutputType.Asset}
-                    value={freeCollateral?.current || 0}
+                    value={usdcBalance}
                     fractionDigits={2}
                   />
                 </div>
-                <AssetActions asset={DydxChainAsset.USDC} dispatch={dispatch} withOnboarding />
+                <AssetActions
+                  asset={DydxChainAsset.USDC}
+                  dispatch={dispatch}
+                  hasBalance={MustBigNumber(usdcBalance).gt(0)}
+                  withOnboarding
+                />
               </div>
             </Styled.Balances>
           </Styled.AccountInfo>
@@ -217,22 +229,25 @@ const AssetActions = memo(
     asset,
     dispatch,
     withOnboarding,
+    hasBalance,
   }: {
     asset: DydxChainAsset;
     dispatch: Dispatch;
     withOnboarding?: boolean;
+    hasBalance?: boolean;
   }) => (
     <Styled.InlineRow>
       {[
-        withOnboarding && {
-          dialogType: DialogTypes.Withdraw,
-          iconName: IconName.Withdraw,
-        },
+        withOnboarding &&
+          hasBalance && {
+            dialogType: DialogTypes.Withdraw,
+            iconName: IconName.Withdraw,
+          },
         withOnboarding && {
           dialogType: DialogTypes.Deposit,
           iconName: IconName.Deposit,
         },
-        {
+        hasBalance && {
           dialogType: DialogTypes.Transfer,
           dialogProps: { selectedAsset: asset },
           iconName: IconName.Send,


### PR DESCRIPTION
- When buying power is negative, show '-' instead of the value where makes sense, matching v3 behavior;
- Hide send/withdraw options in AccountMenu dropdown when balance is negative.