### PR TITLE
Make additional markets visible

### DIFF
--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -27,4 +27,13 @@ export enum FundingDirection {
   ToLong = 'ToLong',
 }
 
-export const MARKETS_TO_DISPLAY = ['BTC-USD', 'ETH-USD', 'LINK-USD', 'SOL-USD'];
+export const MARKETS_TO_DISPLAY = [
+  'BTC-USD',
+  'ETH-USD',
+  'LINK-USD',
+  'SOL-USD',
+  'MATIC-USD',
+  'ATOM-USD',
+  'AVAX-USD',
+  'APE-USD',
+];


### PR DESCRIPTION
Adds the following markets to the market filter list so they are displayed
matic-usd
atom-usd
avax-usd
ape-usd