### PR TITLE
Use BigInt toString() for initialDepositAmount param

### DIFF
--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -433,7 +433,8 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
         params,
         utils.getGovAddNewMarketTitle(params.ticker),
         utils.getGovAddNewMarketSummary(params.ticker, newMarketProposal.delayBlocks),
-        newMarketProposal.initialDepositAmount
+        // @ts-ignore - Need to change type in v4-client-js
+        BigInt(newMarketProposal.initialDepositAmount).toString()
       );
 
       return response;


### PR DESCRIPTION
Use BigInt because mainnet value of 10_000_000_000_000_000_000_000 returns scientific notation 1e22.