### PR TITLE
[reduce-only] add featureFlags to env config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.4.0",
+    "@dydxprotocol/v4-abacus": "file:/Users/alekacheung/Documents/dydx/v4/v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.2.tgz",
     "@dydxprotocol/v4-client-js": "^1.0.20",
     "@dydxprotocol/v4-localization": "^1.1.22",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.4.0
-    version: 1.4.0
+    specifier: file:/Users/alekacheung/Documents/dydx/v4/v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.2.tgz
+    version: file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.2.tgz
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.20
     version: 1.0.20
@@ -1087,10 +1087,6 @@ packages:
   /@cush/relative@1.0.0:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: true
-
-  /@dydxprotocol/v4-abacus@1.4.0:
-    resolution: {integrity: sha512-mkdkXQXTVF1K6UmZwIwLC9gjsXg+Nt3h5/iW+WriVv1cUMPmHfPyRWL31eDDvkVO5UeECf05kiYXPk1y+7dPuA==}
-    dev: false
 
   /@dydxprotocol/v4-client-js@1.0.20:
     resolution: {integrity: sha512-dXKW2NC1XlVVIRKvHWVDofLZSCPTJAaRY5eXzxH5CcXpnl2kdXorr7ykqWZxW0jHFPWWvRSJtUDqZN1qFrEe/w==}
@@ -14912,6 +14908,12 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+  file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.2.tgz:
+    resolution: {integrity: sha512-YD3RdvPTVVqjV1kmfTLuiAbRQUyraf88XimURekzeYXYhioodqxLFSdHU8Sp6BmyWP98TM4JaOCIeijoH0vgFQ==, tarball: file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.2.tgz}
+    name: '@dydxprotocol/v4-abacus'
+    version: 1.4.2
+    dev: false
 
 settings:
   autoInstallPeers: true

--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -122,6 +122,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-dev-2": {
@@ -201,6 +204,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-dev-4": {
@@ -281,6 +287,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-dev-5": {
@@ -360,6 +369,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-staging": {
@@ -441,6 +453,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -521,6 +536,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-staging-west": {
@@ -602,6 +620,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet": {
@@ -687,6 +708,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -769,6 +793,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -851,6 +878,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -933,6 +963,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -1015,6 +1048,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -1089,6 +1125,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -1171,6 +1210,9 @@
                "delayBlocks": 900,
                "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       },
       "dydxprotocol-mainnet": {
@@ -1253,6 +1295,9 @@
                "delayBlocks": 0,
                "newMarketsMethodology": "[URL to spreadsheet or document that explains methodology]"
             }
+         },
+         "featureFlags": {
+            "reduceOnlySupported": false
          }
       }
    }


### PR DESCRIPTION
`reduceOnlySupported` should be set to `true` for all staging environments, and false for all non-staging

theoretically if `reduceOnlySupported` or `featureFlags` is not set, that should default to False and still work

in draft until abacus version is published