### PR TITLE
Added a TestFlight deployment so help native app testers

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -11,6 +11,13 @@
          ],
          "default": "dydxprotocol-mainnet"
       },
+      "TESTFLIGHT": {
+         "environments": [
+            "dydxprotocol-mainnet",
+            "dydxprotocol-testnet"
+         ],
+         "default": "dydxprotocol-mainnet"
+      },
       "TESTNET": {
          "environments": [
             "dydxprotocol-testnet"


### PR DESCRIPTION
<!-- Overall purpose of the PR -->

For native apps, we need a special deployment for testers of deployer's app. They would have access to deployer's mainnet, and regular testnet
