### PR TITLE
Add historical trading rewards gated by feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.3.2",
+    "@dydxprotocol/v4-abacus": "^1.3.4",
     "@dydxprotocol/v4-client-js": "^1.0.20",
     "@dydxprotocol/v4-localization": "^1.1.22",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.3.4",
+    "@dydxprotocol/v4-abacus": "^1.4.0",
     "@dydxprotocol/v4-client-js": "^1.0.20",
     "@dydxprotocol/v4-localization": "^1.1.22",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,22 +13,22 @@ dependencies:
     version: 1.10.0
   '@cosmjs/amino':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@cosmjs/crypto':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@cosmjs/encoding':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@cosmjs/proto-signing':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@cosmjs/stargate':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@cosmjs/tendermint-rpc':
     specifier: ^0.32.1
-    version: 0.32.1
+    version: 0.32.2
   '@dydxprotocol/v4-abacus':
     specifier: ^1.3.4
     version: 1.3.4
@@ -382,7 +382,7 @@ packages:
   /@0xsquid/sdk@1.10.0:
     resolution: {integrity: sha512-NKxHYB+g/TMPY+XmCHs+LuhyfbhH4KvAbGpVBOBPXM9Q5FsKcKrDJpTd5YnGYCLF9B3qXAzVTR0XhiC73GmOOA==}
     dependencies:
-      '@cosmjs/encoding': 0.31.1
+      '@cosmjs/encoding': 0.31.0
       '@cosmjs/stargate': 0.31.0
       axios: 0.27.2
       cosmjs-types: 0.8.0
@@ -689,16 +689,16 @@ packages:
     resolution: {integrity: sha512-xJ5CCEK7H79FTpOuEmlpSzVI+ZeYESTVvO3wHDgbnceIyAne3C68SvyaKqLUR4uJB0Z4q4+DZHbqW6itUiv4lA==}
     dependencies:
       '@cosmjs/crypto': 0.31.0
-      '@cosmjs/encoding': 0.31.1
-      '@cosmjs/math': 0.31.1
-      '@cosmjs/utils': 0.31.1
+      '@cosmjs/encoding': 0.31.0
+      '@cosmjs/math': 0.31.0
+      '@cosmjs/utils': 0.31.0
     dev: false
 
-  /@cosmjs/amino@0.32.1:
-    resolution: {integrity: sha512-5l2xQ2XuAhV/B3kTIMPBcVZ/OQ+9Yyddzw/lIVs4qE5e/oBI0PVNWXw1oyR0wgfGHrMUxgKjsoOOqE2IbXVyCw==}
+  /@cosmjs/amino@0.32.2:
+    resolution: {integrity: sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==}
     dependencies:
-      '@cosmjs/crypto': 0.32.1
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/crypto': 0.32.2
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/math': 0.32.2
       '@cosmjs/utils': 0.32.2
     dev: false
@@ -753,19 +753,19 @@ packages:
   /@cosmjs/crypto@0.31.0:
     resolution: {integrity: sha512-UaqCe6Tgh0pe1QlZ66E13t6FlIF86QrnBXXq+EN7Xe1Rouza3fJ1ojGlPleJZkBoq3tAyYVIOOqdZIxtVj/sIQ==}
     dependencies:
-      '@cosmjs/encoding': 0.31.1
-      '@cosmjs/math': 0.31.1
-      '@cosmjs/utils': 0.31.1
+      '@cosmjs/encoding': 0.31.0
+      '@cosmjs/math': 0.31.0
+      '@cosmjs/utils': 0.31.0
       '@noble/hashes': 1.3.3
       bn.js: 5.2.1
       elliptic: 6.5.4
       libsodium-wrappers-sumo: 0.7.11
     dev: false
 
-  /@cosmjs/crypto@0.32.1:
-    resolution: {integrity: sha512-AsKucEg5o8evU0wXF/lDwX+ZSwCKF4bbc57nFzraHywlp3sNu4dfPPURoMrT0r7kT7wQZAy4Pdnvmm9nnCCm/Q==}
+  /@cosmjs/crypto@0.32.2:
+    resolution: {integrity: sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==}
     dependencies:
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/math': 0.32.2
       '@cosmjs/utils': 0.32.2
       '@noble/hashes': 1.3.3
@@ -790,16 +790,16 @@ packages:
       readonly-date: 1.0.0
     dev: false
 
-  /@cosmjs/encoding@0.31.1:
-    resolution: {integrity: sha512-IuxP6ewwX6vg9sUJ8ocJD92pkerI4lyG8J5ynAM3NaX3q+n+uMoPRSQXNeL9bnlrv01FF1kIm8if/f5F7ZPtkA==}
+  /@cosmjs/encoding@0.31.0:
+    resolution: {integrity: sha512-NYGQDRxT7MIRSlcbAezwxK0FqnaSPKCH7O32cmfpHNWorFxhy9lwmBoCvoe59Kd0HmArI4h+NGzLEfX3OLnA4Q==}
     dependencies:
       base64-js: 1.5.1
       bech32: 1.1.4
       readonly-date: 1.0.0
     dev: false
 
-  /@cosmjs/encoding@0.32.1:
-    resolution: {integrity: sha512-x60Lfds+Eq42rVV29NaoIAson3kBhATBI3zPp7X3GJTryBc5HFHQ6L/976tE1WB2DrvkfUdWS3ayCMVOY/qm1g==}
+  /@cosmjs/encoding@0.32.2:
+    resolution: {integrity: sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==}
     dependencies:
       base64-js: 1.5.1
       bech32: 1.1.4
@@ -859,12 +859,6 @@ packages:
       bn.js: 5.2.1
     dev: false
 
-  /@cosmjs/math@0.31.1:
-    resolution: {integrity: sha512-kiuHV6m6DSB8/4UV1qpFhlc4ul8SgLXTGRlYkYiIIP4l0YNeJ+OpPYaOlEgx4Unk2mW3/O2FWYj7Jc93+BWXng==}
-    dependencies:
-      bn.js: 5.2.1
-    dev: false
-
   /@cosmjs/math@0.32.2:
     resolution: {integrity: sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==}
     dependencies:
@@ -888,19 +882,19 @@ packages:
     dependencies:
       '@cosmjs/amino': 0.31.0
       '@cosmjs/crypto': 0.31.0
-      '@cosmjs/encoding': 0.31.1
-      '@cosmjs/math': 0.31.1
-      '@cosmjs/utils': 0.31.1
+      '@cosmjs/encoding': 0.31.0
+      '@cosmjs/math': 0.31.0
+      '@cosmjs/utils': 0.31.0
       cosmjs-types: 0.8.0
       long: 4.0.0
     dev: false
 
-  /@cosmjs/proto-signing@0.32.1:
-    resolution: {integrity: sha512-IHJMXQ8XnfzR5K1hWb8VV/jEfJof6BL2mgGIA7X4hSPegwoVfb9hnFKPEPgFjGCTTvGZ8SfnCdXxpsOjianVIA==}
+  /@cosmjs/proto-signing@0.32.2:
+    resolution: {integrity: sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==}
     dependencies:
-      '@cosmjs/amino': 0.32.1
-      '@cosmjs/crypto': 0.32.1
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/amino': 0.32.2
+      '@cosmjs/crypto': 0.32.2
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/math': 0.32.2
       '@cosmjs/utils': 0.32.2
       cosmjs-types: 0.9.0
@@ -968,7 +962,7 @@ packages:
     dependencies:
       '@confio/ics23': 0.6.8
       '@cosmjs/amino': 0.31.0
-      '@cosmjs/encoding': 0.31.1
+      '@cosmjs/encoding': 0.31.0
       '@cosmjs/math': 0.31.0
       '@cosmjs/proto-signing': 0.31.0
       '@cosmjs/stream': 0.31.0
@@ -984,16 +978,16 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@cosmjs/stargate@0.32.1:
-    resolution: {integrity: sha512-S0E1qKQ2CMJU79G8bQTquTyrbU03gFsvCkbo3RvK8v2OltVCByjFNh+0nGN5do+uDOzwwmDvnNLhR+SaIyNQoQ==}
+  /@cosmjs/stargate@0.32.2:
+    resolution: {integrity: sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==}
     dependencies:
       '@confio/ics23': 0.6.8
-      '@cosmjs/amino': 0.32.1
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/amino': 0.32.2
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/math': 0.32.2
-      '@cosmjs/proto-signing': 0.32.1
+      '@cosmjs/proto-signing': 0.32.2
       '@cosmjs/stream': 0.32.2
-      '@cosmjs/tendermint-rpc': 0.32.1
+      '@cosmjs/tendermint-rpc': 0.32.2
       '@cosmjs/utils': 0.32.2
       cosmjs-types: 0.9.0
       xstream: 11.14.0
