### PR TITLE
TRCL-1979 Show open positions / orders in portfolio sidebar

### DIFF
--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -17,9 +17,10 @@ import { TransferHistoryTable } from '@/views/tables/TransferHistoryTable';
 import { Button } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
 import { NavigationMenu } from '@/components/NavigationMenu';
+import { Tag, TagType } from '@/components/Tag';
 import { WithSidebar } from '@/components/WithSidebar';
 
-import { getOnboardingState, getSubaccount } from '@/state/accountSelectors';
+import { getExistingOpenPositions, getOnboardingState, getSubaccount, getSubaccountUnclearedOrders } from '@/state/accountSelectors';
 import { openDialog } from '@/state/dialogs';
 
 import { PortfolioNavMobile } from './PortfolioNavMobile';
@@ -41,6 +42,9 @@ export default () => {
   const onboardingState = useSelector(getOnboardingState);
   const { freeCollateral } = useSelector(getSubaccount, shallowEqual) || {};
   const { nativeTokenBalance } = useAccountBalance();
+
+  const numPositions = useSelector(getExistingOpenPositions)?.length || 0;
+  const numOrders = useSelector(getSubaccountUnclearedOrders)?.length || 0;
 
   const usdcBalance = freeCollateral?.current || 0;
 
@@ -119,13 +123,27 @@ export default () => {
                     {
                       value: PortfolioRoute.Positions,
                       slotBefore: <Styled.Icon iconName={IconName.Positions} />,
-                      label: stringGetter({ key: STRING_KEYS.POSITIONS }),
+                      label: (
+                        <>
+                          {stringGetter({ key: STRING_KEYS.POSITIONS })}
+                          {numPositions > 0 && (
+                            <Tag type={TagType.Number}> {numPositions} </Tag>
+                          )}
+                        </>
+                      ),
                       href: PortfolioRoute.Positions,
                     },
                     {
                       value: PortfolioRoute.Orders,
                       slotBefore: <Styled.Icon iconName={IconName.OrderPending} />,
-                      label: stringGetter({ key: STRING_KEYS.ORDERS }),
+                      label: (
+                        <>
+                          {stringGetter({ key: STRING_KEYS.ORDERS })}
+                          {numOrders > 0 && (
+                            <Tag type={TagType.Number}> {numOrders} </Tag>
+                          )}
+                        </>
+                      ),
                       href: PortfolioRoute.Orders,
                     },
                     {

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -20,8 +20,10 @@ import { NavigationMenu } from '@/components/NavigationMenu';
 import { Tag, TagType } from '@/components/Tag';
 import { WithSidebar } from '@/components/WithSidebar';
 
-import { getNumExistingOpenPositions, getNumSubaccountUnclearedOrders, getOnboardingState, getSubaccount } from '@/state/accountSelectors';
+import { getOnboardingState, getSubaccount, getTradeInfoNumbers } from '@/state/accountSelectors';
 import { openDialog } from '@/state/dialogs';
+
+import { shortenNumberForDisplay } from '@/lib/numbers';
 
 import { PortfolioNavMobile } from './PortfolioNavMobile';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
@@ -43,8 +45,9 @@ export default () => {
   const { freeCollateral } = useSelector(getSubaccount, shallowEqual) || {};
   const { nativeTokenBalance } = useAccountBalance();
 
-  const numPositions = useSelector(getNumExistingOpenPositions);
-  const numOrders = useSelector(getNumSubaccountUnclearedOrders);
+  const { numTotalPositions, numTotalOpenOrders } = useSelector(getTradeInfoNumbers, shallowEqual) || {};
+  const numPositions = shortenNumberForDisplay(numTotalPositions);
+  const numOrders = shortenNumberForDisplay(numTotalOpenOrders);
 
   const usdcBalance = freeCollateral?.current || 0;
 

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -20,7 +20,7 @@ import { NavigationMenu } from '@/components/NavigationMenu';
 import { Tag, TagType } from '@/components/Tag';
 import { WithSidebar } from '@/components/WithSidebar';
 
-import { getExistingOpenPositions, getOnboardingState, getSubaccount, getSubaccountUnclearedOrders } from '@/state/accountSelectors';
+import { getNumExistingOpenPositions, getNumSubaccountUnclearedOrders, getOnboardingState, getSubaccount } from '@/state/accountSelectors';
 import { openDialog } from '@/state/dialogs';
 
 import { PortfolioNavMobile } from './PortfolioNavMobile';
@@ -43,8 +43,8 @@ export default () => {
   const { freeCollateral } = useSelector(getSubaccount, shallowEqual) || {};
   const { nativeTokenBalance } = useAccountBalance();
 
-  const numPositions = useSelector(getExistingOpenPositions)?.length || 0;
-  const numOrders = useSelector(getSubaccountUnclearedOrders)?.length || 0;
+  const numPositions = useSelector(getNumExistingOpenPositions);
+  const numOrders = useSelector(getNumSubaccountUnclearedOrders);
 
   const usdcBalance = freeCollateral?.current || 0;
 

--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -1,10 +1,8 @@
 import { createSelector } from 'reselect';
 
-import { SubaccountPosition } from '@/constants/abacus';
 import { OnboardingState, OnboardingSteps } from '@/constants/account';
 
 import {
-  getExistingOpenPositions,
   getOnboardingGuards,
   getOnboardingState,
   getSubaccountId,
@@ -60,13 +58,8 @@ export const calculateIsAccountViewOnly = createSelector(
 );
 
 /**
- * @description calculate whether the subaccount has open positions
+ * @description calculate whether the subaccount has uncommitted positions
  */
-export const calculateHasOpenPositions = createSelector(
-  [getExistingOpenPositions],
-  (openPositions?: SubaccountPosition[]) => (openPositions?.length || 0) > 0
-);
-
 export const calculateHasUncommittedOrders = createSelector(
   [getUncommittedOrderClientIds],
   (uncommittedOrderClientIds: number[]) => uncommittedOrderClientIds.length > 0

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -61,6 +61,15 @@ export const getExistingOpenPositions = createSelector([getOpenPositions], (allO
 
 /**
  * @param state
+ * @returns total number of open positions in a subaccount, excluding the ones in draft, i.e. with NONE position side.
+ */
+export const getNumExistingOpenPositions = createSelector(
+  [getExistingOpenPositions],
+  (positions) => positions?.length || 0
+);
+
+/**
+ * @param state
  * @returns AccountPositions of the current market
  */
 export const getCurrentMarketPositionData = (state: RootState) => {
@@ -97,6 +106,15 @@ export const getSubaccountClearedOrderIds = (state: RootState) => state.account.
 export const getSubaccountUnclearedOrders = createSelector(
   [getSubaccountOrders, getSubaccountClearedOrderIds],
   (orders, clearedOrderIds) => orders?.filter((order) => !clearedOrderIds?.includes(order.id))
+);
+
+/**
+ * @param state
+ * @returns total number of orders that user has not cleared and should be displayed
+ */
+export const getNumSubaccountUnclearedOrders = createSelector(
+  [getSubaccountUnclearedOrders],
+  (orders) => orders?.length || 0
 );
 
 /**

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -2,6 +2,7 @@ import { OrderSide } from '@dydxprotocol/v4-client-js';
 import { createSelector } from 'reselect';
 
 import {
+  type AbacusOrderStatuses,
   type SubaccountOrder,
   type SubaccountFill,
   type SubaccountFundingPayment,
@@ -43,7 +44,6 @@ export const getSubaccountBuyingPower = (state: RootState) => state.account.suba
 export const getSubaccountEquity = (state: RootState) => state.account.subaccount?.equity;
 
 export const getSubaccountHistoricalPnl = (state: RootState) => state.account?.historicalPnl;
-
 /**
  * @param state
  * @returns list of a subaccount's open positions. Each item in the list is an open position in a different market.
@@ -57,15 +57,6 @@ export const getOpenPositions = (state: RootState) =>
  */
 export const getExistingOpenPositions = createSelector([getOpenPositions], (allOpenPositions) =>
   allOpenPositions?.filter((position) => position.side.current !== AbacusPositionSide.NONE)
-);
-
-/**
- * @param state
- * @returns total number of open positions in a subaccount, excluding the ones in draft, i.e. with NONE position side.
- */
-export const getNumExistingOpenPositions = createSelector(
-  [getExistingOpenPositions],
-  (positions) => positions?.length || 0
 );
 
 /**
@@ -106,15 +97,6 @@ export const getSubaccountClearedOrderIds = (state: RootState) => state.account.
 export const getSubaccountUnclearedOrders = createSelector(
   [getSubaccountOrders, getSubaccountClearedOrderIds],
   (orders, clearedOrderIds) => orders?.filter((order) => !clearedOrderIds?.includes(order.id))
-);
-
-/**
- * @param state
- * @returns total number of orders that user has not cleared and should be displayed
- */
-export const getNumSubaccountUnclearedOrders = createSelector(
-  [getSubaccountUnclearedOrders],
-  (orders) => orders?.length || 0
 );
 
 /**
@@ -278,14 +260,21 @@ export const getCurrentMarketFundingPayments = createSelector(
 
 /**
  * @param state
+ * @returns boolean on whether an order status is considered open
+ */
+const isOpenOrderStatus = (status: AbacusOrderStatuses) => {
+  return status !== AbacusOrderStatus.filled && status !== AbacusOrderStatus.cancelled;
+};
+
+/**
+ * @param state
  * @returns Total numbers of the subaccount's open positions, open orders and fills
  */
 export const getTradeInfoNumbers = createSelector(
   [getExistingOpenPositions, getSubaccountOrders, getSubaccountFills, getSubaccountFundingPayments],
   (positions, orders, fills, fundingPayments) => ({
     numTotalPositions: positions?.length,
-    numTotalOpenOrders: orders?.filter((order) => order.status !== AbacusOrderStatus.cancelled)
-      .length,
+    numTotalOpenOrders: orders?.filter((order) => isOpenOrderStatus(order.status)).length,
     numTotalFills: fills?.length,
     numTotalFundingPayments: fundingPayments?.length,
   })
@@ -299,8 +288,7 @@ export const getCurrentMarketTradeInfoNumbers = createSelector(
   [getCurrentMarketOrders, getCurrentMarketFills, getCurrentMarketFundingPayments],
   (marketOrders, marketFills, marketFundingPayments) => {
     return {
-      numOpenOrders: marketOrders?.filter((order) => order.status !== AbacusOrderStatus.cancelled)
-        .length,
+      numOpenOrders: marketOrders?.filter((order) => isOpenOrderStatus(order.status)).length,
       numFills: marketFills?.length,
       numFundingPayments: marketFundingPayments?.length,
     };


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

| No open positions/orders  | With open positions/orders |
| ------------- | ------------- |
| <img width="1493" alt="Screenshot 2024-01-12 at 10 56 02 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/a0211be5-b478-42c0-9a64-bac0dcec7ecf"> | <img width="1263" alt="Screenshot 2024-01-12 at 10 41 25 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/037211f1-e195-40b1-82b8-c8bbc5735324"> |

<!-- Overall purpose of the PR -->

Display the number of open positions/orders in portfolio sidebar when they exist (non-zero). 

---

<!-- Reorder/delete the following sections accordingly: -->

## Views
N/A

## Components

* `<Portfolio>`
  * Update Positions and Orders labels to optionally render a tag showing num of open positions and orders when non zero
    * Matched selector + display logic to what is used in `HorizontalPanel` 
## Styles/Mixins
None needed.

## Constants/Types
N/A

## Functions
N/A

## Hooks
N/A

## State
* `state/accountSelectors.ts`
  *  Updated hooks: `getTradeInfoNumbers` and `getCurrentMarketTradeInfoNumbers` to reflect that both filled and cancelled orders should not be included in "open orders"
 * `state/accountCalculators.ts`
   * Removed unused `calculateHasOpenPositions`
 
## Packages
N/A

## Workflows
N/A

## Edge Cases
* Confirmed with yi that we don't need to implement anything for the mobile/small screen view yet 
* Confirmed with yi that we don't need to highlight the tags (if there are "unviewed orders")
* Confirmed with yi that both "cancelled" and "filled" orders should not be reflected in the open order number tags 

---

Verified numbers match the values shown in the horizontal pane on the trade page.

|  | Horizontal Panel | Portfolios Sidebar |
| ------------- | ------------- | ------------- |
| Cancelled Order should not reflect in open order total | <img width="1258" alt="Screenshot 2024-01-12 at 10 42 26 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/8915c218-5922-43f2-a0e1-4034b35b54e8"> | <img width="1258" alt="Screenshot 2024-01-12 at 10 42 13 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/2322f357-497f-4a52-812c-f785ca518468"> |
| Filled Order should not reflect in open order total | <img width="933" alt="Screenshot 2024-01-12 at 10 58 43 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/c0150241-f01a-4a91-b160-b863e0635027"> | <img width="1549" alt="Screenshot 2024-01-12 at 10 58 36 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/40754d6f-75bc-4b29-875b-23e6c28467b0"> |
