### PR TITLE
Remove base from baseInitialMarginFraction

### DIFF
--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -114,8 +114,8 @@ export const MarketDetails: React.FC = () => {
       ),
     },
     {
-      key: 'base-initial-margin-fraction',
-      label: stringGetter({ key: STRING_KEYS.BASE_INITIAL_MARGIN_FRACTION }),
+      key: 'initial-margin-fraction',
+      label: stringGetter({ key: STRING_KEYS.INITIAL_MARGIN_FRACTION }),
       tooltip: 'initial-margin-fraction',
       value: <Output useGrouping value={initialMarginFraction} type={OutputType.SmallPercent} />,
     },


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="528" alt="Screen Shot 2023-12-21 at 2 32 09 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/c68f0d7d-8ed3-4232-9be9-7103b926c615">

<!-- Overall purpose of the PR -->
With deprecation of non linear margin requirement, only display `Initial Margin Fraction` instead of `Base Initial Margin Fraction`

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<ViewComponentName>`
  * `Base Initial Margin Fraction` -> `Initial Margin Fraction`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
