### PR TITLE
Onboarding fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@cosmjs/tendermint-rpc": "^0.31.0",
     "@dydxprotocol/v4-abacus": "^1.0.19",
     "@dydxprotocol/v4-client-js": "^1.0.0",
-    "@dydxprotocol/v4-localization": "^1.0.3",
+    "@dydxprotocol/v4-localization": "^1.0.5",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@0xsquid/sdk':
     specifier: ^1.10.0
@@ -1007,13 +1011,8 @@ packages:
       - utf-8-validate
     dev: false
 
-<<<<<<< HEAD
-  /@dydxprotocol/v4-localization@1.0.3:
-    resolution: {integrity: sha512-DSTVabwVI6TjR0Z6Nlcl+ryrmayCoki0eBbBcSO/bsNYAffsPAy1e4ctajH49hQC6CKaCyK4urZPEXsdCmLlzQ==}
-=======
   /@dydxprotocol/v4-localization@1.0.5:
     resolution: {integrity: sha512-zZm3GFp/ORz9YjigQFVBlcWmaxYY+XEdIw8AWN5nEbsuiA2Jay+/OA7lO9+nV1J1p1T+TgLo9iczIHJsAo3IsA==}
->>>>>>> 90c3fd1 (address comments)
     dev: false
 
   /@dydxprotocol/v4-proto@0.4.1:
@@ -14101,7 +14100,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@dydxprotocol/v4-localization':
-    specifier: ^1.0.3
-    version: 1.0.3
+    specifier: ^1.0.5
+    version: 1.0.5
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1007,8 +1007,13 @@ packages:
       - utf-8-validate
     dev: false
 
+<<<<<<< HEAD
   /@dydxprotocol/v4-localization@1.0.3:
     resolution: {integrity: sha512-DSTVabwVI6TjR0Z6Nlcl+ryrmayCoki0eBbBcSO/bsNYAffsPAy1e4ctajH49hQC6CKaCyK4urZPEXsdCmLlzQ==}
+=======
+  /@dydxprotocol/v4-localization@1.0.5:
+    resolution: {integrity: sha512-zZm3GFp/ORz9YjigQFVBlcWmaxYY+XEdIw8AWN5nEbsuiA2Jay+/OA7lO9+nV1J1p1T+TgLo9iczIHJsAo3IsA==}
+>>>>>>> 90c3fd1 (address comments)
     dev: false
 
   /@dydxprotocol/v4-proto@0.4.1:

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -42,6 +42,7 @@ const useAccountsContext = () => {
     selectedWalletError,
     evmAddress,
     signerWagmi,
+    publicClientWagmi,
     dydxAddress: connectedDydxAddress,
     signerGraz,
   } = useWalletConnection();
