### PR TITLE
CT-363 Fix Price Impact Calculation

### DIFF
--- a/src/views/charts/DepthChart/Tooltip.tsx
+++ b/src/views/charts/DepthChart/Tooltip.tsx
@@ -48,12 +48,12 @@ export const DepthChartTooltipContent = ({
       const depthChartSeries = nearestDatum.key as DepthChartSeries;
 
       return {
-        [DepthChartSeries.Bids]: MustBigNumber(nearestDatum?.datum.price)
-          .minus(chartPointAtPointer.price)
-          .div(nearestDatum?.datum.price),
-        [DepthChartSeries.Asks]: MustBigNumber(chartPointAtPointer.price)
+        [DepthChartSeries.Bids]: MustBigNumber(midMarketPrice)
           .minus(nearestDatum?.datum.price)
-          .div(chartPointAtPointer.price),
+          .div(midMarketPrice),
+        [DepthChartSeries.Asks]: MustBigNumber(nearestDatum?.datum.price)
+          .minus(midMarketPrice)
+          .div(midMarketPrice),
         [DepthChartSeries.MidMarket]: undefined,
       }[depthChartSeries];
     }


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

Original price impact calculation was just wrong as far as I can tell, chatted with research and confirmed that formula should be `abs(price - midMarketPrice) / midMarketPrice`. Also confirmed with product that we should be using the nearestDatum price (the circle on the chart), rather than the pointer, for price.

*This also more closely reflects the [formula](https://github.com/dydxprotocol/titan/blob/d1020661ff487ebb588a0592e018e4442f0728c3/src/pages/trade/charts/DepthChart.tsx#L185) we used in v3 (though that one used bestAsk/bestBid instead of midMarket)
<!-- Overall purpose of the PR -->

https://github.com/dydxprotocol/v4-web/assets/70078372/5829b2e9-f615-4f6f-92e8-d6cf6c120112


---