### PR TITLE
use updated isaccountconnected check

### DIFF
--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -115,7 +115,15 @@ export const useWalletConnection = () => {
   });
 
   const connectWallet = useCallback(
-    async ({ walletType, forceConnect }: { walletType?: WalletType; forceConnect?: boolean }) => {
+    async ({
+      walletType,
+      forceConnect,
+      isAccountConnected,
+    }: {
+      walletType?: WalletType;
+      forceConnect?: boolean;
+      isAccountConnected?: boolean;
+    }) => {
       if (!walletType) return { walletType, walletConnectionType };
 
       const walletConnection = getWalletConnection({ walletType });
@@ -143,9 +151,6 @@ export const useWalletConnection = () => {
         } else if (walletConnection.type === WalletConnectionType.TestWallet) {
           saveEvmAddress(STRING_KEYS.TEST_WALLET as EvmAddress);
         } else {
-          const isAccountConnected = Boolean(
-            evmAddress && evmDerivedAddresses[evmAddress]?.encryptedSignature
-          );
           // if account connected (via remember me), do not show wagmi popup until forceConnect
           if (!isConnectedWagmi && (forceConnect || !isAccountConnected)) {
             await connectWagmi({
@@ -195,6 +200,9 @@ export const useWalletConnection = () => {
         try {
           const { walletType, walletConnectionType } = await connectWallet({
             walletType: selectedWalletType,
+            isAccountConnected: Boolean(
+              evmAddress && evmDerivedAddresses[evmAddress]?.encryptedSignature
+            ),
           });
 
           setWalletType(walletType);
@@ -217,7 +225,7 @@ export const useWalletConnection = () => {
         await disconnectWallet();
       }
     })();
-  }, [selectedWalletType, signerWagmi, signerGraz]);
+  }, [selectedWalletType, signerWagmi, signerGraz, evmDerivedAddresses]);
 
   const selectWalletType = async (walletType: WalletType | undefined) => {
     if (selectedWalletType) {

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -225,7 +225,7 @@ export const useWalletConnection = () => {
         await disconnectWallet();
       }
     })();
-  }, [selectedWalletType, signerWagmi, signerGraz, evmDerivedAddresses]);
+  }, [selectedWalletType, signerWagmi, signerGraz, evmDerivedAddresses, evmAddress]);
 
   const selectWalletType = async (walletType: WalletType | undefined) => {
     if (selectedWalletType) {


### PR DESCRIPTION
there was a bug where clicking wallet type does nothing
repro steps:
1. use metamask, connect to wallet A, remember me enabled
2. refresh or quit chrome and reopen, your dydx wallet should still be connected (but wagmi will be disconnected)
3. disconnect wallet
4. choose metamask again but nothing happens

seems like the issue is the `isAccountConnected` check is using an outdated version of evmDerivedAddresses, where during disconnect wallet the `encryptedSignature` should be deleted