### PR TITLE
Update comparison function in Table

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -43,6 +43,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Icon, IconName } from './Icon';
 import { Tag } from './Tag';
+import { MustBigNumber } from '@/lib/numbers';
 
 export { TableCell } from './Table/TableCell';
 export { TableColumnHeader } from './Table/TableColumnHeader';
@@ -161,10 +162,7 @@ export const Table = <TableRowData extends object, TableRowKey extends Key>({
         ? // String
           collator.compare(first as string, second as string)
         : // Number
-          Math.sign(
-            (parseInt(first as string) || (first as number)) -
-              (parseInt(second as string) || (second as number))
-          )) *
+          MustBigNumber(first).comparedTo(MustBigNumber(second))) *
       // Flip the direction if descending order is specified.
       (sortDirection === 'descending' ? -1 : 1)
     );

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -10,6 +10,7 @@ export const LEVERAGE_DECIMALS = 2;
 export const TOKEN_DECIMALS = 4;
 export const LARGE_TOKEN_DECIMALS = 2;
 export const FEE_DECIMALS = 3;
+export const FUNDING_DECIMALS = 6;
 
 export const QUANTUM_MULTIPLIER = 1_000_000;
 

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { STRING_KEYS } from '@/constants/localization';
 import { MarketFilters, type MarketData } from '@/constants/markets';
-import { LARGE_TOKEN_DECIMALS } from '@/constants/numbers';
+import { FUNDING_DECIMALS, LARGE_TOKEN_DECIMALS } from '@/constants/numbers';
 import { AppRoute } from '@/constants/routes';
 
 import { useBreakpoints, useStringGetter } from '@/hooks';
@@ -128,7 +128,8 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               label: stringGetter({ key: STRING_KEYS.FUNDING_RATE_1H_SHORT }),
               renderCell: (row) => (
                 <Styled.Output
-                  type={OutputType.SmallPercent}
+                  type={OutputType.Percent}
+                  fractionDigits={FUNDING_DECIMALS}
                   value={row.nextFundingRate}
                   isPositive={MustBigNumber(row.nextFundingRate).gt(0)}
                   isNegative={MustBigNumber(row.nextFundingRate).isNegative()}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Updated screenies:
<img width="241" alt="Screen Shot 2023-12-20 at 3 36 35 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/b3a5a3c0-e688-41c3-94f2-41d566da0592">
<img width="190" alt="Screen Shot 2023-12-20 at 3 36 43 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/169d2280-e77c-486b-90b2-7b201cea40a0">

<!-- Overall purpose of the PR -->
Fix inaccuracies when sorting the Markets table by 1h funding.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketsTable>`
  * use `FUNDING_DECIMALS` as the `fractionDigits` for display of `1h funding`

## Components

* `<Table>`
  * use `bignumber.js` for number formatting instead of `parseInt`

## Constants/Types

* `constants/numbers`
  * add `FUNDING_DECIMALS`
  * defaulted to 6 but can be changed

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
