### PR TITLE
Firefox issues

### DIFF
--- a/src/components/CollapsibleTabs.tsx
+++ b/src/components/CollapsibleTabs.tsx
@@ -31,9 +31,11 @@ type ElementProps<TabItemsValue> = {
 };
 
 type StyleProps = {
-  fullWidthTabs?: boolean;
   className?: string;
+  fullWidthTabs?: boolean;
 };
+
+export type CollapsibleTabsProps<TabItemsValue> = ElementProps<TabItemsValue> & StyleProps;
 
 export const CollapsibleTabs = <TabItemsValue extends string>({
   defaultValue,
@@ -43,8 +45,9 @@ export const CollapsibleTabs = <TabItemsValue extends string>({
   onOpenChange,
 
   fullWidthTabs,
+
   className,
-}: ElementProps<TabItemsValue> & StyleProps) => {
+}: CollapsibleTabsProps<TabItemsValue>) => {
   const [value, setValue] = useState(defaultValue);
 
   const currentItem = items.find((item) => item.value === value);
@@ -86,8 +89,8 @@ export const CollapsibleTabs = <TabItemsValue extends string>({
         </Styled.Header>
 
         <Styled.CollapsibleContent>
-          {items.map(({ value, content }) => (
-            <Styled.TabsContent key={value} value={value}>
+          {items.map(({ asChild, value, content }) => (
+            <Styled.TabsContent key={value} asChild={asChild} value={value}>
               {content}
             </Styled.TabsContent>
           ))}
@@ -219,7 +222,6 @@ Styled.Header = styled.header`
 
 Styled.CollapsibleContent = styled(CollapsibleContent)`
   ${layoutMixins.stack}
-  ${layoutMixins.perspectiveArea}
 
   box-shadow: none;
 `;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -198,7 +198,6 @@ Styled.InputContainer = styled.div`
   border-radius: inherit;
 
   input {
-    user-select: all;
     flex: 1;
     width: 100%;
   }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -746,6 +746,7 @@ Styled.Tr = styled.tr<{
       &:focus-visible,
       &:focus-within {
         --tableRow-currentBackgroundColor: var(--tableRow-hover-backgroundColor);
+        filter: brightness(1.1);
       }
     `};
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -746,7 +746,6 @@ Styled.Tr = styled.tr<{
       &:focus-visible,
       &:focus-within {
         --tableRow-currentBackgroundColor: var(--tableRow-hover-backgroundColor);
-        filter: brightness(1.1);
       }
     `};
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -21,6 +21,7 @@ export type TabItem<TabItemsValue> = {
   content?: React.ReactNode;
   subitems?: TabItem<TabItemsValue>[];
   customTrigger?: ReactNode;
+  asChild?: boolean;
 };
 
 type ElementProps<TabItemsValue> = {
@@ -40,6 +41,8 @@ type StyleProps = {
   withTransitions?: boolean;
   className?: string;
 };
+
+export type TabsProps<TabItemsValue> = ElementProps<TabItemsValue> & StyleProps;
 
 export const Tabs = <TabItemsValue extends string>({
   defaultValue,
@@ -107,9 +110,10 @@ export const Tabs = <TabItemsValue extends string>({
         sharedContent
       ) : (
         <Styled.Stack>
-          {items.map(({ value, content, forceMount }) => (
+          {items.map(({ asChild, value, content, forceMount }) => (
             <Styled.Content
               key={value}
+              asChild={asChild}
               value={value}
               forceMount={forceMount}
               $hide={forceMount && currentItem?.value !== value}
@@ -242,7 +246,6 @@ Styled.Trigger = styled(Trigger)<{ $withBorders?: boolean }>`
 
 Styled.Stack = styled.div`
   ${layoutMixins.stack}
-  ${layoutMixins.perspectiveArea}
 
   box-shadow: none;
 `;

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -9,7 +9,7 @@ import { useBreakpoints, useStringGetter } from '@/hooks';
 import { AssetIcon } from '@/components/AssetIcon';
 import { CollapsibleTabs } from '@/components/CollapsibleTabs';
 import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
-import { MobileTabs, Tabs } from '@/components/Tabs';
+import { MobileTabs } from '@/components/Tabs';
 import { Tag, TagType } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
@@ -27,7 +27,6 @@ import {
   getCurrentMarketTradeInfoNumbers,
   getHasUnseenFillUpdates,
   getHasUnseenOrderUpdates,
-  getLatestOrderStatus,
   getTradeInfoNumbers,
 } from '@/state/accountSelectors';
 
@@ -222,7 +221,6 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
     <MobileTabs defaultValue={InfoSection.Position} items={tabItems} withBorders={false} />
   ) : (
     <Styled.CollapsibleTabs
-      withTransitions={false}
       defaultValue={InfoSection.Position}
       defaultOpen={isOpen}
       onOpenChange={setIsOpen}

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -877,11 +877,6 @@ export const layoutMixins: Record<
     }
   `,
 
-  perspectiveArea: css`
-    perspective: 100rem;
-    transform-style: preserve-3d;
-  `,
-
   absolute: css`
     position: absolute;
     top: 0;

--- a/src/views/AccountInfo.tsx
+++ b/src/views/AccountInfo.tsx
@@ -63,7 +63,6 @@ Styled.AccountInfoSectionContainer = styled.div<{ showAccountInfo?: boolean }>`
   ${layoutMixins.column}
   height: var(--account-info-section-height);
   min-height: var(--account-info-section-height);
-  overflow-x: clip;
 
   ${({ showAccountInfo }) =>
     !showAccountInfo &&

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -203,7 +203,6 @@ const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.Stack = styled.div`
   ${layoutMixins.stack}
-  ${layoutMixins.perspectiveArea}
 `;
 
 Styled.CornerButton = styled(Button)`

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -293,7 +293,14 @@ Styled.TransferButtons = styled.div`
 
 Styled.ConnectedAccountInfoContainer = styled.div<{ $showHeader?: boolean }>`
   ${layoutMixins.column}
-  ${layoutMixins.withOuterAndInnerBorders}
+
+  @media ${breakpoints.notTablet} {
+    ${layoutMixins.withOuterAndInnerBorders}
+  }
+
+  @media ${breakpoints.tablet} {
+    ${layoutMixins.withInnerBorder}
+  }
 
   ${({ $showHeader }) =>
     $showHeader &&

--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -213,13 +213,8 @@ Styled.MarketDetails = styled.div`
 `;
 
 Styled.Header = styled.header`
-  /* max-width: fit-content; */
-
   ${layoutMixins.column}
   gap: 1.25rem;
-
-  position: sticky;
-  bottom: 3rem;
 `;
 
 Styled.WrapRow = styled.div`

--- a/src/views/PositionInfo.tsx
+++ b/src/views/PositionInfo.tsx
@@ -556,12 +556,12 @@ Styled.MobilePositionInfo = styled.div`
 Styled.PositionTile = styled(PositionTile)``;
 
 Styled.ClosePositionButton = styled(Button)`
-  --button-border: solid var(--border-width) var(--color-border-destructive);
+  --button-border: solid var(--border-width) var(--color-border-red);
   --button-textColor: var(--color-negative);
 `;
 
 Styled.ClosePositionToggleButton = styled(ToggleButton)`
-  --button-border: solid var(--border-width) var(--color-border-destructive);
+  --button-border: solid var(--border-width) var(--color-border-red);
   --button-toggle-off-textColor: var(--color-negative);
   --button-toggle-on-textColor: var(--color-negative);
 `;

--- a/src/views/PositionInfo.tsx
+++ b/src/views/PositionInfo.tsx
@@ -453,13 +453,6 @@ Styled.Actions = styled.footer`
   > :last-child {
     flex: 2;
   }
-
-  position: sticky;
-  bottom: clamp(0.5rem, 7.5%, 2rem);
-
-  @media ${breakpoints.tablet} {
-    bottom: 0;
-  }
 `;
 
 Styled.Output = styled(Output)<{ sign: NumberSign; smallText?: boolean; margin?: string }>`
@@ -514,6 +507,7 @@ Styled.PositionInfo = styled.div`
 
 Styled.DetachedSection = styled(DetachedSection)`
   padding: 0 1.5rem;
+  position: relative;
 `;
 
 Styled.DetachedScrollableSection = styled(DetachedScrollableSection)`
@@ -562,12 +556,12 @@ Styled.MobilePositionInfo = styled.div`
 Styled.PositionTile = styled(PositionTile)``;
 
 Styled.ClosePositionButton = styled(Button)`
-  --button-border: solid var(--border-width) var(--color-border-red);
+  --button-border: solid var(--border-width) var(--color-border-destructive);
   --button-textColor: var(--color-negative);
 `;
 
 Styled.ClosePositionToggleButton = styled(ToggleButton)`
-  --button-border: solid var(--border-width) var(--color-border-red);
+  --button-border: solid var(--border-width) var(--color-border-destructive);
   --button-toggle-off-textColor: var(--color-negative);
   --button-toggle-on-textColor: var(--color-negative);
 `;

--- a/src/views/charts/TvChart.tsx
+++ b/src/views/charts/TvChart.tsx
@@ -82,7 +82,6 @@ const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.PriceChart = styled.div<{ isChartReady?: boolean }>`
   ${layoutMixins.stack}
-  ${layoutMixins.perspectiveArea}
 
   height: 100%;
 

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -230,14 +230,7 @@ const getOrdersTableColumnDef = ({
         label: `${stringGetter({ key: STRING_KEYS.STATUS })} / ${stringGetter({
           key: STRING_KEYS.FILL,
         })}`,
-        renderCell: ({
-          asset,
-          createdAtMilliseconds,
-          size,
-          status,
-          totalFilled,
-          resources,
-        }) => {
+        renderCell: ({ asset, createdAtMilliseconds, size, status, totalFilled, resources }) => {
           const { statusIconColor, statusStringKey } = getStatusIconInfo({
             status,
             totalFilled,
@@ -345,9 +338,7 @@ export const OrdersTable = ({
     if (hasUnseenOrderUpdates) dispatch(viewedOrders());
   }, [hasUnseenOrderUpdates]);
 
-  const symbol = currentMarket
-    ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.symbol
-    : null;
+  const symbol = currentMarket ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.id : null;
 
   const ordersData = orders.map((order: SubaccountOrder) =>
     getHydratedTradingData({


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Fix miscellaneous firefox issues.


---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<HorizontalPanel>`
  * memoize config for `<CollapsibleTabs>`

* `<AccountInfo>`
  * remove `overflow-x: clip`, caused issues with rendering the `<AccountInfo>` at smaller breakpoints on firefox

https://github.com/dydxprotocol/v4-web/assets/13111994/3845e327-f13f-4848-b502-1469fe4f9ad1

* `<AccountInfoConnectedState>`
  * Remove `layoutMixins.perspectiveArea`
  * Remove `outerBorders` when rendered on MobileTopPanel. Border was rendered out of place at smaller breakpoints on firefox

* `<MarketDetails>`/`<PositionInfo>`
  * Remove `position: sticky` made buttons un-clickable in firefox:
    *  external links
    * close position

https://github.com/dydxprotocol/v4-web/assets/13111994/de517b63-ad14-4a86-a7b4-5aa9c673a06b

https://github.com/dydxprotocol/v4-web/assets/13111994/bb451dca-3be6-4969-a0f6-53403dcf8e12

https://github.com/dydxprotocol/v4-web/assets/13111994/ffeb8f4b-0b0c-43cc-a366-ea3ea0e57e48


## Components

* `<Tabs>/<CollapsibleTabs>`
  * allow `asChild` prop to be passed to TabContent
  * remove usage of `layoutMixins.PerspectiveArea`. It was causing the rows to flash on hover in firefox

https://github.com/dydxprotocol/v4-web/assets/13111994/9632f173-7d71-4896-85fb-208f9c9de0a5


## Styles/Mixins

* `styles/layoutMixins`
  * Remove `perspecitveArea`.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
