### PR TITLE
fix parsing error and surface tx broadcast error

### DIFF
--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -46,6 +46,10 @@ import { log } from '../telemetry';
 import { hashFromTx, getMintscanTxLink } from '../txUtils';
 import { getDydxChainIdFromNetwork } from '../network';
 
+(BigInt.prototype as any).toJSON = function () {
+  return this.toString();
+};
+
 class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
   private compositeClient: CompositeClient | undefined;
   private nobleClient: NobleClient | undefined;
@@ -537,7 +541,6 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
         case TransactionType.CctpWithdraw: {
           const result = await this.cctpWithdraw(params);
           callback(result);
-          break;
           break;
         }
         default: {

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -34,7 +34,7 @@ import {
 import { DEFAULT_TRANSACTION_MEMO } from '@/constants/analytics';
 import { DialogTypes } from '@/constants/dialogs';
 import { UNCOMMITTED_ORDER_TIMEOUT_MS } from '@/constants/trade';
-import { DydxNetwork, isTestnet } from '@/constants/networks';
+import { DydxChainId, isTestnet } from '@/constants/networks';
 
 import { RootStore } from '@/state/_store';
 import { addUncommittedOrderClientId, removeUncommittedOrderClientId } from '@/state/account';
@@ -44,7 +44,6 @@ import { StatefulOrderError } from '../errors';
 import { bytesToBigInt } from '../numbers';
 import { log } from '../telemetry';
 import { hashFromTx, getMintscanTxLink } from '../txUtils';
-import { getDydxChainIdFromNetwork } from '../network';
 
 (BigInt.prototype as any).toJSON = function () {
   return this.toString();
@@ -243,10 +242,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
 
       if (isTestnet) {
         console.log(
-          getMintscanTxLink(
-            getDydxChainIdFromNetwork(this.compositeClient.network.getString() as DydxNetwork),
-            hash
-          )
+          getMintscanTxLink(this.compositeClient.network.getString() as DydxChainId, hash)
         );
       } else console.log(`txHash: ${hash}`);
 

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -2,7 +2,3 @@ import { type DydxNetwork, ENVIRONMENT_CONFIG_MAP, type DydxChainId } from '@/co
 
 export const validateAgainstAvailableEnvironments = (value: DydxNetwork) =>
   Object.keys(ENVIRONMENT_CONFIG_MAP).includes(value);
-
-export const getDydxChainIdFromNetwork = (network: DydxNetwork) => {
-  return ENVIRONMENT_CONFIG_MAP[network].dydxChainId as DydxChainId;
-};


### PR DESCRIPTION
there was a json.stringify parsing error that covered up the broadcast error, making abacus failed to parse it properly
