### PR TITLE
Mobile friendly Toast: Collapse/Close

### DIFF
--- a/src/components/ComboboxMenu.tsx
+++ b/src/components/ComboboxMenu.tsx
@@ -44,13 +44,6 @@ export const ComboboxMenu = <MenuItemValue extends string, MenuGroupValue extend
 }: ComboboxMenuProps<MenuItemValue, MenuGroupValue>) => {
   const [highlightedCommand, setHighlightedCommand] = useState<MenuItemValue>();
   const [searchValue, setSearchValue] = useState('');
-  // const inputRef = useRef<HTMLInputElement | null>(null);
-
-  // console.log({ commandValue: highlightedCommand });
-
-  // useEffect(() => {
-  //   inputRef?.current?.focus();
-  // }, []);
 
   return (
     <Styled.Command
@@ -67,11 +60,14 @@ export const ComboboxMenu = <MenuItemValue extends string, MenuGroupValue extend
       {withSearch && (
         <Styled.Header $withStickyLayout={withStickyLayout}>
           <Styled.Input
-            // ref={inputRef}
+            /**
+             * Mobile Issue: Search Input will always trigger mobile keyboard drawer. There is no fix.
+             * https://github.com/pacocoursey/cmdk/issues/127
+             */
+            autoFocus
             type="search"
             value={searchValue}
             onValueChange={setSearchValue}
-            autoFocus
             placeholder={inputPlaceholder}
           />
         </Styled.Header>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -4,6 +4,7 @@ import { Root, Action, Close } from '@radix-ui/react-toast';
 
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { popoverMixins } from '@/styles/popoverMixins';
+import { breakpoints } from '@/styles';
 
 import { Notification, type NotificationProps } from '@/components/Notification';
 
@@ -251,6 +252,11 @@ const $CloseButton = styled(IconButton)`
   border: solid var(--border-width) var(--color-border);
 
   ${$Root}:hover & {
+    display: block;
+    z-index: 2;
+  }
+
+  @media ${breakpoints.mobile} {
     display: block;
     z-index: 2;
   }

--- a/src/layout/NotificationsToastArea.tsx
+++ b/src/layout/NotificationsToastArea.tsx
@@ -75,7 +75,7 @@ export const NotificationsToastArea = ({ className }: StyleProps) => {
       {notificationMap.map(({ notification, key, displayData }, idx) => (
         <StyledToast
           key={key}
-          isStacked={!isMobile && shouldStackNotifications}
+          isStacked={shouldStackNotifications}
           isOpen={notification.status < NotificationStatus.Unseen}
           layer={notificationMap.length - 1 - idx}
           notification={notification}
@@ -167,6 +167,9 @@ const StyledToggleButton = styled(ToggleButton)<{ isPressed: boolean }>`
   }
 
   @media ${breakpoints.mobile} {
-    display: none;
+    display: flex;
+    left: calc(50% - 2rem);
+    --button-width: 4rem;
+    --button-height: 2rem;
   }
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/dydxprotocol/v4-web/assets/13111994/92164f67-8a95-4c8f-8253-00f664ac2b54


<!-- Overall purpose of the PR -->
Update Toast/ToastArea component to be more mobile friendly.

---

## Views

* `<ComboboxMenu>`
  * Attempted to fix an issue with autofocus in the mobile `<NotificationsMenu>`
  * CMDK lib does not expose the props necessary to fix the issue. Added link to repo providing explanation.

* `<NotificationsToastArea>`
  * Allow notifs to be stacked
  * Make notif collapse toggle larger for mobile breakpoints 

## Components

* `<Toast>`
  * Always display `CloseButton` when at Mobile breakpoint (No `:hover` effect)

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
