### PR TITLE
Configs: Change iOS app scheme to dydx-t-v4

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -1,7 +1,7 @@
 {
    "apps": {
       "ios": {
-         "scheme": "dydx_t_v4"
+         "scheme": "dydx-t-v4"
       }
    },
    "deployments": {


### PR DESCRIPTION
Can't have underscores in the scheme:

```

Scheme names consist of a sequence of characters beginning with a
   letter and followed by any combination of letters, digits, plus
   ("+"), period ("."), or hyphen ("-").
```

https://www.rfc-editor.org/rfc/rfc3986#page-17