### PR TITLE
Size inputs

### DIFF
--- a/src/views/forms/TradeForm/LeverageSlider.tsx
+++ b/src/views/forms/TradeForm/LeverageSlider.tsx
@@ -86,7 +86,6 @@ export const LeverageSlider = ({
 
   const onValueCommit = ([newLeverage]: number[]) => {
     setLeverageInputValue(`${newLeverage}`);
-    console.log('commit', newLeverage);
 
     // Ensure Abacus is updated with the latest, committed value
     debouncedSetAbacusLeverage.cancel();

--- a/src/views/forms/TradeForm/LeverageSlider.tsx
+++ b/src/views/forms/TradeForm/LeverageSlider.tsx
@@ -1,10 +1,10 @@
-import { type Dispatch, type SetStateAction, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import styled, { AnyStyledComponent, css } from 'styled-components';
 import { Root, Thumb, Track } from '@radix-ui/react-slider';
 import _ from 'lodash';
 import { OrderSide } from '@dydxprotocol/v4-client-js';
 
-import { type Nullable, TradeInputField } from '@/constants/abacus';
+import { TradeInputField } from '@/constants/abacus';
 import { PositionSide } from '@/constants/trade';
 
 import { MustBigNumber, type BigNumberish } from '@/lib/numbers';
@@ -12,11 +12,11 @@ import abacusStateManager from '@/lib/abacus';
 
 type ElementProps = {
   leverage?: BigNumberish | null;
-  leverageInputValue: Nullable<number>;
+  leverageInputValue: string;
   maxLeverage: BigNumberish | null;
   orderSide: OrderSide;
   positionSide: PositionSide;
-  setLeverageInputValue: Dispatch<SetStateAction<Nullable<number>>>;
+  setLeverageInputValue: (value: string) => void;
 };
 
 type StyleProps = { className?: string };
@@ -33,6 +33,7 @@ export const LeverageSlider = ({
   const leverageBN = MustBigNumber(leverage);
   const maxLeverageBN = MustBigNumber(maxLeverage);
   const leverageInputBN = MustBigNumber(leverageInputValue || leverage);
+  const leverageInputNumber = isNaN(leverageInputBN.toNumber()) ? 0 : leverageInputBN.toNumber();
 
   const sliderConfig = useMemo(
     () => ({
@@ -79,12 +80,13 @@ export const LeverageSlider = ({
   );
 
   const onSliderDrag = ([newLeverage]: number[]) => {
-    setLeverageInputValue(newLeverage);
+    setLeverageInputValue(`${newLeverage}`);
     debouncedSetAbacusLeverage(newLeverage);
   };
 
   const onValueCommit = ([newLeverage]: number[]) => {
-    setLeverageInputValue(newLeverage);
+    setLeverageInputValue(`${newLeverage}`);
+    console.log('commit', newLeverage);
 
     // Ensure Abacus is updated with the latest, committed value
     debouncedSetAbacusLeverage.cancel();
@@ -102,7 +104,7 @@ export const LeverageSlider = ({
         min={min}
         max={max}
         step={0.1}
-        value={[Math.min(Math.max(leverageInputBN.toNumber(), min), max)]}
+        value={[Math.min(Math.max(leverageInputNumber, min), max)]}
         onValueChange={onSliderDrag}
         onValueCommit={onValueCommit}
       >

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -77,7 +77,7 @@ export const TradeSizeInputs = () => {
     floatValue?: number;
     formattedValue: string;
   }) => {
-    dispatch(setTradeFormInputs({ amountInput: MustBigNumber(floatValue).toString() }));
+    dispatch(setTradeFormInputs({ amountInput: formattedValue }));
     const newAmount = MustBigNumber(floatValue).toFixed(decimals);
 
     abacusStateManager.setTradeValue({
@@ -93,7 +93,7 @@ export const TradeSizeInputs = () => {
     floatValue?: number;
     formattedValue: string;
   }) => {
-    dispatch(setTradeFormInputs({ usdAmountInput: MustBigNumber(floatValue).toString() }));
+    dispatch(setTradeFormInputs({ usdAmountInput: formattedValue }));
     const newUsdcAmount = MustBigNumber(floatValue).toFixed(tickSizeDecimals || USD_DECIMALS);
 
     abacusStateManager.setTradeValue({


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Before

https://github.com/dydxprotocol/v4-web/assets/13111994/66039ccc-4e90-4524-9e92-7b03f77c6ab0

After

https://github.com/dydxprotocol/v4-web/assets/13111994/58aa74aa-486a-4fb0-af76-afcf8876790a


<!-- Overall purpose of the PR -->

Allow Size inputs to gracefully handle `0.0` when deleting chars.  

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketLeverageInput>`
  * Add `getSignedLeverage` method to get the raw leverage value (signed)
  * Have separate methods to handle when slider is used vs when input is used

* `<TradeSizeInputs>`
  * Update redux state using `formattedValue` 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
