### PR TITLE
CT-145 Add warning icon + tooltip to trade order button CTA

### DIFF
--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -294,7 +294,7 @@ export const ClosePositionForm = ({
           validationErrorString={alertContent}
           summary={summary ?? undefined}
           currentStep={currentStep}
-          confirmButton={{
+          confirmButtonConfig={{
             stringKey: STRING_KEYS.CLOSE_ORDER,
             buttonTextStringKey: STRING_KEYS.CLOSE_POSITION,
             buttonAction: ButtonAction.Destroy,

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -14,6 +14,7 @@ import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/b
 import { TOKEN_DECIMALS } from '@/constants/numbers';
 import { STRING_KEYS } from '@/constants/localization';
 import { MobilePlaceOrderSteps } from '@/constants/trade';
+
 import { useBreakpoints, useIsFirstRender, useStringGetter, useSubaccount } from '@/hooks';
 import { useOnLastOrderIndexed } from '@/hooks/useOnLastOrderIndexed';
 
@@ -35,7 +36,6 @@ import { Orderbook, orderbookMixins, type OrderbookScrollBehavior } from '@/view
 import { PositionPreview } from '@/views/forms/TradeForm/PositionPreview';
 
 import { getCurrentMarketPositionData } from '@/state/accountSelectors';
-
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getClosePositionInputErrors, getInputClosePositionData } from '@/state/inputsSelectors';
 import { getCurrentMarketConfig, getCurrentMarketId } from '@/state/perpetualsSelectors';
@@ -291,9 +291,14 @@ export const ClosePositionForm = ({
           isLoading={isClosingPosition}
           hasValidationErrors={hasInputErrors}
           actionStringKey={inputAlert?.actionStringKey}
+          validationErrorString={alertContent}
           summary={summary ?? undefined}
           currentStep={currentStep}
-          isClosePosition
+          confirmButton={{
+            stringKey: STRING_KEYS.CLOSE_ORDER,
+            buttonTextStringKey: STRING_KEYS.CLOSE_POSITION,
+            buttonAction: ButtonAction.Destroy,
+          }}
         />
       </Styled.Footer>
     </Styled.ClosePositionForm>

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -18,7 +18,12 @@ import {
 import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { USD_DECIMALS } from '@/constants/numbers';
-import { InputErrorData, TradeBoxKeys, MobilePlaceOrderSteps, ORDER_TYPE_STRINGS } from '@/constants/trade';
+import {
+  InputErrorData,
+  TradeBoxKeys,
+  MobilePlaceOrderSteps,
+  ORDER_TYPE_STRINGS,
+} from '@/constants/trade';
 
 import { breakpoints } from '@/styles';
 import { useStringGetter, useSubaccount } from '@/hooks';
@@ -39,7 +44,12 @@ import { WithTooltip } from '@/components/WithTooltip';
 import { Orderbook } from '@/views/tables/Orderbook';
 
 import { setTradeFormInputs } from '@/state/inputs';
-import { getCurrentInput, getInputTradeData, getTradeFormInputs, useTradeFormData } from '@/state/inputsSelectors';
+import {
+  getCurrentInput,
+  getInputTradeData,
+  getTradeFormInputs,
+  useTradeFormData,
+} from '@/state/inputsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
@@ -343,10 +353,10 @@ export const TradeForm = ({
           summary={summary ?? undefined}
           currentStep={currentStep}
           showDeposit={inputAlert?.errorAction === TradeInputErrorAction.DEPOSIT}
-          confirmButton={{
+          confirmButtonConfig={{
             stringKey: ORDER_TYPE_STRINGS[selectedTradeType].orderTypeKey,
             buttonTextStringKey: STRING_KEYS.PLACE_ORDER,
-            buttonAction: orderSideAction
+            buttonAction: orderSideAction,
           }}
         />
       </Styled.Footer>

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -1,16 +1,17 @@
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { OrderSide } from '@dydxprotocol/v4-client-js';
+import { useDispatch, useSelector } from 'react-redux';
+import styled, { type AnyStyledComponent, css } from 'styled-components';
 
 import type { TradeInputSummary } from '@/constants/abacus';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
-import { ORDER_TYPE_STRINGS, MobilePlaceOrderSteps } from '@/constants/trade';
+import { MobilePlaceOrderSteps } from '@/constants/trade';
 
 import { useStringGetter, useTokenConfigs } from '@/hooks';
 
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
+import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType, ShowSign } from '@/components/Output';
 import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
 import { WithTooltip } from '@/components/WithTooltip';
@@ -20,30 +21,34 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getSubaccountId } from '@/state/accountSelectors';
 import { openDialog } from '@/state/dialogs';
-import { getCurrentInput, getInputTradeData } from '@/state/inputsSelectors';
+import { getCurrentInput } from '@/state/inputsSelectors';
 
-import { getSelectedOrderSide, getSelectedTradeType } from '@/lib/tradeData';
+type ConfirmButton = {
+  stringKey: string;
+  buttonTextStringKey: string;
+  buttonAction: ButtonAction;
+};
 
 type ElementProps = {
   isLoading: boolean;
-  isClosePosition?: boolean;
   actionStringKey?: string;
   summary?: TradeInputSummary;
   hasValidationErrors?: boolean;
+  validationErrorString?: string;
   currentStep?: MobilePlaceOrderSteps;
   showDeposit?: boolean;
-  showConnectWallet?: boolean;
+  confirmButton: ConfirmButton;
 };
 
 export const PlaceOrderButtonAndReceipt = ({
   isLoading,
-  isClosePosition,
   actionStringKey,
   summary,
   hasValidationErrors,
+  validationErrorString,
   currentStep,
   showDeposit,
-  showConnectWallet,
+  confirmButton,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
   const dispatch = useDispatch();
@@ -52,17 +57,11 @@ export const PlaceOrderButtonAndReceipt = ({
   const canAccountTrade = useSelector(calculateCanAccountTrade);
   const subaccountNumber = useSelector(getSubaccountId);
   const currentInput = useSelector(getCurrentInput);
-  const currentTradeData = useSelector(getInputTradeData, shallowEqual);
 
   const hasMissingData = subaccountNumber === undefined;
 
   const shouldEnableTrade =
     canAccountTrade && !hasMissingData && !hasValidationErrors && currentInput !== 'transfer';
-
-  const { side, type } = currentTradeData || {};
-
-  const selectedTradeType = getSelectedTradeType(type);
-  const selectedOrderSide = getSelectedOrderSide(side);
 
   const { fee, price: expectedPrice, total, reward } = summary || {};
 
@@ -110,11 +109,6 @@ export const PlaceOrderButtonAndReceipt = ({
     },
   ];
 
-  const orderSideAction = {
-    [OrderSide.BUY]: ButtonAction.Create,
-    [OrderSide.SELL]: ButtonAction.Destroy,
-  }[selectedOrderSide];
-
   const buttonStatesPerStep = {
     [MobilePlaceOrderSteps.EditOrder]: {
       buttonTextStringKey: shouldEnableTrade
@@ -128,7 +122,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
     [MobilePlaceOrderSteps.PreviewOrder]: {
       buttonTextStringKey: STRING_KEYS.CONFIRM_ORDER,
-      buttonAction: isClosePosition ? ButtonAction.Destroy : orderSideAction,
+      buttonAction: confirmButton.buttonAction,
       buttonState: { isLoading },
     },
     [MobilePlaceOrderSteps.PlacingOrder]: {
@@ -145,15 +139,13 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonAction = currentStep
     ? buttonStatesPerStep[currentStep].buttonAction
-    : isClosePosition
-    ? ButtonAction.Destroy
-    : orderSideAction;
+    : confirmButton.buttonAction;
 
   let buttonTextStringKey = STRING_KEYS.UNAVAILABLE;
   if (currentStep) {
     buttonTextStringKey = buttonStatesPerStep[currentStep].buttonTextStringKey;
   } else if (shouldEnableTrade) {
-    buttonTextStringKey = isClosePosition ? STRING_KEYS.CLOSE_POSITION : STRING_KEYS.PLACE_ORDER;
+    buttonTextStringKey = confirmButton.buttonTextStringKey;
   } else if (actionStringKey) {
     buttonTextStringKey = actionStringKey;
   }
@@ -165,31 +157,56 @@ export const PlaceOrderButtonAndReceipt = ({
         isLoading: isLoading || hasMissingData,
       };
 
+  const depositButton = (
+    <Button
+      action={ButtonAction.Primary}
+      onClick={() => dispatch(openDialog({ type: DialogTypes.Deposit }))}
+    >
+      {stringGetter({ key: STRING_KEYS.DEPOSIT_FUNDS })}
+    </Button>
+  );
+
+  const submitButton = (
+    <Styled.Button
+      state={buttonState}
+      type={ButtonType.Submit}
+      action={buttonAction}
+      slotLeft={
+        hasValidationErrors ? <Styled.WarningIcon iconName={IconName.Warning} /> : undefined
+      }
+    >
+      {stringGetter({
+        key: buttonTextStringKey,
+        params: {
+          ORDER: stringGetter({
+            key: confirmButton.stringKey,
+          }),
+        },
+      })}
+    </Styled.Button>
+  );
+
   return (
     <WithDetailsReceipt detailItems={items}>
-      {!canAccountTrade || showConnectWallet ? (
+      {!canAccountTrade ? (
         <OnboardingTriggerButton size={ButtonSize.Base} />
       ) : showDeposit ? (
-        <Button
-          action={ButtonAction.Primary}
-          onClick={() => dispatch(openDialog({ type: DialogTypes.Deposit }))}
-        >
-          {stringGetter({ key: STRING_KEYS.DEPOSIT_FUNDS })}
-        </Button>
+        depositButton
       ) : (
-        <Button state={buttonState} type={ButtonType.Submit} action={buttonAction}>
-          {stringGetter({
-            key: buttonTextStringKey,
-            params: {
-              ORDER: stringGetter({
-                key: isClosePosition
-                  ? STRING_KEYS.CLOSE_ORDER
-                  : ORDER_TYPE_STRINGS[selectedTradeType].orderTypeKey,
-              }),
-            },
-          })}
-        </Button>
+        <WithTooltip tooltipString={hasValidationErrors ? validationErrorString : undefined}>
+          {submitButton}
+        </WithTooltip>
       )}
     </WithDetailsReceipt>
   );
 };
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Button = styled(Button)`
+  width: 100%;
+`;
+
+Styled.WarningIcon = styled(Icon)`
+  color: var(--color-warning);
+`;

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -23,7 +23,7 @@ import { getSubaccountId } from '@/state/accountSelectors';
 import { openDialog } from '@/state/dialogs';
 import { getCurrentInput } from '@/state/inputsSelectors';
 
-type ConfirmButton = {
+type ConfirmButtonConfig = {
   stringKey: string;
   buttonTextStringKey: string;
   buttonAction: ButtonAction;
@@ -37,7 +37,7 @@ type ElementProps = {
   validationErrorString?: string;
   currentStep?: MobilePlaceOrderSteps;
   showDeposit?: boolean;
-  confirmButton: ConfirmButton;
+  confirmButtonConfig: ConfirmButtonConfig;
 };
 
 export const PlaceOrderButtonAndReceipt = ({
@@ -48,7 +48,7 @@ export const PlaceOrderButtonAndReceipt = ({
   validationErrorString,
   currentStep,
   showDeposit,
-  confirmButton,
+  confirmButtonConfig,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
   const dispatch = useDispatch();
@@ -122,7 +122,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
     [MobilePlaceOrderSteps.PreviewOrder]: {
       buttonTextStringKey: STRING_KEYS.CONFIRM_ORDER,
-      buttonAction: confirmButton.buttonAction,
+      buttonAction: confirmButtonConfig.buttonAction,
       buttonState: { isLoading },
     },
     [MobilePlaceOrderSteps.PlacingOrder]: {
@@ -139,13 +139,13 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const buttonAction = currentStep
     ? buttonStatesPerStep[currentStep].buttonAction
-    : confirmButton.buttonAction;
+    : confirmButtonConfig.buttonAction;
 
   let buttonTextStringKey = STRING_KEYS.UNAVAILABLE;
   if (currentStep) {
     buttonTextStringKey = buttonStatesPerStep[currentStep].buttonTextStringKey;
   } else if (shouldEnableTrade) {
-    buttonTextStringKey = confirmButton.buttonTextStringKey;
+    buttonTextStringKey = confirmButtonConfig.buttonTextStringKey;
   } else if (actionStringKey) {
     buttonTextStringKey = actionStringKey;
   }
@@ -179,7 +179,7 @@ export const PlaceOrderButtonAndReceipt = ({
         key: buttonTextStringKey,
         params: {
           ORDER: stringGetter({
-            key: confirmButton.stringKey,
+            key: confirmButtonConfig.stringKey,
           }),
         },
       })}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

1. Add a warning icon to the trade order button whenever it is disabled due to an input error (includes missing inputs)
2. Wrap the trade order button in a tooltip with error message when applicable (showed product the screenshots)

<img width="324" alt="Screenshot 2024-02-12 at 4 24 56 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/d23ea1a5-e788-414d-b74a-679bb2a0d8b4">

![Screenshot 2024-02-12 at 1 21 46 PM](https://github.com/dydxprotocol/v4-web/assets/70078372/70c668db-c9f1-48c5-bb81-4842cce0a93a)
![Screenshot 2024-02-12 at 1 21 36 PM](https://github.com/dydxprotocol/v4-web/assets/70078372/77d07887-0283-42c2-ad32-2402de4f321d)


<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* Modified: `src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx`
  * replaced `isClosePosition` prop with `confirmButton` prop because it was a little hard to follow all the ternaries in code
    * Also seemed like caller should just be passing down this info
  * Removed `showConnectWallet?: boolean;` which was unused
* Updated: `src/views/forms/TradeForm.tsx` (caller of `PlaceOrderButtonAndReceipt`)
*  Updated: `src/views/forms/ClosePositionForm.tsx` (caller of `PlaceOrderButtonAndReceipt`)
