### PR TITLE
TRCL-3406: firefox mobile position table row has stretched icon

### DIFF
--- a/src/views/dialogs/HelpDialog.tsx
+++ b/src/views/dialogs/HelpDialog.tsx
@@ -8,6 +8,7 @@ import { ComboboxDialogMenu } from '@/components/ComboboxDialogMenu';
 import { Icon, IconName } from '@/components/Icon';
 
 import { isTruthy } from '@/lib/isTruthy';
+import { breakpoints } from '@/styles';
 
 type ElementProps = {
   setIsOpen: (open: boolean) => void;
@@ -72,8 +73,11 @@ export const HelpDialog = ({ setIsOpen }: ElementProps) => {
 const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.ComboboxDialogMenu = styled(ComboboxDialogMenu)`
-  --dialog-width: var(--dialog-small-width);
   --dialog-content-paddingTop: 1rem;
   --dialog-content-paddingBottom: 1rem;
   --comboxDialogMenu-item-gap: 1rem;
+
+  @media ${breakpoints.notMobile} {
+    --dialog-width: var(--dialog-small-width);
+  }
 `;

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -366,6 +366,7 @@ Styled.InlineRow = styled.div`
 
 Styled.AssetIcon = styled(AssetIcon)`
   ${layoutMixins.inlineRow}
+  min-width: unset;
   font-size: 2.25rem;
 `;
 


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
![Screen Shot 2023-12-19 at 4 42 56 PM](https://github.com/dydxprotocol/v4-web/assets/13111994/7fed979e-dd72-4429-ae72-7874f1b9e07a)

<!-- Overall purpose of the PR -->
Fix stretched icon
---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<PositionsTable>`
  * <!-- explain changes to existing view component -->
  * `min-width: max-contents;` forces the AssetIcon to stretch in firefox
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
