### PR TITLE
Fix highlighted tag text color

### DIFF
--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -33,4 +33,9 @@ TagStory.argTypes = {
     control: { type: 'select' },
     defaultValue: undefined,
   },
+  isHighlighted: {
+    options: [true, false],
+    control: { type: 'select' },
+    defaultValue: false,
+  },
 };

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -76,5 +76,6 @@ export const Tag = styled.span<StyleProps>`
     isHighlighted &&
     css`
       background-color: var(--color-accent);
+      color: var(--color-text-button);
     `}
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Nit issue I noticed while poking around the positions table; quick fix. 

Issue was that highlighted tag text color was wrong for `isHighlighted` (purple), which was apparent in light mode.

| | Classic | Light | Dark |
| ----- | ----- | ----- | ----- |
| Before | <img width="310" alt="Screenshot 2024-02-14 at 10 25 50 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/92d61814-de0e-450e-895f-61990350bbe5"> | <img width="307" alt="Screenshot 2024-02-14 at 10 25 41 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/a3b84640-7efb-41f8-b863-47a655729317"> | <img width="304" alt="Screenshot 2024-02-14 at 10 25 45 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/65058904-5b97-4cd4-a568-8578f65e32a5"> |
| After | <img width="309" alt="Screenshot 2024-02-14 at 10 25 19 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/e56629b0-e6ee-4f37-9918-8674badbf392"> | <img width="315" alt="Screenshot 2024-02-14 at 10 25 30 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/486d44e3-1247-477c-bd2d-2444f7ff146f"> | <img width="309" alt="Screenshot 2024-02-14 at 10 25 35 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/ea9f82fb-1162-40df-a0b6-899686af4c45"> | 




<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Components

* `<Tag>`
  * Update css with `var(--color-text-button)`
