### PR TITLE
Fix decimal overflow bug

### DIFF
--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -79,16 +79,34 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
         subaccountClient: SubaccountClient;
         assetId?: number;
         amount: number;
-      }) => await compositeClient?.depositToSubaccount(subaccountClient, amount.toString()),
-
+      }) => {
+        try {
+          await compositeClient?.depositToSubaccount(
+            subaccountClient,
+            amount.toFixed(QUANTUM_MULTIPLIER)
+          );
+        } catch (error) {
+          log('useSubaccount/depositToSubaccount', error);
+          throw error;
+        }
+      },
       withdrawFromSubaccount: async ({
         subaccountClient,
         amount,
       }: {
         subaccountClient: SubaccountClient;
         amount: number;
-      }) => await compositeClient?.withdrawFromSubaccount(subaccountClient, amount.toString()),
-
+      }) => {
+        try {
+          await compositeClient?.withdrawFromSubaccount(
+            subaccountClient,
+            amount.toFixed(QUANTUM_MULTIPLIER)
+          );
+        } catch (error) {
+          log('useSubaccount/withdrawFromSubaccount', error);
+          throw error;
+        }
+      },
       transferFromSubaccountToAddress: async ({
         subaccountClient,
         assetId = 0,
@@ -137,7 +155,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
               const msg = compositeClient?.sendTokenMessage(
                 subaccountClient.wallet,
                 amount.toString(),
-                recipient,
+                recipient
               );
 
               resolve([msg]);
@@ -161,7 +179,10 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
 
         const transaction = JSON.parse(payload);
 
-        const msg = compositeClient.withdrawFromSubaccountMessage(subaccountClient, amount.toString());
+        const msg = compositeClient.withdrawFromSubaccountMessage(
+          subaccountClient,
+          amount.toFixed(6)
+        );
         const ibcMsg: EncodeObject = {
           typeUrl: transaction.msgTypeUrl,
           value: transaction.msg,

--- a/src/hooks/useTokenConfigs.ts
+++ b/src/hooks/useTokenConfigs.ts
@@ -19,8 +19,10 @@ export const useTokenConfigs = (): {
     },
   };
   usdcDenom: string;
+  usdcDecimals: number;
   usdcLabel: string;
   chainTokenDenom: string;
+  chainTokenDecimals: number;
   chainTokenLabel: string;
 } => {
   const { selectedNetwork } = useSelectedNetwork();
@@ -29,8 +31,10 @@ export const useTokenConfigs = (): {
   return { 
     tokensConfigs,
     usdcDenom: tokensConfigs[DydxChainAsset.USDC].denom, 
+    usdcDecimals: tokensConfigs[DydxChainAsset.USDC].decimals, 
     usdcLabel: tokensConfigs[DydxChainAsset.USDC].name,
     chainTokenDenom: tokensConfigs[DydxChainAsset.CHAINTOKEN].denom,
+    chainTokenDecimals: tokensConfigs[DydxChainAsset.CHAINTOKEN].decimals, 
     chainTokenLabel: tokensConfigs[DydxChainAsset.CHAINTOKEN].name,
   };
 };


### PR DESCRIPTION
Fix bug `depositToSubaccount` and other v4-client functions that take in amount as string, where if the the amount decimals exceeds the token decimals, ethers.parseUnit will throw an error.

Fix this using `toFixed()` to ensure the decimals are correct
