### PR TITLE
Temp hide fees for CCTP route until Squid returns toAmountUSD

### DIFF
--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -34,6 +34,7 @@ import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getSubaccountBuyingPower, getSubaccountEquity } from '@/state/accountSelectors';
 import { getTransferInputs } from '@/state/inputsSelectors';
 
+import { isTruthy } from '@/lib/isTruthy';
 import { MustBigNumber } from '@/lib/numbers';
 
 import { SlippageEditor } from '../SlippageEditor';
@@ -83,7 +84,7 @@ export const DepositButtonAndReceipt = ({
   const { current: buyingPower, postOrder: newBuyingPower } =
     useSelector(getSubaccountBuyingPower, shallowEqual) || {};
 
-  const { summary, requestPayload } = useSelector(getTransferInputs, shallowEqual) || {};
+  const { isCctp, summary, requestPayload } = useSelector(getTransferInputs, shallowEqual) || {};
 
   const feeSubitems: DetailsItem[] = [];
 
@@ -157,7 +158,7 @@ export const DepositButtonAndReceipt = ({
         </Styled.ExchangeRate>
       ),
     },
-    {
+    !isCctp && {
       key: 'total-fees',
       label: <span>{stringGetter({ key: STRING_KEYS.TOTAL_FEES })}</span>,
       value: <Output type={OutputType.Fiat} value={totalFees} />,
@@ -193,7 +194,7 @@ export const DepositButtonAndReceipt = ({
         />
       ),
     },
-  ];
+  ].filter(isTruthy);
 
   const isFormValid = !isDisabled && !isEditingSlippage;
 


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
`toAmountUSD` is not currently being populated. Temporarily hide fee receipt-line so the users' wallets are the source of truth for gas price.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<DepositButtonAndReceipt>`
  * `toAmountUSD` is not currently being populated. Temporarily hide fee receipt-line so the users' wallets are the source of truth for gas price.