### PR TITLE
Handle squid rout errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "@cosmjs/tendermint-rpc": "^0.31.0",
-    "@dydxprotocol/v4-abacus": "^1.0.22",
+    "@dydxprotocol/v4-abacus": "^1.0.24",
     "@dydxprotocol/v4-client-js": "^1.0.0",
     "@dydxprotocol/v4-localization": "^1.0.5",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "@cosmjs/tendermint-rpc": "^0.31.0",
-    "@dydxprotocol/v4-abacus": "^1.0.19",
+    "@dydxprotocol/v4-abacus": "^1.0.22",
     "@dydxprotocol/v4-client-js": "^1.0.0",
     "@dydxprotocol/v4-localization": "^1.0.5",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^0.31.0
     version: 0.31.0
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.0.19
-    version: 1.0.19
+    specifier: ^1.0.22
+    version: 1.0.22
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.0
     version: 1.0.0
@@ -982,8 +982,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.0.19:
-    resolution: {integrity: sha512-XhvSHGr503gNwHWEiOYP7M2uYeLu+Qm4szpE5w5H6hWFCanSGz6zAsTbPuyPLtt7IE1gj5z8mlL9J3tw2AZROg==}
+  /@dydxprotocol/v4-abacus@1.0.22:
+    resolution: {integrity: sha512-KLkBGY61T5xBYOS1WWDdH4Xk17TGJeDWuLmLEuQSdT4l0BKwasbI5F44ayBMyuu6vLvsP0iWSHtk5LlZHY5ChA==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^0.31.0
     version: 0.31.0
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.0.22
-    version: 1.0.22
+    specifier: ^1.0.24
+    version: 1.0.24
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.0
     version: 1.0.0
@@ -982,8 +982,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.0.22:
-    resolution: {integrity: sha512-KLkBGY61T5xBYOS1WWDdH4Xk17TGJeDWuLmLEuQSdT4l0BKwasbI5F44ayBMyuu6vLvsP0iWSHtk5LlZHY5ChA==}
+  /@dydxprotocol/v4-abacus@1.0.24:
+    resolution: {integrity: sha512-wDGSjkrc3Se6Ev7UTjPgJV7PiyzZSz2mJwOTZikLwH7W3k1iPYGQmaCd7TudFk8h2aSdlEwNsQBCf0sLoyvHaQ==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.0:

--- a/src/lib/abacus/rest.ts
+++ b/src/lib/abacus/rest.ts
@@ -56,13 +56,8 @@ class AbacusRest implements AbacusRestProtocol {
       .then(async (response) => {
         const data = await response.text();
 
-        if (response.ok) {
-          callback(data, response.status);
-        } else {
-          // response not OK, call callback with null data and the status, this includes 400/500 status codes
-          callback(null, response.status);
-        }
-
+        callback(data, response.status);
+        
         try {
           lastSuccessfulRestRequestByOrigin[new URL(url).origin] = Date.now();
         } catch {}

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -65,6 +65,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     chain: chainIdStr,
     resources,
     summary,
+    errors: routeErrors,
   } = useSelector(getTransferInputs, shallowEqual) || {};
   const chainId = chainIdStr ? parseInt(chainIdStr) : undefined;
 
@@ -286,6 +287,17 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     if (error) {
       return parseWalletError({ error, stringGetter }).message;
     }
+
+    if (routeErrors) {
+      const parsedErrors = JSON.parse(routeErrors);
+      if (parsedErrors?.[0]?.message) {
+        return stringGetter({
+          key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
+          params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
+        });
+      }
+    }
+
 
     if (fromAmount) {
       if (!chainId) {

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -66,6 +66,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     resources,
     summary,
     errors: routeErrors,
+    errorMessage: routeErrorMessage,
   } = useSelector(getTransferInputs, shallowEqual) || {};
   const chainId = chainIdStr ? parseInt(chainIdStr) : undefined;
 
@@ -289,18 +290,12 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     if (routeErrors) {
-      try {
-        const parsedErrors = JSON.parse(routeErrors);
-        if (parsedErrors?.[0]?.message) {
-          return stringGetter({
+      return routeErrorMessage
+        ? stringGetter({
             key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-            params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
-          });
-        }
-      } catch (e) {
-        log('WithDrawForm/errorMessage', e);
-        return stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
-      }
+            params: { ERROR_MESSAGE: routeErrorMessage },
+          })
+        : stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
     }
 
     if (fromAmount) {
@@ -316,7 +311,16 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     return undefined;
-  }, [error, routeErrors, balance, chainId, fromAmount, sourceToken, stringGetter]);
+  }, [
+    error,
+    routeErrors,
+    routeErrorMessage,
+    balance,
+    chainId,
+    fromAmount,
+    sourceToken,
+    stringGetter,
+  ]);
 
   const isDisabled =
     Boolean(errorMessage) ||

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -98,7 +98,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
 
   useEffect(() => {
     const hasInvalidInput =
-      debouncedAmountBN.isNaN() || debouncedAmountBN.lte(0) || debouncedAmountBN.gte(balanceBN);
+      debouncedAmountBN.isNaN() || debouncedAmountBN.lte(0) || debouncedAmountBN.gt(balanceBN);
 
     abacusStateManager.setTransferValue({
       value: hasInvalidInput ? 0 : debouncedAmount,

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -289,12 +289,17 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     if (routeErrors) {
-      const parsedErrors = JSON.parse(routeErrors);
-      if (parsedErrors?.[0]?.message) {
-        return stringGetter({
-          key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-          params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
-        });
+      try {
+        const parsedErrors = JSON.parse(routeErrors);
+        if (parsedErrors?.[0]?.message) {
+          return stringGetter({
+            key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
+            params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
+          });
+        }
+      } catch (e) {
+        log('WithDrawForm/errorMessage', e);
+        return stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
       }
     }
 
@@ -311,7 +316,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     return undefined;
-  }, [error, routeErrors, balance, chainId, fromAmount, sourceToken]);
+  }, [error, routeErrors, balance, chainId, fromAmount, sourceToken, stringGetter]);
 
   const isDisabled =
     Boolean(errorMessage) ||

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -2,7 +2,7 @@ import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react
 import styled, { type AnyStyledComponent } from 'styled-components';
 import { type NumberFormatValues } from 'react-number-format';
 import { shallowEqual, useSelector } from 'react-redux';
-import { parseUnits } from 'viem'
+import { parseUnits } from 'viem';
 
 import erc20 from '@/abi/erc20.json';
 import { TransferInputField, TransferInputTokenResource, TransferType } from '@/constants/abacus';
@@ -172,7 +172,8 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
 
   const validateTokenApproval = useCallback(async () => {
     if (!signerWagmi || !publicClientWagmi) throw new Error('Missing signer');
-    if (!sourceToken?.address || !sourceToken.decimals) throw new Error('Missing source token address');
+    if (!sourceToken?.address || !sourceToken.decimals)
+      throw new Error('Missing source token address');
     if (!sourceChain?.rpc) throw new Error('Missing source chain rpc');
     if (!requestPayload?.targetAddress) throw new Error('Missing target address');
     if (!requestPayload?.value) throw new Error('Missing transaction value');
@@ -182,11 +183,11 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
       address: sourceToken.address as EvmAddress,
       abi: erc20,
       functionName: 'allowance',
-      args: [evmAddress as EvmAddress, requestPayload.targetAddress as EvmAddress]
+      args: [evmAddress as EvmAddress, requestPayload.targetAddress as EvmAddress],
     });
 
     const sourceAmountBN = parseUnits(debouncedAmount, sourceToken.decimals);
-    
+
     if (sourceAmountBN > (allowance as bigint)) {
       const { request } = await publicClientWagmi.simulateContract({
         account: evmAddress,
@@ -194,12 +195,12 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
         abi: erc20,
         functionName: 'approve',
         args: [requestPayload.targetAddress as EvmAddress, sourceAmountBN],
-      })
+      });
 
       const approveTx = await signerWagmi.writeContract(request);
       await publicClientWagmi.waitForTransactionReceipt({
         hash: approveTx,
-      })
+      });
     }
   }, [signerWagmi, sourceToken, sourceChain, requestPayload, publicClientWagmi]);
 
