### PR TITLE
Configs: Add app configuration to env.json

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -1,4 +1,9 @@
 {
+   "apps": {
+      "iOS": {
+         "scheme": "dydxv4"
+      }
+   },
    "deployments": {
       "MAINNET": {
          "environments": [


### PR DESCRIPTION
We will use this section to load the params for mobile apps during build and run-time.  It contains iOS app scheme for now.