### PR TITLE
Fix status empty bug

### DIFF
--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -66,7 +66,16 @@ const useLocalNotificationsContext = () => {
         status: currentStatus,
       } of transferNotifications) {
         try {
-          if (currentStatus && currentStatus?.squidTransactionStatus !== 'ongoing') continue;
+          // skip if error is returned or if the transaction is not ongoing
+          if (
+            // @ts-ignore status.errors is not in the type definition but can be returned
+            currentStatus?.errors ||
+            currentStatus?.error ||
+            (currentStatus?.squidTransactionStatus &&
+              currentStatus?.squidTransactionStatus !== 'ongoing')
+          ) {
+            continue;
+          }
 
           const status = await squid?.getStatus({ transactionId: txHash, toChainId, fromChainId });
           if (status) statuses[txHash] = status;

--- a/src/hooks/useSquid.tsx
+++ b/src/hooks/useSquid.tsx
@@ -8,7 +8,7 @@ import { getSelectedNetwork } from '@/state/appSelectors';
 
 export const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
-export const STATUS_ERROR_GRACE_PERIOD = 120_000;
+export const STATUS_ERROR_GRACE_PERIOD = 300_000;
 
 const useSquidContext = () => {
   const selectedNetwork = useSelector(getSelectedNetwork);

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -44,7 +44,6 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { MustBigNumber } from '@/lib/numbers';
-import { log } from '@/lib/telemetry';
 
 import { TokenSelectMenu } from './TokenSelectMenu';
 import { WithdrawButtonAndReceipt } from './WithdrawForm/WithdrawButtonAndReceipt';


### PR DESCRIPTION
There is an initial 2m grace period where the status error is ignored. but if it goes over 2m, status can sometime get set as an empty object and 

- increase the grace period.
- Update the status fetch skip logic to skip if error is found or if `squidTransactionStatus` exists and is not "ongoing".