@@ -229,8 +230,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
           to: requestPayload.targetAddress as EvmAddress,
           data: requestPayload.data as EvmAddress,
           gasLimit: BigInt(requestPayload.gasLimit),
-          value:
-            requestPayload.routeType !== 'SEND' ? BigInt(requestPayload.value) : undefined,
+          value: requestPayload.routeType !== 'SEND' ? BigInt(requestPayload.value) : undefined,
         };
         const txHash = await signerWagmi.sendTransaction(tx);
 
@@ -298,7 +298,6 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
       }
     }
 
-
     if (fromAmount) {
       if (!chainId) {
         return stringGetter({ key: STRING_KEYS.MUST_SPECIFY_CHAIN });
@@ -312,7 +311,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     return undefined;
-  }, [error, balance, chainId, fromAmount, sourceToken]);
+  }, [error, routeErrors, balance, chainId, fromAmount, sourceToken]);
 
   const isDisabled =
     Boolean(errorMessage) ||

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -164,6 +164,7 @@ export const DepositButtonAndReceipt = ({
       label: <span>{stringGetter({ key: STRING_KEYS.SLIPPAGE })}</span>,
       value: (
         <SlippageEditor
+          disabled
           slippage={slippage}
           setIsEditing={setIsEditingSlipapge}
           setSlippage={setSlippage}

--- a/src/views/forms/AccountManagementForms/SlippageEditor.tsx
+++ b/src/views/forms/AccountManagementForms/SlippageEditor.tsx
@@ -24,11 +24,17 @@ type ElementProps = {
   slippage: number;
   setIsEditing?: Dispatch<SetStateAction<boolean>>;
   setSlippage: (slippage: number) => void;
+  disabled?: boolean;
 };
 
 export type SlippageEditorProps = ElementProps;
 
-export const SlippageEditor = ({ slippage, setIsEditing, setSlippage }: SlippageEditorProps) => {
+export const SlippageEditor = ({
+  disabled,
+  slippage,
+  setIsEditing,
+  setSlippage,
+}: SlippageEditorProps) => {
   const percentSlippage = slippage * 100;
   const [slippageInputValue, setSlippageInputValue] = useState(percentSlippage.toString());
   const [editorState, setEditorState] = useState(EditorState.Viewing);
@@ -79,6 +85,10 @@ export const SlippageEditor = ({ slippage, setIsEditing, setSlippage }: Slippage
       setEditorState(EditorState.Viewing);
     }
   };
+
+  if (disabled) {
+    return <Output type={OutputType.Percent} value={slippage} />;
+  }
 
   return (
     <Styled.WithConfirmationPopover

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -69,6 +69,7 @@ export const WithdrawForm = () => {
     chain: chainIdStr,
     address: toAddress,
     resources,
+    errors: routeErrors,
   } = useSelector(getTransferInputs, shallowEqual) || {};
 
   const isValidAddress = toAddress && isAddress(toAddress);
@@ -281,6 +282,16 @@ export const WithdrawForm = () => {
       });
     }
 
+    if (routeErrors) {
+      const parsedErrors = JSON.parse(routeErrors);
+      if (parsedErrors?.[0]?.message) {
+        return stringGetter({
+          key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
+          params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
+        });
+      }
+    }
+
     if (!toAddress) return stringGetter({ key: STRING_KEYS.WITHDRAW_MUST_SPECIFY_ADDRESS });
 
     if (sanctionedAddresses.has(toAddress))
@@ -303,6 +314,7 @@ export const WithdrawForm = () => {
     return undefined;
   }, [
     error,
+    routeErrors,
     freeCollateralBN,
     chainIdStr,
     debouncedAmountBN,

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -44,10 +44,10 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { MustBigNumber } from '@/lib/numbers';
+import { log } from '@/lib/telemetry';
 
 import { TokenSelectMenu } from './TokenSelectMenu';
 import { WithdrawButtonAndReceipt } from './WithdrawForm/WithdrawButtonAndReceipt';
-import { join } from 'path';
 
 export const WithdrawForm = () => {
   const stringGetter = useStringGetter();
@@ -283,12 +283,17 @@ export const WithdrawForm = () => {
     }
 
     if (routeErrors) {
-      const parsedErrors = JSON.parse(routeErrors);
-      if (parsedErrors?.[0]?.message) {
-        return stringGetter({
-          key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-          params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
-        });
+      try {
+        const parsedErrors = JSON.parse(routeErrors);
+        if (parsedErrors?.[0]?.message) {
+          return stringGetter({
+            key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
+            params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
+          });
+        }
+      } catch (e) {
+        log('WithDrawForm/errorMessage', e);
+        return stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
       }
     }
 
@@ -321,6 +326,7 @@ export const WithdrawForm = () => {
     toToken,
     toAddress,
     sanctionedAddresses,
+    stringGetter,
   ]);
 
   const isDisabled =

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -70,6 +70,7 @@ export const WithdrawForm = () => {
     address: toAddress,
     resources,
     errors: routeErrors,
+    errorMessage: routeErrorMessage,
   } = useSelector(getTransferInputs, shallowEqual) || {};
 
   const isValidAddress = toAddress && isAddress(toAddress);
@@ -283,18 +284,12 @@ export const WithdrawForm = () => {
     }
 
     if (routeErrors) {
-      try {
-        const parsedErrors = JSON.parse(routeErrors);
-        if (parsedErrors?.[0]?.message) {
-          return stringGetter({
+      return routeErrorMessage
+        ? stringGetter({
             key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-            params: { ERROR_MESSAGE: parsedErrors?.[0]?.message },
-          });
-        }
-      } catch (e) {
-        log('WithDrawForm/errorMessage', e);
-        return stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
-      }
+            params: { ERROR_MESSAGE: routeErrorMessage },
+          })
+        : stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG });
     }
 
     if (!toAddress) return stringGetter({ key: STRING_KEYS.WITHDRAW_MUST_SPECIFY_ADDRESS });
@@ -320,6 +315,7 @@ export const WithdrawForm = () => {
   }, [
     error,
     routeErrors,
+    routeErrorMessage,
     freeCollateralBN,
     chainIdStr,
     debouncedAmountBN,

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -147,6 +147,7 @@ export const WithdrawButtonAndReceipt = ({
       label: <span>{stringGetter({ key: STRING_KEYS.SLIPPAGE })}</span>,
       value: (
         <SlippageEditor
+          disabled
           slippage={slippage}
           setIsEditing={setIsEditingSlipapge}
           setSlippage={setSlippage}


### PR DESCRIPTION
<img width="512" alt="Screenshot 2023-11-08 at 1 42 05 PM" src="https://github.com/dydxprotocol/v4-web/assets/1062252/79c2b7ac-ad8a-4a9a-8087-2b6cd45d37e6">

- Handle squid errors passed back via abacus
- `src/lib/abacus/rest.ts`
  - Do not filter response of requests with unsuccessful status codes
- fix max deposit button
- disable slippage editor for now, as we can't edit slippage in abacus yet