### PR TITLE
Navigate to the Markets page if  the current marketId is not included in subscribed markets

### DIFF
--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -5,15 +5,15 @@ import { useMatch, useNavigate } from 'react-router-dom';
 import { LocalStorageKey } from '@/constants/localStorage';
 import { DEFAULT_MARKETID } from '@/constants/markets';
 import { AppRoute } from '@/constants/routes';
+import { useIsFirstRender } from '@/hooks/useIsFirstRender';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
 import { closeDialogInTradeBox } from '@/state/dialogs';
 import { setCurrentMarketId } from '@/state/perpetuals';
+import { getMarketIds } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
-
-import { useLocalStorage } from './useLocalStorage';
-import { getMarketIds } from '@/state/perpetualsSelectors';
 
 export const useCurrentMarketId = () => {
   const navigate = useNavigate();
@@ -23,6 +23,7 @@ export const useCurrentMarketId = () => {
   const selectedNetwork = useSelector(getSelectedNetwork);
   const marketIds = useSelector(getMarketIds, shallowEqual);
   const hasMarketIds = marketIds.length > 0;
+  const isFirstRender = useIsFirstRender();
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,
@@ -33,17 +34,35 @@ export const useCurrentMarketId = () => {
     if (marketIds.length === 0) return marketId ?? lastViewedMarket;
     if (!marketIds.includes(marketId ?? lastViewedMarket)) return DEFAULT_MARKETID;
     return marketId ?? lastViewedMarket;
-  }, [marketIds, marketId]);
+  }, [hasMarketIds, marketId]);
 
   useEffect(() => {
-    setLastViewedMarket(validId);
-    dispatch(setCurrentMarketId(validId));
-    dispatch(closeDialogInTradeBox());
+    // If v4_markets has not been subscribed to yet or marketId is not specified, default to validId
+    if (!hasMarketIds || !marketId) {
+      setLastViewedMarket(validId);
+      dispatch(setCurrentMarketId(validId));
+      dispatch(closeDialogInTradeBox());
 
-    navigate(`${AppRoute.Trade}/${validId}`, {
-      replace: true,
-    });
-  }, [validId]);
+      if (validId !== marketId) {
+        navigate(`${AppRoute.Trade}/${validId}`, {
+          replace: true,
+        });
+      }
+    } else if (hasMarketIds) {
+      // If v4_markets has been subscribed to, check if marketId is valid
+      if (!marketIds.includes(marketId) && !isFirstRender) {
+        // If marketId is not valid (i.e. final settlement), navigate to markets page
+        navigate(AppRoute.Markets, {
+          replace: true,
+        });
+      } else {
+        // If marketId is valid, set currentMarketId
+        setLastViewedMarket(marketId);
+        dispatch(setCurrentMarketId(marketId));
+        dispatch(closeDialogInTradeBox());
+      }
+    }
+  }, [hasMarketIds, marketId]);
 
   useEffect(() => {
     // Check for marketIds otherwise Abacus will silently fail its isMarketValid check

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -5,7 +5,6 @@ import { useMatch, useNavigate } from 'react-router-dom';
 import { LocalStorageKey } from '@/constants/localStorage';
 import { DEFAULT_MARKETID } from '@/constants/markets';
 import { AppRoute } from '@/constants/routes';
-import { useIsFirstRender } from '@/hooks/useIsFirstRender';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
@@ -23,7 +22,6 @@ export const useCurrentMarketId = () => {
   const selectedNetwork = useSelector(getSelectedNetwork);
   const marketIds = useSelector(getMarketIds, shallowEqual);
   const hasMarketIds = marketIds.length > 0;
-  const isFirstRender = useIsFirstRender();
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,
@@ -48,9 +46,9 @@ export const useCurrentMarketId = () => {
           replace: true,
         });
       }
-    } else if (hasMarketIds) {
+    } else {
       // If v4_markets has been subscribed to, check if marketId is valid
-      if (!marketIds.includes(marketId) && !isFirstRender) {
+      if (!marketIds.includes(marketId)) {
         // If marketId is not valid (i.e. final settlement), navigate to markets page
         navigate(AppRoute.Markets, {
           replace: true,


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Navigate to the Markets page if  the current marketId is not included in subscribed markets. This will be used to handle navigating to markets that have a status of `final_settlement`.

---

<!-- Reorder/delete the following sections accordingly: -->
## Hooks

* `hooks/useCurrentMarketId`
  * If v4_markets has not been subscribed to yet or marketId is not specified, default to validId
  * If marketId is not valid (i.e. final settlement), navigate to markets page
  * If marketId is valid, set currentMarketId
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
