### PR TITLE
CT-486 Fix sticky chart resolution setting

### DIFF
--- a/src/hooks/tradingView/useChartMarketAndResolution.ts
+++ b/src/hooks/tradingView/useChartMarketAndResolution.ts
@@ -27,19 +27,26 @@ export const useChartMarketAndResolution = ({
   const dispatch = useDispatch();
 
   const currentMarketId: string = useSelector(getCurrentMarketId) || DEFAULT_MARKETID;
+
   const selectedResolution: string =
     useSelector(getSelectedResolutionForMarket(currentMarketId)) || DEFAULT_RESOLUTION;
 
   const chart = isWidgetReady ? tvWidget?.chart() : undefined;
   const chartResolution = chart?.resolution?.();
 
+  /**
+   * @description Hook to handle changing markets - intentionally should avoid triggering on change of resolutions.
+   */
   useEffect(() => {
     if (currentMarketId && isWidgetReady) {
       const resolution = savedResolution || selectedResolution;
       tvWidget?.setSymbol(currentMarketId, resolution as ResolutionString, () => {});
     }
-  }, [currentMarketId, isWidgetReady, savedResolution, selectedResolution]);
+  }, [currentMarketId, isWidgetReady]);
 
+  /**
+   * @description Hook to handle changing chart resolution
+   */
   useEffect(() => {
     if (chartResolution) {
       if (chartResolution !== selectedResolution) {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/dydxprotocol/v4-web/assets/70078372/78a40026-259f-4dda-b45f-0b834083e661



<!-- Overall purpose of the PR -->

---

Bug due to `tvWidget?.setSymbol` being called every time the resolution was being changed - where the resolution that was being saved was first the `savedResolution`. Updated effect to no longer depend on `resolution` dependencies, with comment explaining why.