@@ -1044,12 +1038,12 @@ packages:
     resolution: {integrity: sha512-yo9xbeuI6UoEKIhFZ9g0dvUKLqnBzwdpEc/uldQygQc51j38gQVwFko+6sjmhieJqRYYvrYumcbJMiV6GFM9aA==}
     dependencies:
       '@cosmjs/crypto': 0.31.0
-      '@cosmjs/encoding': 0.31.1
+      '@cosmjs/encoding': 0.31.0
       '@cosmjs/json-rpc': 0.31.0
-      '@cosmjs/math': 0.31.1
+      '@cosmjs/math': 0.31.0
       '@cosmjs/socket': 0.31.0
       '@cosmjs/stream': 0.31.0
-      '@cosmjs/utils': 0.31.1
+      '@cosmjs/utils': 0.31.0
       axios: 0.21.4
       readonly-date: 1.0.0
       xstream: 11.14.0
@@ -1059,11 +1053,11 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@cosmjs/tendermint-rpc@0.32.1:
-    resolution: {integrity: sha512-4uGSxB2JejWhwBUgxca4GqcK/BGnCFMIP7ptwEledrC3AY/shPeIYcPXWEBwO7sfwCta8DhAOCLrc9zhVC+VAQ==}
+  /@cosmjs/tendermint-rpc@0.32.2:
+    resolution: {integrity: sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==}
     dependencies:
-      '@cosmjs/crypto': 0.32.1
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/crypto': 0.32.2
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/json-rpc': 0.32.2
       '@cosmjs/math': 0.32.2
       '@cosmjs/socket': 0.32.2
@@ -1090,10 +1084,6 @@ packages:
     resolution: {integrity: sha512-nNcycZWUYLNJlrIXgpcgVRqdl6BXjF4YlXdxobQWpW9Tikk61bEGeAFhDYtC0PwHlokCNw0KxWiHGJL4nL7Q5A==}
     dev: false
 
-  /@cosmjs/utils@0.31.1:
-    resolution: {integrity: sha512-n4Se1wu4GnKwztQHNFfJvUeWcpvx3o8cWhSbNs9JQShEuB3nv3R5lqFBtDCgHZF/emFQAP+ZjF8bTfCs9UBGhA==}
-    dev: false
-
   /@cosmjs/utils@0.32.2:
     resolution: {integrity: sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q==}
     dev: false
@@ -1109,22 +1099,22 @@ packages:
   /@dydxprotocol/v4-client-js@1.0.20:
     resolution: {integrity: sha512-dXKW2NC1XlVVIRKvHWVDofLZSCPTJAaRY5eXzxH5CcXpnl2kdXorr7ykqWZxW0jHFPWWvRSJtUDqZN1qFrEe/w==}
     dependencies:
-      '@cosmjs/amino': 0.32.1
-      '@cosmjs/encoding': 0.32.1
+      '@cosmjs/amino': 0.32.2
+      '@cosmjs/encoding': 0.32.2
       '@cosmjs/math': 0.32.2
-      '@cosmjs/proto-signing': 0.32.1
-      '@cosmjs/stargate': 0.32.1
-      '@cosmjs/tendermint-rpc': 0.32.1
+      '@cosmjs/proto-signing': 0.32.2
+      '@cosmjs/stargate': 0.32.2
+      '@cosmjs/tendermint-rpc': 0.32.2
       '@cosmjs/utils': 0.32.2
       '@dydxprotocol/v4-proto': 4.0.0-dev.0
       '@osmonauts/lcd': 0.6.0
-      '@scure/bip32': 1.3.3
-      '@scure/bip39': 1.2.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
       axios: 1.1.3
       bech32: 1.1.4
       bignumber.js: 9.1.1
       cosmjs-types: 0.9.0
-      ethereum-cryptography: 2.1.3
+      ethereum-cryptography: 2.1.2
       ethers: 6.6.1
       long: 4.0.0
       protobufjs: 6.11.4
@@ -2158,16 +2148,16 @@ packages:
       '@noble/hashes': 1.3.0
     dev: false
 
+  /@noble/curves@1.1.0:
+    resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
+    dependencies:
+      '@noble/hashes': 1.3.1
+    dev: false
+
   /@noble/curves@1.2.0:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
     dependencies:
       '@noble/hashes': 1.3.2
-    dev: false
-
-  /@noble/curves@1.3.0:
-    resolution: {integrity: sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==}
-    dependencies:
-      '@noble/hashes': 1.3.3
     dev: false
 
   /@noble/ed25519@1.7.3:
@@ -5035,18 +5025,18 @@ packages:
       '@scure/base': 1.1.1
     dev: false
 
-  /@scure/bip32@1.3.2:
-    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
+  /@scure/bip32@1.3.1:
+    resolution: {integrity: sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==}
     dependencies:
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: false
 
-  /@scure/bip32@1.3.3:
-    resolution: {integrity: sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==}
+  /@scure/bip32@1.3.2:
+    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
     dependencies:
-      '@noble/curves': 1.3.0
+      '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: false
@@ -5065,13 +5055,6 @@ packages:
       '@scure/base': 1.1.5
     dev: false
 
-  /@scure/bip39@1.2.2:
-    resolution: {integrity: sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==}
-    dependencies:
-      '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.5
-    dev: false
-
   /@solana/buffer-layout@4.0.1:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
@@ -5083,7 +5066,7 @@ packages:
     resolution: {integrity: sha512-up5VG1dK+GPhykmuMIozJZBbVqpm77vbOG6/r5dS7NBGZonwHfTLdBbsYc3rjmaQ4DpCXUa3tUc4RZHRORvZrw==}
     dependencies:
       '@babel/runtime': 7.22.10
-      '@noble/curves': 1.3.0
+      '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.3
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.5.0
@@ -9307,13 +9290,13 @@ packages:
       fast-safe-stringify: 2.1.1
     dev: false
 
-  /ethereum-cryptography@2.1.3:
-    resolution: {integrity: sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==}
+  /ethereum-cryptography@2.1.2:
+    resolution: {integrity: sha512-Z5Ba0T0ImZ8fqXrJbpHcbpAvIswRte2wGNR/KePnu8GbbvgJ47lMxT/ZZPG6i9Jaht4azPDop4HaM00J0J59ug==}
     dependencies:
-      '@noble/curves': 1.3.0
-      '@noble/hashes': 1.3.3
-      '@scure/bip32': 1.3.3
-      '@scure/bip39': 1.2.2
+      '@noble/curves': 1.1.0
+      '@noble/hashes': 1.3.1
+      '@scure/bip32': 1.3.1
+      '@scure/bip39': 1.2.1
     dev: false
 
   /ethers@5.7.2:
@@ -14935,6 +14918,3 @@ packages:
     dev: true
 
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.1
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.3.2
-    version: 1.3.2
+    specifier: ^1.3.4
+    version: 1.3.4
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.20
     version: 1.0.20
