### PR TITLE
add network select menu in restriction modals (dev)

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -439,6 +439,7 @@
             "tos": "https://dydx.exchange/v4-terms",
             "privacy": "https://dydx.exchange/privacy",
             "mintscan": "https://testnet.mintscan.io/dydx-testnet/txs/{tx_hash}",
+            "mintscanBase": "https://testnet.mintscan.io/dydx-testnet",
             "documentation": "https://v4-teacher.vercel.app/",
             "community": "https://discord.com/invite/dydx",
             "feedback": "https://docs.google.com/forms/d/e/1FAIpQLSezLsWCKvAYDEb7L-2O4wOON1T56xxro9A2Azvl6IxXHP_15Q/viewform",

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -200,10 +200,9 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
 
       if (isTestnet) {
         console.log(
-          `${
-            ENVIRONMENT_CONFIG_MAP[this.compositeClient.network.getString() as DydxNetwork]?.links
-              ?.mintscanBase
-          }/txs/${hash}`
+          `${ENVIRONMENT_CONFIG_MAP[
+            this.compositeClient.network.getString() as DydxNetwork
+          ]?.links?.mintscan?.replace('{tx_hash}', hash.toString())}`
         );
       } else console.log(`txHash: ${hash}`);
 

--- a/src/views/dialogs/RestrictedGeoDialog.tsx
+++ b/src/views/dialogs/RestrictedGeoDialog.tsx
@@ -1,11 +1,13 @@
 import styled, { AnyStyledComponent } from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
+import { isDev } from '@/constants/networks';
 import { useStringGetter } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
+import { NetworkSelectMenu } from '@/views/menus/NetworkSelectMenu';
 
 type ElementProps = {
   preventClose?: boolean;
@@ -25,6 +27,7 @@ export const RestrictedGeoDialog = ({ preventClose, setIsOpen }: ElementProps) =
     >
       <Styled.Content>
         {stringGetter({ key: STRING_KEYS.REGION_NOT_PERMITTED_SUBTITLE })}
+        {isDev && <NetworkSelectMenu />}
       </Styled.Content>
     </Dialog>
   );

--- a/src/views/dialogs/RestrictedWalletDialog.tsx
+++ b/src/views/dialogs/RestrictedWalletDialog.tsx
@@ -1,11 +1,13 @@
 import styled, { AnyStyledComponent } from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
+import { isDev } from '@/constants/networks';
 import { useStringGetter } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
+import { NetworkSelectMenu } from '@/views/menus/NetworkSelectMenu';
 
 type ElementProps = {
   preventClose?: boolean;
@@ -25,6 +27,7 @@ export const RestrictedWalletDialog = ({ preventClose, setIsOpen }: ElementProps
     >
       <Styled.Content>
         {stringGetter({ key: STRING_KEYS.REGION_NOT_PERMITTED_SUBTITLE })}
+        {isDev && <NetworkSelectMenu />}
       </Styled.Content>
     </Dialog>
   );

--- a/src/views/menus/NetworkSelectMenu.tsx
+++ b/src/views/menus/NetworkSelectMenu.tsx
@@ -33,6 +33,8 @@ const Styled: Record<string, AnyStyledComponent> = {};
 Styled.DropdownSelectMenu = styled(DropdownSelectMenu)`
   ${headerMixins.dropdownTrigger}
 
+  width: max-content;
+
   & > span:first-of-type {
     ${layoutMixins.textOverflow}
     max-width: 5.625rem;


### PR DESCRIPTION
<img width="669" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/5ec221d0-7b93-418b-836b-4043f3ea310b">
- for dev / staging env, show network select menu in restriction modals
- add missing `mintscanBase` in `env.json`
- use mintscan w/ `tx_hash` where applicable