@@ -296,6 +297,7 @@ const useAccountsContext = () => {
     // Wallet connection (EVM)
     evmAddress,
     signerWagmi,
+    publicClientWagmi,
 
     // Wallet connection (Cosmos)
     signerGraz,

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { LocalStorageKey } from '@/constants/localStorage';
@@ -90,18 +90,23 @@ export const useWalletConnection = () => {
 
   const selectedNetwork = useSelector(getSelectedNetwork);
   const walletConnectConfig = ENVIRONMENT_CONFIG_MAP[selectedNetwork].wallets.walletconnect;
-
-  const { connectAsync: connectWagmi } =
-    walletType && walletConnectionType
-      ? useConnectWagmi({
-          connector: resolveWagmiConnector({
+  const wagmiConnector = useMemo(
+    () =>
+      walletType && walletConnectionType
+        ? resolveWagmiConnector({
             walletType,
             walletConnection: {
               type: walletConnectionType,
             },
             walletConnectConfig,
-          }),
-        })
+          })
+        : undefined,
+    [walletConnectConfig, walletType, walletConnectionType]
+  );
+
+  const { connectAsync: connectWagmi } =
+    walletType && walletConnectionType
+      ? useConnectWagmi({ connector: wagmiConnector })
       : useConnectWagmi();
   const { suggestAndConnect: connectGraz } = useConnectGraz();
 

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -104,10 +104,7 @@ export const useWalletConnection = () => {
     [walletConnectConfig, walletType, walletConnectionType]
   );
 
-  const { connectAsync: connectWagmi } =
-    walletType && walletConnectionType
-      ? useConnectWagmi({ connector: wagmiConnector })
-      : useConnectWagmi();
+  const { connectAsync: connectWagmi } = useConnectWagmi({ connector: wagmiConnector })
   const { suggestAndConnect: connectGraz } = useConnectGraz();
 
   const connectWallet = useCallback(

--- a/src/views/TransferStatus.tsx
+++ b/src/views/TransferStatus.tsx
@@ -34,7 +34,7 @@ export const TransferStatusToast = ({
 }: ElementProps) => {
   const stringGetter = useStringGetter();
   const [open, setOpen] = useState<boolean>(false);
-  const [secondsLeft, setSecondsLeft] = useState<number | undefined>();
+  const [secondsLeft, setSecondsLeft] = useState<number>(0);
 
   // @ts-ignore status.errors is not in the type definition but can be returned
   const error = status?.errors?.length ? status?.errors[0] : status?.error;
@@ -49,14 +49,23 @@ export const TransferStatusToast = ({
 
   if (!status) return <LoadingDots size={3} />;
 
+  const inProgressStatusString =
+    type === 'deposit'
+      ? secondsLeft > 0
+        ? STRING_KEYS.DEPOSIT_STATUS
+        : STRING_KEYS.DEPOSIT_STATUS_SHORTLY
+      : secondsLeft > 0
+      ? STRING_KEYS.WITHDRAW_COMPLETE
+      : STRING_KEYS.WITHDRAW_STATUS_SHORTLY;
+
   const statusString =
     type === 'deposit'
       ? status?.squidTransactionStatus === 'success'
         ? STRING_KEYS.DEPOSIT_COMPLETE
-        : STRING_KEYS.DEPOSIT_STATUS
+        : inProgressStatusString
       : status?.squidTransactionStatus === 'success'
       ? STRING_KEYS.WITHDRAW_COMPLETE
-      : STRING_KEYS.WITHDRAW_STATUS;
+      : inProgressStatusString;
 
   return (
     <Styled.Root open={open} onOpenChange={setOpen}>

--- a/src/views/TransferStatus.tsx
+++ b/src/views/TransferStatus.tsx
@@ -55,7 +55,7 @@ export const TransferStatusToast = ({
         ? STRING_KEYS.DEPOSIT_STATUS
         : STRING_KEYS.DEPOSIT_STATUS_SHORTLY
       : secondsLeft > 0
-      ? STRING_KEYS.WITHDRAW_COMPLETE
+      ? STRING_KEYS.WITHDRAW_STATUS
       : STRING_KEYS.WITHDRAW_STATUS_SHORTLY;
 
   const statusString =

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -17,7 +17,6 @@ import { useAccounts, useDebounce, useStringGetter, useSelectedNetwork } from '@
 import { useAccountBalance, CHAIN_DEFAULT_TOKEN_ADDRESS } from '@/hooks/useAccountBalance';
 import { useLocalNotifications } from '@/hooks/useLocalNotifications';
 import { NATIVE_TOKEN_ADDRESS, useSquid } from '@/hooks/useSquid';
-import { useWalletConnection } from '@/hooks/useWalletConnection';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 import { formMixins } from '@/styles/formMixins';
@@ -56,8 +55,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const { selectedNetwork } = useSelectedNetwork();
 
-  const { evmAddress, signerWagmi } = useAccounts();
-  const { publicClientWagmi } = useWalletConnection();
+  const { evmAddress, signerWagmi, publicClientWagmi } = useAccounts();
 
   const { addTransferNotification } = useLocalNotifications();
 


### PR DESCRIPTION
Depends on https://github.com/dydxprotocol/v4-localization/pull/149

- Memo `resolveWagmiConnector` so it does not repeatedly trigger `WalletConnectConnector` constructor which kicks of a wss auth request everytime
- Do not use `useWalletConnection` directly from Deposit form, it should be using the hook instance from the `useAccounts` context
- During deposit, the final step in does not have the correct transaction URL on complection. This is because the `toChain` object from squid status is not reliable and returns osmosis instead of dydx. It is better to derive the tranasction URL from the final step of `routeStatus` instead
- Update `TransferStatus` string when countdown reach 0, to show "available shortly" instead