### PR TITLE
Create documentation.json for trading rewards FAQ

### DIFF
--- a/public/configs/documentation.json
+++ b/public/configs/documentation.json
@@ -1,0 +1,16 @@
+{
+    "tradingRewardsFAQs": [
+        {
+            "questionLocalizationKey": "APP.TRADING_REWARDS.FAQ_WHO_IS_ELIGIBLE_QUESTION",
+            "answerLocalizationKey": "APP.TRADING_REWARDS.FAQ_WHO_IS_ELIGIBLE_ANSWER"
+        },
+        {
+            "questionLocalizationKey": "APP.TRADING_REWARDS.FAQ_HOW_DO_TRADING_REWARDS_WORK_QUESTION",
+            "answerLocalizationKey": "APP.TRADING_REWARDS.FAQ_HOW_DO_TRADING_REWARDS_WORK_ANSWER"
+        },
+        {
+            "questionLocalizationKey": "APP.TRADING_REWARDS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_QUESTION",
+            "answerLocalizationKey": "APP.TRADING_REWARDS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_ANSWER"
+        }
+    ]
+}


### PR DESCRIPTION
[TRCL-3427 : Add Trading Rewards FAQ to Abacus](https://linear.app/dydx/issue/TRCL-3427/add-trading-rewards-faq-to-abacus)

### Description
- adds documentation.json

Trading Rewards FAQs are shared across clients, so we can use a deployed FAQs config json to update FAQs remotely.  Naming it `documentation.json` to support further static documentation.