### PR TITLE
CCTP deposit/withdraw to throw error if nobleClient is not initialized

### DIFF
--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -56,6 +56,10 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
     this.store = undefined;
   }
 
+  get isNobleClientConnected(): boolean {
+    return this.nobleClient?.isConnected ?? false;
+  }
+
   setStore(store: RootStore): void {
     this.store = store;
   }

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -236,7 +236,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
         }
 
         if (isCctp && !abacusStateManager.chainTransactions.isNobleClientConnected) {
-          throw new Error('Noble client unable to initialize');
+          throw new Error('Noble RPC endpoint unaccessible');
         }
 
         setIsLoading(true);

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -235,6 +235,10 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
           throw new Error('Missing request payload');
         }
 
+        if (isCctp && !abacusStateManager.chainTransactions.isNobleClientConnected) {
+          throw new Error('Noble client unable to initialize');
+        }
+
         setIsLoading(true);
 
         await validateTokenApproval();

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -148,6 +148,10 @@ export const WithdrawForm = () => {
           throw new Error('Invalid request payload');
         }
 
+        if (isCctp && !abacusStateManager.chainTransactions.isNobleClientConnected) {
+          throw new Error('Noble client unable to initialize');
+        }
+
         setIsLoading(true);
         setError(undefined);
 
@@ -289,10 +293,7 @@ export const WithdrawForm = () => {
 
   const errorMessage = useMemo(() => {
     if (error) {
-      return stringGetter({
-        key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-        params: { ERROR_MESSAGE: error },
-      });
+      return error;
     }
 
     if (routeErrors) {

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -149,7 +149,7 @@ export const WithdrawForm = () => {
         }
 
         if (isCctp && !abacusStateManager.chainTransactions.isNobleClientConnected) {
-          throw new Error('Noble client unable to initialize');
+          throw new Error('Noble RPC endpoint unaccessible');
         }
 
         setIsLoading(true);


### PR DESCRIPTION
- Throw an error when attempting an CCTP deposit/withdraw, if the NobleClient has not been connected successfully.
- Also fix withdraw error being double wrapped.

<img width="498" alt="Screenshot 2024-01-02 at 9 07 36 PM" src="https://github.com/dydxprotocol/v4-web/assets/1062252/f07907d1-88ff-4c45-8d3f-58a6bd2f35be">
