### PR TITLE
TRCL-3553 Having the launch incentive api in env.json

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -71,7 +71,8 @@
          "keplrDashboard": "https://testnet.keplr.app/",
          "strideZoneApp": "https://testnet.stride.zone",
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
-         "walletLearnMore": "https://www.dydx.academy/video/defi-wallet"
+         "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
+         "launchIncentive": "https://cloud.chaoslabs.co/"
       },
       "dydx-testnet-4": {
          "tos": "https://dydx.exchange/v4-terms",
@@ -92,7 +93,8 @@
          "keplrDashboard": "https://testnet.keplr.app/",
          "strideZoneApp": "https://testnet.stride.zone",
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
-         "walletLearnMore": "https://www.dydx.academy/video/defi-wallet"
+         "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
+         "launchIncentive": "https://cloud.chaoslabs.co/"
       },
       "[mainnet chain id]": {
          "tos": "[HTTP link to TOS]",
@@ -113,7 +115,8 @@
          "keplrDashboard": "[HTTP link to keplr dashboard, can be null]",
          "strideZoneApp": "[HTTP link to stride zone app, can be null]",
          "accountExportLearnMore": "[HTTP link to account export learn more, can be null]",
-         "walletLearnMore": "[HTTP link to wallet learn more, can be null]"
+         "walletLearnMore": "[HTTP link to wallet learn more, can be null]",
+         "launchIncentive": "[HTTP link to launch incentive host, can be null]"
       }
    },
    "wallets": {


### PR DESCRIPTION
@aforaleka @mike-dydx 
I assume Chaos Labs does not have a testnet environment.

This PR enables us to test launch Incentive in testnet, with their production API. That means, we will retrieve the production seasons, and then it will get 0 for the incentives since the testnet address won't be found on deployer's mainnet.