@@ -1102,8 +1102,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.3.2:
-    resolution: {integrity: sha512-zo0IHjGMlJRKOYDgNqNFQ9GtBJKJP4+Y9YY7V0X3Wt61ppKAYzodaYQhc9V/RYchcZTtS/xkicLug444YrvehQ==}
+  /@dydxprotocol/v4-abacus@1.3.4:
+    resolution: {integrity: sha512-6P61ZEMFqDit5G1+1yQSrDQWT51ap1jqF+ba/oaSg30CMUuhD2+1z6lDtUZbPw5+TjE4f7UyN/LYBTwylSiobA==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.20:
@@ -14933,3 +14933,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   follow-redirects: 1.15.3
 
@@ -30,8 +26,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.3.4
-    version: 1.3.4
+    specifier: ^1.4.0
+    version: 1.4.0
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.20
     version: 1.0.20
@@ -1092,8 +1088,8 @@ packages:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.3.4:
-    resolution: {integrity: sha512-6P61ZEMFqDit5G1+1yQSrDQWT51ap1jqF+ba/oaSg30CMUuhD2+1z6lDtUZbPw5+TjE4f7UyN/LYBTwylSiobA==}
+  /@dydxprotocol/v4-abacus@1.4.0:
+    resolution: {integrity: sha512-mkdkXQXTVF1K6UmZwIwLC9gjsXg+Nt3h5/iW+WriVv1cUMPmHfPyRWL31eDDvkVO5UeECf05kiYXPk1y+7dPuA==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.20:
@@ -14917,4 +14913,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -65,6 +65,9 @@ type ElementProps = {
     resolution?: number;
     stripRelativeWords?: boolean;
   };
+  timeOptions?: {
+    useUTC?: boolean;
+  };
   tag?: React.ReactNode;
   withParentheses?: boolean;
   locale?: string;
@@ -89,6 +92,7 @@ export const Output = ({
   relativeTimeFormatOptions = {
     format: 'singleCharacter',
   },
+  timeOptions,
   tag,
   withParentheses,
   locale = navigator.language || 'en-US',
@@ -166,16 +170,21 @@ export const Output = ({
       if ((typeof value !== 'string' && typeof value !== 'number') || !value) return null;
       const date = new Date(value);
       const dateString = {
-        [OutputType.Date]: date.toLocaleString(selectedLocale, { dateStyle: 'medium' }),
+        [OutputType.Date]: date.toLocaleString(selectedLocale, {
+          dateStyle: 'medium',
+          timeZone: timeOptions?.useUTC ? 'UTC' : undefined,
+        }),
         [OutputType.DateTime]: date.toLocaleString(selectedLocale, {
           dateStyle: 'short',
           timeStyle: 'short',
+          timeZone: timeOptions?.useUTC ? 'UTC' : undefined,
         }),
         [OutputType.Time]: date.toLocaleString(selectedLocale, {
           hour12: false,
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit',
+          timeZone: timeOptions?.useUTC ? 'UTC' : undefined,
         }),
       }[type];
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -68,7 +68,7 @@ export type TableItem<TableRowData> = {
   onSelect?: (key: TableRowData) => void;
 };
 
-type ColumnDef<TableRowData extends object> = {
+export type ColumnDef<TableRowData extends object> = {
   columnKey: string;
   label: React.ReactNode;
   tag?: React.ReactNode;
@@ -513,7 +513,7 @@ const TableColumnHeader = <TableRowData extends object>({
 export const ViewMoreRow = ({ colSpan, onClick }: { colSpan: number; onClick: () => void }) => {
   const stringGetter = useStringGetter();
   return (
-    <Styled.Tr key="viewmore">
+    <Styled.ViewMoreTr key="viewmore">
       <Styled.Td
         colSpan={colSpan}
         onMouseDown={(e: MouseEvent) => e.preventDefault()}
@@ -523,7 +523,7 @@ export const ViewMoreRow = ({ colSpan, onClick }: { colSpan: number; onClick: ()
           {stringGetter({ key: STRING_KEYS.VIEW_MORE })}
         </Styled.ViewMoreButton>
       </Styled.Td>
-    </Styled.Tr>
+    </Styled.ViewMoreTr>
   );
 };
 
@@ -672,6 +672,8 @@ Styled.TableWrapper = styled.div<{
   --table-firstColumn-cell-align: start; // start | center | end | var(--table-cell-align)
   --table-lastColumn-cell-align: end; // start | center | end | var(--table-cell-align)
   --tableCell-padding: 0 1rem;
+
+  --tableViewMore-borderColor: inherit;
 
   // Rules
 
@@ -983,4 +985,8 @@ Styled.ViewMoreButton = styled(Button)`
     width: 0.675rem;
     margin-left: 0.5ch;
   }
+`;
+
+Styled.ViewMoreTr = styled(Styled.Tr)`
+  --border-color: var(--tableViewMore-borderColor);
 `;

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -209,6 +209,9 @@ export const RestrictionType = Abacus.exchange.dydx.abacus.output.Restriction;
 const restrictionTypes = [...RestrictionType.values()] as const;
 export type RestrictionTypes = (typeof restrictionTypes)[number];
 
+// ------ Api data ------ //
+export const ApiData = Abacus.exchange.dydx.abacus.state.manager.ApiData;
+
 // ------ Enum Conversions ------ //
 type IfEquals<X, Y, A, B> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
   ? A

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -119,6 +119,13 @@ export const InputSelectionOption = Abacus.exchange.dydx.abacus.output.input.Sel
 // ------ Wallet ------ //
 export type Wallet = Abacus.exchange.dydx.abacus.output.Wallet;
 export type AccountBalance = Abacus.exchange.dydx.abacus.output.AccountBalance;
+export type TradingRewards = Abacus.exchange.dydx.abacus.output.TradingRewards;
+export type HistoricalTradingReward = Abacus.exchange.dydx.abacus.output.HistoricalTradingReward;
+export const HistoricaTradingRewardsPeriod =
+  Abacus.exchange.dydx.abacus.state.manager.HistoricaTradingRewardsPeriod;
+const historicalTradingRewardsPeriod = [...HistoricaTradingRewardsPeriod.values()] as const;
+export type HistoricaTradingRewardsPeriods = (typeof historicalTradingRewardsPeriod)[number];
+
 export type Subaccount = Abacus.exchange.dydx.abacus.output.Subaccount;
 export type SubaccountPosition = Abacus.exchange.dydx.abacus.output.SubaccountPosition;
 export type SubaccountOrder = Abacus.exchange.dydx.abacus.output.SubaccountOrder;
@@ -234,6 +241,15 @@ export const HISTORICAL_PNL_PERIODS: Record<
   [HistoricalPnlPeriod.Period7d.name]: HistoricalPnlPeriod.Period7d,
   [HistoricalPnlPeriod.Period30d.name]: HistoricalPnlPeriod.Period30d,
   [HistoricalPnlPeriod.Period90d.name]: HistoricalPnlPeriod.Period90d,
+};
+
+export const HISTORICAL_TRADING_REWARDS_PERIODS: Record<
+  KotlinIrEnumValues<typeof HistoricaTradingRewardsPeriod>,
+  HistoricaTradingRewardsPeriods
+> = {
+  [HistoricaTradingRewardsPeriod.MONTHLY.name]: HistoricaTradingRewardsPeriod.MONTHLY,
+  [HistoricaTradingRewardsPeriod.WEEKLY.name]: HistoricaTradingRewardsPeriod.WEEKLY,
+  [HistoricaTradingRewardsPeriod.DAILY.name]: HistoricaTradingRewardsPeriod.DAILY,
 };
 
 export const ORDER_STATUS_STRINGS: Record<KotlinIrEnumValues<typeof AbacusOrderStatus>, string> = {

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -121,10 +121,10 @@ export type Wallet = Abacus.exchange.dydx.abacus.output.Wallet;
 export type AccountBalance = Abacus.exchange.dydx.abacus.output.AccountBalance;
 export type TradingRewards = Abacus.exchange.dydx.abacus.output.TradingRewards;
 export type HistoricalTradingReward = Abacus.exchange.dydx.abacus.output.HistoricalTradingReward;
-export const HistoricaTradingRewardsPeriod =
-  Abacus.exchange.dydx.abacus.state.manager.HistoricaTradingRewardsPeriod;
-const historicalTradingRewardsPeriod = [...HistoricaTradingRewardsPeriod.values()] as const;
-export type HistoricaTradingRewardsPeriods = (typeof historicalTradingRewardsPeriod)[number];
+export const HistoricalTradingRewardsPeriod =
+  Abacus.exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod;
+const historicalTradingRewardsPeriod = [...HistoricalTradingRewardsPeriod.values()] as const;
+export type HistoricalTradingRewardsPeriods = (typeof historicalTradingRewardsPeriod)[number];
 
 export type Subaccount = Abacus.exchange.dydx.abacus.output.Subaccount;
 export type SubaccountPosition = Abacus.exchange.dydx.abacus.output.SubaccountPosition;
@@ -244,12 +244,12 @@ export const HISTORICAL_PNL_PERIODS: Record<
 };
 
 export const HISTORICAL_TRADING_REWARDS_PERIODS: Record<
-  KotlinIrEnumValues<typeof HistoricaTradingRewardsPeriod>,
-  HistoricaTradingRewardsPeriods
+  KotlinIrEnumValues<typeof HistoricalTradingRewardsPeriod>,
+  HistoricalTradingRewardsPeriods
 > = {
-  [HistoricaTradingRewardsPeriod.MONTHLY.name]: HistoricaTradingRewardsPeriod.MONTHLY,
-  [HistoricaTradingRewardsPeriod.WEEKLY.name]: HistoricaTradingRewardsPeriod.WEEKLY,
-  [HistoricaTradingRewardsPeriod.DAILY.name]: HistoricaTradingRewardsPeriod.DAILY,
+  [HistoricalTradingRewardsPeriod.MONTHLY.name]: HistoricalTradingRewardsPeriod.MONTHLY,
+  [HistoricalTradingRewardsPeriod.WEEKLY.name]: HistoricalTradingRewardsPeriod.WEEKLY,
+  [HistoricalTradingRewardsPeriod.DAILY.name]: HistoricalTradingRewardsPeriod.DAILY,
 };
 
 export const ORDER_STATUS_STRINGS: Record<KotlinIrEnumValues<typeof AbacusOrderStatus>, string> = {

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -95,8 +95,8 @@ export type TooltipStrings = {
     stringParams?: any;
     urlConfigs?: LinksConfigs;
   }) => {
-    title: string;
-    body: string;
+    title?: string;
+    body?: string;
     learnMoreLink?: string;
   };
 };

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -96,7 +96,7 @@ export type TooltipStrings = {
     urlConfigs?: LinksConfigs;
   }) => {
     title?: string;
-    body?: string;
+    body: string;
     learnMoreLink?: string;
   };
 };

--- a/src/constants/tooltips/trade.ts
+++ b/src/constants/tooltips/trade.ts
@@ -198,4 +198,7 @@ export const tradeTooltips: TooltipStrings = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.UNREALIZED_PNL_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.UNREALIZED_PNL_BODY }),
   }),
+  'reward-history': ({ stringGetter }) => ({
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.REWARD_HISTORY_BODY }),
+  }),
 } as const;

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -3,15 +3,14 @@ import type { LocalWallet } from '@dydxprotocol/v4-client-js';
 import type {
   ClosePositionInputFields,
   Nullable,
+  HistoricaTradingRewardsPeriod,
+  HistoricaTradingRewardsPeriods,
   HumanReadablePlaceOrderPayload,
   HumanReadableCancelOrderPayload,
   TradeInputFields,
   TransferInputFields,
   HistoricalPnlPeriods,
   ParsingError,
-  HistoricaTradingRewardsPeriods,
-  HistoricaTradingRewardsPeriod,
-  HistoricalTradingReward,
 } from '@/constants/abacus';
 
 import {
@@ -35,8 +34,6 @@ import { CLEARED_SIZE_INPUTS, CLEARED_TRADE_INPUTS } from '@/constants/trade';
 import type { RootStore } from '@/state/_store';
 import { setTradeFormInputs } from '@/state/inputs';
 import { getInputTradeOptions, getTransferInputs } from '@/state/inputsSelectors';
-
-import { testFlags } from '@/lib/testFlags';
 
 import AbacusRest from './rest';
 import AbacusAnalytics from './analytics';

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -25,6 +25,7 @@ import {
   CoroutineTimer,
   TransferType,
   AbacusAppConfig,
+  ApiData,
 } from '@/constants/abacus';
 
 import { DEFAULT_MARKETID } from '@/constants/markets';
@@ -232,6 +233,9 @@ class AbacusStateManager {
   ) => {
     this.stateManager.historicalTradingRewardPeriod = period;
   };
+
+  refreshHistoricalTradingRewards = () =>
+    this.stateManager.refresh(ApiData.HISTORICAL_TRADING_REWARDS);
 
   switchNetwork = (network: DydxNetwork) => {
     this.stateManager.environmentId = network;

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -9,6 +9,9 @@ import type {
   TransferInputFields,
   HistoricalPnlPeriods,
   ParsingError,
+  HistoricaTradingRewardsPeriods,
+  HistoricaTradingRewardsPeriod,
+  HistoricalTradingReward,
 } from '@/constants/abacus';
 
 import {
@@ -227,6 +230,12 @@ class AbacusStateManager {
     this.stateManager.historicalPnlPeriod = period;
   };
 
+  setHistoricalTradingRewardPeriod = (
+    period: (typeof HistoricaTradingRewardsPeriod)[keyof typeof HistoricaTradingRewardsPeriod]
+  ) => {
+    this.stateManager.historicalTradingRewardPeriod = period;
+  };
+
   switchNetwork = (network: DydxNetwork) => {
     this.stateManager.environmentId = network;
 
@@ -277,6 +286,9 @@ class AbacusStateManager {
   // ------ Utils ------ //
   getHistoricalPnlPeriod = (): Nullable<HistoricalPnlPeriods> =>
     this.stateManager.historicalPnlPeriod;
+
+  getHistoricalTradingRewardPeriod = (): HistoricaTradingRewardsPeriods =>
+    this.stateManager.historicalTradingRewardPeriod;
 
   handleCandlesSubscription = ({
     channelId,

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -3,8 +3,8 @@ import type { LocalWallet } from '@dydxprotocol/v4-client-js';
 import type {
   ClosePositionInputFields,
   Nullable,
-  HistoricaTradingRewardsPeriod,
-  HistoricaTradingRewardsPeriods,
+  HistoricalTradingRewardsPeriod,
+  HistoricalTradingRewardsPeriods,
   HumanReadablePlaceOrderPayload,
   HumanReadableCancelOrderPayload,
   TradeInputFields,
@@ -228,7 +228,7 @@ class AbacusStateManager {
   };
 
   setHistoricalTradingRewardPeriod = (
-    period: (typeof HistoricaTradingRewardsPeriod)[keyof typeof HistoricaTradingRewardsPeriod]
+    period: (typeof HistoricalTradingRewardsPeriod)[keyof typeof HistoricalTradingRewardsPeriod]
   ) => {
     this.stateManager.historicalTradingRewardPeriod = period;
   };
@@ -284,7 +284,7 @@ class AbacusStateManager {
   getHistoricalPnlPeriod = (): Nullable<HistoricalPnlPeriods> =>
     this.stateManager.historicalPnlPeriod;
 
-  getHistoricalTradingRewardPeriod = (): HistoricaTradingRewardsPeriods =>
+  getHistoricalTradingRewardPeriod = (): HistoricalTradingRewardsPeriods =>
     this.stateManager.historicalTradingRewardPeriod;
 
   handleCandlesSubscription = ({

--- a/src/lib/abacus/stateNotification.ts
+++ b/src/lib/abacus/stateNotification.ts
@@ -29,6 +29,7 @@ import {
   setSubaccount,
   setTransfers,
   setWallet,
+  setTradingRewards,
 } from '@/state/account';
 
 import { setApiState } from '@/state/app';
@@ -93,6 +94,12 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
             stakingBalances[k] = v;
           }
           dispatch(setStakingBalances(stakingBalances));
+        }
+      }
+
+      if (changes.has(Changes.tradingRewards)) {
+        if (updatedState.account?.tradingRewards) {
+          dispatch(setTradingRewards(updatedState.account?.tradingRewards));
         }
       }
 

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -26,6 +26,10 @@ class TestFlags {
   get addressOverride():string {
     return this.queryParams.address;
   }
+  
+  get showTradingRewards() {
+    return !!this.queryParams.tradingrewards;
+  }
 }
 
 export const testFlags = new TestFlags();

--- a/src/pages/rewards/DYDXBalancePanel.tsx
+++ b/src/pages/rewards/DYDXBalancePanel.tsx
@@ -22,7 +22,7 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 import { openDialog } from '@/state/dialogs';
 import { calculateCanAccountTrade } from '@/state/accountCalculators';
 
-export const DYDXBalancePanel = () => {
+export const DYDXBalancePanel = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
   const stringGetter = useStringGetter();
 
@@ -33,6 +33,7 @@ export const DYDXBalancePanel = () => {
 
   return (
     <Panel
+      className={className}
       slotHeader={
         <Styled.Header>
           <Styled.Title>

--- a/src/pages/rewards/RewardHistoryPanel.tsx
+++ b/src/pages/rewards/RewardHistoryPanel.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState } from 'react';
+import styled, { AnyStyledComponent } from 'styled-components';
+
+import breakpoints from '@/styles/breakpoints';
+import { layoutMixins } from '@/styles/layoutMixins';
+import { useStringGetter } from '@/hooks';
+
+import {
+  HISTORICAL_TRADING_REWARDS_PERIODS,
+  HistoricaTradingRewardsPeriod,
+  HistoricaTradingRewardsPeriods,
+} from '@/constants/abacus';
+
+import { STRING_KEYS } from '@/constants/localization';
+
+import { Panel } from '@/components/Panel';
+import { ToggleGroup } from '@/components/ToggleGroup';
+import { TradingRewardHistoryTable } from '@/views/tables/TradingRewardHistoryTable';
+
+import abacusStateManager from '@/lib/abacus';
+
+export const RewardHistoryPanel = () => {
+  const stringGetter = useStringGetter();
+
+  const [selectedPeriod, setSelectedPeriod] = useState<HistoricaTradingRewardsPeriods>(
+    abacusStateManager.getHistoricalTradingRewardPeriod() || HistoricaTradingRewardsPeriod.WEEKLY
+  );
+
+  const onSelectPeriod = useCallback(
+    (periodName: string) => {
+      const selectedPeriod =
+        HISTORICAL_TRADING_REWARDS_PERIODS[
+          periodName as keyof typeof HISTORICAL_TRADING_REWARDS_PERIODS
+        ];
+      setSelectedPeriod(selectedPeriod);
+      abacusStateManager.setHistoricalTradingRewardPeriod(selectedPeriod);
+    },
+    [setSelectedPeriod, selectedPeriod]
+  );
+
+  return (
+    <Panel
+      slotHeader={
+        <Styled.Header>
+          <Styled.Title>
+            <h3>{stringGetter({ key: STRING_KEYS.REWARD_HISTORY })}</h3>
+            <span>{stringGetter({ key: STRING_KEYS.REWARD_HISTORY_DESCRIPTION })}</span>
+          </Styled.Title>
+          <ToggleGroup
+            items={[
+              {
+                value: HistoricaTradingRewardsPeriod.MONTHLY.name,
+                label: stringGetter({ key: STRING_KEYS.MONTHLY }),
+              },
+              {
+                value: HistoricaTradingRewardsPeriod.WEEKLY.name,
+                label: stringGetter({ key: STRING_KEYS.WEEKLY }),
+              },
+              {
+                value: HistoricaTradingRewardsPeriod.DAILY.name,
+                label: stringGetter({ key: STRING_KEYS.DAILY }),
+              },
+            ]}
+            value={selectedPeriod.name}
+            onValueChange={onSelectPeriod}
+          />
+        </Styled.Header>
+      }
+    >
+      <TradingRewardHistoryTable period={selectedPeriod} />
+    </Panel>
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Header = styled.div`
+  ${layoutMixins.spacedRow}
+
+  padding: 1rem 1rem 0;
+  margin-bottom: -0.5rem;
+
+  @media ${breakpoints.notTablet} {
+    padding: 1.25rem 1.5rem 0;
+  }
+`;
+
+Styled.Title = styled.div`
+  color: var(--color-text-0);
+  font: var(--font-small-book);
+
+  h3 {
+    font: var(--font-medium-book);
+    color: var(--color-text-2);
+  }
+`;
+
+Styled.Content = styled.div`
+  ${layoutMixins.flexColumn}
+  gap: 0.75rem;
+`;

--- a/src/pages/rewards/RewardHistoryPanel.tsx
+++ b/src/pages/rewards/RewardHistoryPanel.tsx
@@ -18,6 +18,7 @@ import { ToggleGroup } from '@/components/ToggleGroup';
 import { TradingRewardHistoryTable } from '@/views/tables/TradingRewardHistoryTable';
 
 import abacusStateManager from '@/lib/abacus';
+import { WithTooltip } from '@/components/WithTooltip';
 
 export const RewardHistoryPanel = () => {
   const stringGetter = useStringGetter();
@@ -43,7 +44,9 @@ export const RewardHistoryPanel = () => {
       slotHeader={
         <Styled.Header>
           <Styled.Title>
-            <h3>{stringGetter({ key: STRING_KEYS.REWARD_HISTORY })}</h3>
+            <WithTooltip tooltip="reward-history">
+              <h3>{stringGetter({ key: STRING_KEYS.REWARD_HISTORY })}</h3>
+            </WithTooltip>
             <span>{stringGetter({ key: STRING_KEYS.REWARD_HISTORY_DESCRIPTION })}</span>
           </Styled.Title>
           <ToggleGroup
@@ -86,6 +89,7 @@ Styled.Header = styled.div`
 `;
 
 Styled.Title = styled.div`
+  ${layoutMixins.column}
   color: var(--color-text-0);
   font: var(--font-small-book);
 

--- a/src/pages/rewards/RewardHistoryPanel.tsx
+++ b/src/pages/rewards/RewardHistoryPanel.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useState } from 'react';
 import styled, { AnyStyledComponent } from 'styled-components';
 
-import breakpoints from '@/styles/breakpoints';
-import { layoutMixins } from '@/styles/layoutMixins';
 import { useStringGetter } from '@/hooks';
 
 import {
@@ -12,13 +10,15 @@ import {
 } from '@/constants/abacus';
 
 import { STRING_KEYS } from '@/constants/localization';
+import breakpoints from '@/styles/breakpoints';
+import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Panel } from '@/components/Panel';
 import { ToggleGroup } from '@/components/ToggleGroup';
+import { WithTooltip } from '@/components/WithTooltip';
 import { TradingRewardHistoryTable } from '@/views/tables/TradingRewardHistoryTable';
 
 import abacusStateManager from '@/lib/abacus';
-import { WithTooltip } from '@/components/WithTooltip';
 
 export const RewardHistoryPanel = () => {
   const stringGetter = useStringGetter();

--- a/src/pages/rewards/RewardHistoryPanel.tsx
+++ b/src/pages/rewards/RewardHistoryPanel.tsx
@@ -5,8 +5,8 @@ import { useStringGetter } from '@/hooks';
 
 import {
   HISTORICAL_TRADING_REWARDS_PERIODS,
-  HistoricaTradingRewardsPeriod,
-  HistoricaTradingRewardsPeriods,
+  HistoricalTradingRewardsPeriod,
+  HistoricalTradingRewardsPeriods,
 } from '@/constants/abacus';
 
 import { STRING_KEYS } from '@/constants/localization';
@@ -23,8 +23,8 @@ import abacusStateManager from '@/lib/abacus';
 export const RewardHistoryPanel = () => {
   const stringGetter = useStringGetter();
 
-  const [selectedPeriod, setSelectedPeriod] = useState<HistoricaTradingRewardsPeriods>(
-    abacusStateManager.getHistoricalTradingRewardPeriod() || HistoricaTradingRewardsPeriod.WEEKLY
+  const [selectedPeriod, setSelectedPeriod] = useState<HistoricalTradingRewardsPeriods>(
+    abacusStateManager.getHistoricalTradingRewardPeriod() || HistoricalTradingRewardsPeriod.WEEKLY
   );
 
   const onSelectPeriod = useCallback(
@@ -52,15 +52,15 @@ export const RewardHistoryPanel = () => {
           <ToggleGroup
             items={[
               {
-                value: HistoricaTradingRewardsPeriod.MONTHLY.name,
+                value: HistoricalTradingRewardsPeriod.MONTHLY.name,
                 label: stringGetter({ key: STRING_KEYS.MONTHLY }),
               },
               {
-                value: HistoricaTradingRewardsPeriod.WEEKLY.name,
+                value: HistoricalTradingRewardsPeriod.WEEKLY.name,
                 label: stringGetter({ key: STRING_KEYS.WEEKLY }),
               },
               {
-                value: HistoricaTradingRewardsPeriod.DAILY.name,
+                value: HistoricalTradingRewardsPeriod.DAILY.name,
                 label: stringGetter({ key: STRING_KEYS.DAILY }),
               },
             ]}

--- a/src/pages/rewards/RewardsHelpPanel.tsx
+++ b/src/pages/rewards/RewardsHelpPanel.tsx
@@ -29,20 +29,18 @@ export const RewardsHelpPanel = () => {
     >
       <Accordion
         items={[
-          {
-            header: 'Who is eligible for trading rewards?',
-            content: 'All traders are eligible for trading rewards.',
-          },
-          {
-            header: 'How do trading rewards work?',
-            content:
-              'Immediately after each fill, trading rewards are sent directly to the trader’s dYdX Chain address, based on the amount of fees paid by the trader.',
-          },
-          {
-            header: 'How do I claim my rewards?',
-            content:
-              'Each block, trading rewards are automatically sent directly to the trader’s dYdX Chain address.',
-          },
+        {
+          header: stringGetter({ key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_QUESTION }),
+          content: stringGetter({ key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_ANSWER }),
+        },
+        {
+          header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_TRADING_REWARDS_WORK_QUESTION }),
+          content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_TRADING_REWARDS_WORK_ANSWER }),
+        },
+        {
+          header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_QUESTION }),
+          content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_ANSWER }),
+        },
         ]}
       />
     </Styled.HelpCard>
@@ -72,7 +70,7 @@ Styled.Header = styled.div`
   font: var(--font-small-book);
 
   @media ${breakpoints.notTablet} {
-    padding: 1.5rem 1.25rem;
+    padding: 1.5rem;
   }
 
   h3 {

--- a/src/pages/rewards/RewardsPage.tsx
+++ b/src/pages/rewards/RewardsPage.tsx
@@ -23,7 +23,6 @@ import { GovernancePanel } from './GovernancePanel';
 import { StakingPanel } from './StakingPanel';
 import { NewMarketsPanel } from './NewMarketsPanel';
 
-
 const RewardsPage = () => {
   const stringGetter = useStringGetter();
   const { isTablet, isNotTablet } = useBreakpoints();
@@ -58,7 +57,7 @@ const RewardsPage = () => {
         )}
 
         {isNotTablet && (
-          <Styled.OtherColumn>
+          <Styled.OtherColumn showTradingRewards={testFlags.showTradingRewards}>
             <NewMarketsPanel />
             <GovernancePanel />
             <StakingPanel />
@@ -156,9 +155,20 @@ Styled.TradingRewardsColumn = styled.div`
   ${layoutMixins.flexColumn}
 `;
 
-Styled.OtherColumn = styled.div`
+Styled.OtherColumn = styled.div<{ showTradingRewards?: boolean }>`
   grid-area: other;
   ${layoutMixins.flexColumn}
+
+  ${({ showTradingRewards }) =>
+    !showTradingRewards &&
+    css`
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+
+      > section:last-of-type {
+        grid-column: 1 / -1;
+      }
+    `}
 `;
 
 Styled.RewardHistoryHeader = styled.div`

--- a/src/pages/rewards/RewardsPage.tsx
+++ b/src/pages/rewards/RewardsPage.tsx
@@ -36,7 +36,10 @@ const RewardsPage = () => {
           {stringGetter({ key: STRING_KEYS.TRADING_REWARDS })}
         </Styled.MobileHeader>
       )}
-      <Styled.GridLayout showTradingRewards={testFlags.showTradingRewards}>
+      <Styled.GridLayout
+        showTradingRewards={testFlags.showTradingRewards}
+        showMigratePanel={import.meta.env.VITE_V3_TOKEN_ADDRESS && isNotTablet}
+      >
         {import.meta.env.VITE_V3_TOKEN_ADDRESS && isNotTablet && <Styled.MigratePanel />}
 
         {isTablet ? (
@@ -105,7 +108,7 @@ Styled.MobileHeader = styled.header`
   background-color: var(--color-layer-2);
 `;
 
-Styled.GridLayout = styled.div<{ showTradingRewards?: boolean }>`
+Styled.GridLayout = styled.div<{ showTradingRewards?: boolean; showMigratePanel?: boolean }>`
   --gap: 1.5rem;
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -115,26 +118,40 @@ Styled.GridLayout = styled.div<{ showTradingRewards?: boolean }>`
     gap: var(--gap);
   }
 
-  grid-template-areas:
-    'migrate migrate'
-    'incentives balance'
-    'other other';
-
-  ${({ showTradingRewards }) =>
-    showTradingRewards &&
-    css`
-      grid-template-areas:
-        'migrate migrate'
-        'incentives balance'
-        'rewards other';
-    `}
+  ${({ showTradingRewards, showMigratePanel }) =>
+    showTradingRewards && showMigratePanel
+      ? css`
+          grid-template-areas:
+            'migrate migrate'
+            'incentives balance'
+            'rewards other';
+        `
+      : showTradingRewards
+      ? css`
+          grid-template-areas: 'incentives balance' 'rewards other';
+        `
+      : showMigratePanel
+      ? css`
+          grid-template-areas: 'migrate migrate' 'incentives balance' 'other other';
+        `
+      : css`
+          grid-template-areas: 'incentives balance' 'other other';
+        `};
 
   @media ${breakpoints.tablet} {
     --gap: 1rem;
     grid-template-columns: 1fr;
-    grid-template-areas:
-      'incentives'
-      'rewards';
+
+    ${({ showTradingRewards }) =>
+      showTradingRewards
+        ? css`
+            grid-template-areas:
+              'incentives'
+              'rewards';
+          `
+        : css`
+            grid-template-areas: 'incentives';
+          `}
   }
 `;
 

--- a/src/pages/rewards/TradingRewardsSummaryPanel.tsx
+++ b/src/pages/rewards/TradingRewardsSummaryPanel.tsx
@@ -1,0 +1,136 @@
+import styled, { AnyStyledComponent } from 'styled-components';
+import { shallowEqual, useSelector } from 'react-redux';
+
+import { STRING_KEYS } from '@/constants/localization';
+import { layoutMixins } from '@/styles/layoutMixins';
+import { useStringGetter, useTokenConfigs } from '@/hooks';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Details } from '@/components/Details';
+import { Output, OutputType } from '@/components/Output';
+import { Panel } from '@/components/Panel';
+
+import { getHistoricalTradingRewardsForPeriod } from '@/state/accountSelectors';
+
+export const TradingRewardsSummaryPanel = () => {
+  const stringGetter = useStringGetter();
+  const { chainTokenLabel } = useTokenConfigs();
+
+  const currentWeekTradingRewards = useSelector(
+    getHistoricalTradingRewardsForPeriod('WEEKLY'),
+    shallowEqual
+  );
+  const currentWeekTradingReward = currentWeekTradingRewards?.firstOrNull();
+
+  return (
+    currentWeekTradingReward && (
+      <Panel
+        slotHeader={
+          <Styled.Header>
+            {stringGetter({ key: STRING_KEYS.TRADING_REWARDS_SUMMARY })}
+          </Styled.Header>
+        }
+      >
+        <Styled.Content>
+          <Styled.TradingRewardsDetails
+            layout="grid"
+            items={[
+              {
+                key: 'week',
+                label: (
+                  <Styled.Label>
+                    <h4>{stringGetter({ key: STRING_KEYS.THIS_WEEK })}</h4>
+                  </Styled.Label>
+                ),
+                value: (
+                  <Styled.Column>
+                    <Output
+                      slotRight={<Styled.AssetIcon symbol={chainTokenLabel} />}
+                      type={OutputType.Asset}
+                      value={currentWeekTradingReward.amount}
+                    />
+                    <Styled.TimePeriod>
+                      <Output
+                        type={OutputType.Date}
+                        value={currentWeekTradingReward.startedAtInMilliseconds}
+                        timeOptions={{ useUTC: true }}
+                      />
+                      →
+                      <Output
+                        type={OutputType.Date}
+                        value={currentWeekTradingReward.endedAtInMilliseconds}
+                        timeOptions={{ useUTC: true }}
+                      />
+                    </Styled.TimePeriod>
+                  </Styled.Column>
+                ),
+              },
+              // TODO(@aforaleka): add all-time when supported
+            ]}
+          />
+        </Styled.Content>
+      </Panel>
+    )
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Header = styled.div`
+  padding: var(--panel-paddingY) var(--panel-paddingX) 0;
+  font: var(--font-medium-book);
+  color: var(--color-text-2);
+`;
+
+Styled.Content = styled.div`
+  ${layoutMixins.flexColumn}
+  gap: 0.75rem;
+`;
+
+Styled.TradingRewardsDetails = styled(Details)`
+  --details-item-backgroundColor: var(--color-layer-6);
+
+  grid-template-columns: 1fr; // TODO(@aforaleka): change to 1fr 1fr when all-time is supported
+  gap: 1rem;
+
+  > div {
+    gap: 0.5rem;
+    padding: 1rem;
+    border-radius: 0.75em;
+    background-color: var(--color-layer-5);
+  }
+
+  dt {
+    width: 100%;
+  }
+
+  output {
+    color: var(--color-text-2);
+    font: var(--font-large-book);
+  }
+`;
+
+Styled.Label = styled.div`
+  ${layoutMixins.spacedRow}
+
+  font: var(--font-base-book);
+  color: var(--color-text-1);
+`;
+
+Styled.TimePeriod = styled.div`
+  ${layoutMixins.inlineRow}
+
+  &, output {
+    color: var(--color-text-0);
+    font: var(--font-small-book);
+  }
+`;
+
+Styled.Column = styled.div`
+  ${layoutMixins.flexColumn}
+  gap: 0.33rem;
+`;
+
+Styled.AssetIcon = styled(AssetIcon)`
+  margin-left: 0.5ch;
+`;

--- a/src/pages/rewards/TradingRewardsSummaryPanel.tsx
+++ b/src/pages/rewards/TradingRewardsSummaryPanel.tsx
@@ -10,17 +10,12 @@ import { Details } from '@/components/Details';
 import { Output, OutputType } from '@/components/Output';
 import { Panel } from '@/components/Panel';
 
-import { getHistoricalTradingRewardsForPeriod } from '@/state/accountSelectors';
+import { getHistoricalTradingRewardsForCurrentWeek } from '@/state/accountSelectors';
 
 export const TradingRewardsSummaryPanel = () => {
   const stringGetter = useStringGetter();
   const { chainTokenLabel } = useTokenConfigs();
-
-  const currentWeekTradingRewards = useSelector(
-    getHistoricalTradingRewardsForPeriod('WEEKLY'),
-    shallowEqual
-  );
-  const currentWeekTradingReward = currentWeekTradingRewards?.firstOrNull();
+  const currentWeekTradingReward = useSelector(getHistoricalTradingRewardsForCurrentWeek);
 
   return !currentWeekTradingReward ? null : (
     <Panel

--- a/src/pages/rewards/TradingRewardsSummaryPanel.tsx
+++ b/src/pages/rewards/TradingRewardsSummaryPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import styled, { AnyStyledComponent } from 'styled-components';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -12,10 +13,16 @@ import { Panel } from '@/components/Panel';
 
 import { getHistoricalTradingRewardsForCurrentWeek } from '@/state/accountSelectors';
 
+import abacusStateManager from '@/lib/abacus';
+
 export const TradingRewardsSummaryPanel = () => {
   const stringGetter = useStringGetter();
   const { chainTokenLabel } = useTokenConfigs();
-  const currentWeekTradingReward = useSelector(getHistoricalTradingRewardsForCurrentWeek);
+  const currentWeekTradingReward = useSelector(getHistoricalTradingRewardsForCurrentWeek, shallowEqual);
+
+  useEffect(() => {
+    abacusStateManager.refreshHistoricalTradingRewards();
+  }, []);
 
   return !currentWeekTradingReward ? null : (
     <Panel

--- a/src/pages/rewards/TradingRewardsSummaryPanel.tsx
+++ b/src/pages/rewards/TradingRewardsSummaryPanel.tsx
@@ -22,55 +22,51 @@ export const TradingRewardsSummaryPanel = () => {
   );
   const currentWeekTradingReward = currentWeekTradingRewards?.firstOrNull();
 
-  return (
-    currentWeekTradingReward && (
-      <Panel
-        slotHeader={
-          <Styled.Header>
-            {stringGetter({ key: STRING_KEYS.TRADING_REWARDS_SUMMARY })}
-          </Styled.Header>
-        }
-      >
-        <Styled.Content>
-          <Styled.TradingRewardsDetails
-            layout="grid"
-            items={[
-              {
-                key: 'week',
-                label: (
-                  <Styled.Label>
-                    <h4>{stringGetter({ key: STRING_KEYS.THIS_WEEK })}</h4>
-                  </Styled.Label>
-                ),
-                value: (
-                  <Styled.Column>
+  return !currentWeekTradingReward ? null : (
+    <Panel
+      slotHeader={
+        <Styled.Header>{stringGetter({ key: STRING_KEYS.TRADING_REWARDS_SUMMARY })}</Styled.Header>
+      }
+    >
+      <Styled.Content>
+        <Styled.TradingRewardsDetails
+          layout="grid"
+          items={[
+            {
+              key: 'week',
+              label: (
+                <Styled.Label>
+                  <h4>{stringGetter({ key: STRING_KEYS.THIS_WEEK })}</h4>
+                </Styled.Label>
+              ),
+              value: (
+                <Styled.Column>
+                  <Output
+                    slotRight={<Styled.AssetIcon symbol={chainTokenLabel} />}
+                    type={OutputType.Asset}
+                    value={currentWeekTradingReward.amount}
+                  />
+                  <Styled.TimePeriod>
                     <Output
-                      slotRight={<Styled.AssetIcon symbol={chainTokenLabel} />}
-                      type={OutputType.Asset}
-                      value={currentWeekTradingReward.amount}
+                      type={OutputType.Date}
+                      value={currentWeekTradingReward.startedAtInMilliseconds}
+                      timeOptions={{ useUTC: true }}
                     />
-                    <Styled.TimePeriod>
-                      <Output
-                        type={OutputType.Date}
-                        value={currentWeekTradingReward.startedAtInMilliseconds}
-                        timeOptions={{ useUTC: true }}
-                      />
-                      →
-                      <Output
-                        type={OutputType.Date}
-                        value={currentWeekTradingReward.endedAtInMilliseconds}
-                        timeOptions={{ useUTC: true }}
-                      />
-                    </Styled.TimePeriod>
-                  </Styled.Column>
-                ),
-              },
-              // TODO(@aforaleka): add all-time when supported
-            ]}
-          />
-        </Styled.Content>
-      </Panel>
-    )
+                    →
+                    <Output
+                      type={OutputType.Date}
+                      value={currentWeekTradingReward.endedAtInMilliseconds}
+                      timeOptions={{ useUTC: true }}
+                    />
+                  </Styled.TimePeriod>
+                </Styled.Column>
+              ),
+            },
+            // TODO(@aforaleka): add all-time when supported
+          ]}
+        />
+      </Styled.Content>
+    </Panel>
   );
 };
 

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -13,6 +13,7 @@ import type {
   HistoricalPnlPeriods,
   SubAccountHistoricalPNLs,
   UsageRestriction,
+  TradingRewards,
 } from '@/constants/abacus';
 
 import { OnboardingGuard, OnboardingState } from '@/constants/account';
@@ -24,6 +25,7 @@ import { getLocalStorage } from '@/lib/localStorage';
 export type AccountState = {
   balances?: Record<string, AccountBalance>;
   stakingBalances?: Record<string, AccountBalance>;
+  tradingRewards?: TradingRewards;
   wallet?: Nullable<Wallet>;
   walletType?: WalletType;
 
@@ -179,6 +181,9 @@ export const accountSlice = createSlice({
     setStakingBalances: (state, action: PayloadAction<Record<string, AccountBalance>>) => {
       state.stakingBalances = action.payload;
     },
+    setTradingRewards: (state, action: PayloadAction<TradingRewards>) => {
+      state.tradingRewards = action.payload;
+    },
     addUncommittedOrderClientId: (state, action: PayloadAction<number>) => {
       state.uncommittedOrderClientIds.push(action.payload);
     },
@@ -206,6 +211,7 @@ export const {
   viewedOrders,
   setBalances,
   setStakingBalances,
+  setTradingRewards,
   addUncommittedOrderClientId,
   removeUncommittedOrderClientId,
 } = accountSlice.actions;

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -1,3 +1,4 @@
+import type { Nullable, kollections } from '@dydxprotocol/v4-abacus';
 import { OrderSide } from '@dydxprotocol/v4-client-js';
 import { createSelector } from 'reselect';
 
@@ -365,8 +366,13 @@ export const getHistoricalTradingRewards = (state: RootState) =>
  * @returns account historical trading rewards for the specified perid
  */
 export const getHistoricalTradingRewardsForPeriod = (period: string) =>
-  createSelector([getHistoricalTradingRewards], (historicalTradingRewards: any) =>
-    historicalTradingRewards?.get(period)
+  createSelector(
+    [getHistoricalTradingRewards],
+    (
+      historicalTradingRewards: Nullable<
+        kollections.Map<string, kollections.List<HistoricalTradingReward>>
+      >
+    ) => historicalTradingRewards?.get(period)
   );
 
 /**

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -9,6 +9,7 @@ import {
   AbacusOrderStatus,
   AbacusPositionSide,
   ORDER_SIDES,
+  HistoricalTradingReward,
 } from '@/constants/abacus';
 
 import { OnboardingState } from '@/constants/account';
@@ -348,6 +349,25 @@ export const getBalances = (state: RootState) => state.account?.balances;
  *  @returns user wallet staking balances
  * */
 export const getStakingBalances = (state: RootState) => state.account?.stakingBalances;
+
+/**
+ * @returns account all time trading rewards
+ */
+export const getTotalTradingRewards = (state: RootState) => state.account?.tradingRewards?.total;
+
+/**
+ * @returns account trading rewards aggregated by period
+ */
+export const getHistoricalTradingRewards = (state: RootState) =>
+  state.account?.tradingRewards?.historical;
+
+/**
+ * @returns account historical trading rewards for the specified perid
+ */
+export const getHistoricalTradingRewardsForPeriod = (period: string) =>
+  createSelector([getHistoricalTradingRewards], (historicalTradingRewards: any) =>
+    historicalTradingRewards?.get(period)
+  );
 
 /**
  * @returns UsageRestriction of the current session

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -11,6 +11,7 @@ import {
   AbacusPositionSide,
   ORDER_SIDES,
   HistoricalTradingReward,
+  HistoricalTradingRewardsPeriod,
 } from '@/constants/abacus';
 
 import { OnboardingState } from '@/constants/account';
@@ -374,6 +375,14 @@ export const getHistoricalTradingRewardsForPeriod = (period: string) =>
       >
     ) => historicalTradingRewards?.get(period)
   );
+
+/**
+ * @returns account historical trading rewards for the current week
+ */
+export const getHistoricalTradingRewardsForCurrentWeek = createSelector(
+  [getHistoricalTradingRewardsForPeriod(HistoricalTradingRewardsPeriod.WEEKLY.name)],
+  (historicalTradingRewards) => historicalTradingRewards?.firstOrNull()
+);
 
 /**
  * @returns UsageRestriction of the current session

--- a/src/views/tables/TradingRewardHistoryTable.tsx
+++ b/src/views/tables/TradingRewardHistoryTable.tsx
@@ -1,0 +1,158 @@
+import styled, { type AnyStyledComponent } from 'styled-components';
+import { shallowEqual, useSelector } from 'react-redux';
+
+import { HistoricaTradingRewardsPeriods } from '@/constants/abacus';
+import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
+import { useStringGetter, useTokenConfigs } from '@/hooks';
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Output, OutputType } from '@/components/Output';
+import { Table, TableCell, type ColumnDef } from '@/components/Table';
+
+import { getHistoricalTradingRewardsForPeriod } from '@/state/accountSelectors';
+
+export enum TradingRewardHistoryTableColumnKey {
+  Event = 'Event',
+  Earned = 'Earned',
+}
+
+const getTradingRewardHistoryTableColumnDef = ({
+  key,
+  chainTokenLabel,
+  stringGetter,
+}: {
+  key: TradingRewardHistoryTableColumnKey;
+  chainTokenLabel: string;
+  stringGetter: StringGetterFunction;
+}): ColumnDef<any> => ({
+  ...(
+    {
+      [TradingRewardHistoryTableColumnKey.Event]: {
+        columnKey: TradingRewardHistoryTableColumnKey.Event,
+        getCellValue: (row) => row.startedAtInMilliseconds,
+        label: stringGetter({ key: STRING_KEYS.EVENT }),
+        renderCell: ({ startedAtInMilliseconds, endedAtInMilliseconds }) => (
+          <TableCell stacked>
+            <Styled.Rewarded>{stringGetter({ key: STRING_KEYS.REWARDED })}</Styled.Rewarded>
+            <Styled.TimePeriod>
+              {stringGetter({
+                key: STRING_KEYS.FOR_TRADING,
+                params: {
+                  PERIOD: (
+                    <>
+                      <Output
+                        type={OutputType.Date}
+                        value={startedAtInMilliseconds}
+                        timeOptions={{ useUTC: true }}
+                      />
+                      →
+                      <Output
+                        type={OutputType.Date}
+                        value={endedAtInMilliseconds}
+                        timeOptions={{ useUTC: true }}
+                      />
+                    </>
+                  ),
+                },
+              })}
+            </Styled.TimePeriod>
+          </TableCell>
+        ),
+      },
+      [TradingRewardHistoryTableColumnKey.Earned]: {
+        columnKey: TradingRewardHistoryTableColumnKey.Earned,
+        getCellValue: (row) => row.amount,
+        label: stringGetter({ key: STRING_KEYS.EARNED }),
+        renderCell: ({ amount }) => (
+          <Output
+            type={OutputType.Asset}
+            value={amount}
+            slotRight={<Styled.AssetIcon symbol={chainTokenLabel} />}
+          />
+        ),
+      },
+    } as Record<TradingRewardHistoryTableColumnKey, ColumnDef<any>>
+  )[key],
+});
+
+type ElementProps = {
+  columnKeys?: TradingRewardHistoryTableColumnKey[];
+  period: HistoricaTradingRewardsPeriods;
+};
+
+type StyleProps = {
+  withOuterBorder?: boolean;
+  withInnerBorders?: boolean;
+};
+
+export const TradingRewardHistoryTable = ({
+  period,
+  columnKeys = Object.values(TradingRewardHistoryTableColumnKey),
+  withOuterBorder,
+  withInnerBorders = true,
+}: ElementProps & StyleProps) => {
+  const stringGetter = useStringGetter();
+  const { chainTokenLabel } = useTokenConfigs();
+
+  const periodTradingRewards = useSelector(
+    getHistoricalTradingRewardsForPeriod(period.name),
+    shallowEqual
+  );
+
+  return (
+    <Styled.Table
+      label={stringGetter({ key: STRING_KEYS.REWARD_HISTORY })}
+      data={periodTradingRewards?.toArray() ?? []}
+      getRowKey={(row: any) => row.startedAtInMilliseconds}
+      columns={columnKeys.map((key: TradingRewardHistoryTableColumnKey) =>
+        getTradingRewardHistoryTableColumnDef({
+          key,
+          chainTokenLabel,
+          stringGetter,
+        })
+      )}
+      selectionBehavior="replace"
+      withOuterBorder={withOuterBorder}
+      withInnerBorders={withInnerBorders}
+      initialNumRowsToShow={5}
+      withScrollSnapColumns
+      withScrollSnapRows
+    />
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Table = styled(Table)`
+  --tableCell-padding: 0.5rem 0;
+  --tableHeader-backgroundColor: var(--color-layer-3);
+  --tableRow-backgroundColor: var(--color-layer-3);
+  --tableViewMore-borderColor: var(--color-layer-3);
+
+  tbody {
+    font: var(--font-medium-book);
+  }
+`;
+
+Styled.Rewarded = styled.span`
+  color: var(--color-text-2);
+`;
+
+Styled.TimePeriod = styled.div`
+  ${layoutMixins.inlineRow}
+
+  && {
+    color: var(--color-text-0);
+    font: var(--font-base-book);
+  }
+
+  output {
+    color: var(--color-text-1);
+    font: var(--font-base-book);
+  }
+`;
+
+Styled.AssetIcon = styled(AssetIcon)`
+  margin-left: 0.5ch;
+`;

--- a/src/views/tables/TradingRewardHistoryTable.tsx
+++ b/src/views/tables/TradingRewardHistoryTable.tsx
@@ -1,7 +1,7 @@
 import styled, { type AnyStyledComponent } from 'styled-components';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import { HistoricaTradingRewardsPeriods } from '@/constants/abacus';
+import { HistoricaTradingRewardsPeriods, HistoricalTradingReward } from '@/constants/abacus';
 import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
 import { useStringGetter, useTokenConfigs } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -25,7 +25,7 @@ const getTradingRewardHistoryTableColumnDef = ({
   key: TradingRewardHistoryTableColumnKey;
   chainTokenLabel: string;
   stringGetter: StringGetterFunction;
-}): ColumnDef<any> => ({
+}): ColumnDef<HistoricalTradingReward> => ({
   ...(
     {
       [TradingRewardHistoryTableColumnKey.Event]: {
@@ -72,7 +72,7 @@ const getTradingRewardHistoryTableColumnDef = ({
           />
         ),
       },
-    } as Record<TradingRewardHistoryTableColumnKey, ColumnDef<any>>
+    } as Record<TradingRewardHistoryTableColumnKey, ColumnDef<HistoricalTradingReward>>
   )[key],
 });
 

--- a/src/views/tables/TradingRewardHistoryTable.tsx
+++ b/src/views/tables/TradingRewardHistoryTable.tsx
@@ -1,7 +1,7 @@
 import styled, { type AnyStyledComponent } from 'styled-components';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import { HistoricaTradingRewardsPeriods, HistoricalTradingReward } from '@/constants/abacus';
+import { HistoricalTradingRewardsPeriods, HistoricalTradingReward } from '@/constants/abacus';
 import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
 import { useStringGetter, useTokenConfigs } from '@/hooks';
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -10,7 +10,10 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Output, OutputType } from '@/components/Output';
 import { Table, TableCell, type ColumnDef } from '@/components/Table';
 
-import { getHistoricalTradingRewardsForPeriod } from '@/state/accountSelectors';
+import {
+  getHistoricalTradingRewards,
+  getHistoricalTradingRewardsForPeriod,
+} from '@/state/accountSelectors';
 
 export enum TradingRewardHistoryTableColumnKey {
   Event = 'Event',
@@ -78,7 +81,7 @@ const getTradingRewardHistoryTableColumnDef = ({
 
 type ElementProps = {
   columnKeys?: TradingRewardHistoryTableColumnKey[];
-  period: HistoricaTradingRewardsPeriods;
+  period: HistoricalTradingRewardsPeriods;
 };
 
 type StyleProps = {
@@ -112,6 +115,9 @@ export const TradingRewardHistoryTable = ({
           stringGetter,
         })
       )}
+      slotEmpty={
+        <div>{stringGetter({ key: STRING_KEYS.EMPTY_HISTORICAL_REWARDS_DESCRIPTION })}</div>
+      }
       selectionBehavior="replace"
       withOuterBorder={withOuterBorder}
       withInnerBorders={withInnerBorders}


### PR DESCRIPTION
no trading rewards:
<img width="1366" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/7370b1d9-0038-4eee-9c39-ca8a44d33118">
with trading rewards:
<img width="1365" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/aafa07f5-04da-49e1-a6d2-2f83d9276a36">

steps to test:
- change network to staging
- trade something (orders must be filled) so you get trading rewards -- you should see a block reward notification
- head to Rewards page, and add `?tradingrewards=1` to end of url
- observe trading rewards summary + historical trading rewards table
- toggle between monthly/weekly/daily - this is more relevant when you have at least 2 days of trading rewards, hence feature flag gated and want to keep testing in staging for 1week+


Shared components changes
- `Output`: component now supports UTC option -- this is because we're showing the time periods in UTC in the historical trading rewards table
- `Table`: enable view more row custom styling

Library changes
- abacus / state manager: adds support for new types + setHistoricalTradingRewardPeriod helper (set the weekly / monthly / daily option) + changes
- `testFlags`: add `tradingreward`
- account state: add `tradingRewards` to account

View changes
- `RewardsPage`: new grid layout
- `RewardsHelpPanel`: localize
- `TradingRewardsSummaryPanel`: just show current week's rewards
- `RewardHistoryPanel` + `TradingRewardHistoryTable`: show list of periodic trading rewards


