### PR TITLE
CT-499 Fix TradingView crash on network switch

### DIFF
--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -57,13 +57,15 @@ export const useChartLines = ({
   useEffect(() => {
     if (tvWidget && isChartReady) {
       tvWidget.onChartReady(() => {
-        tvWidget.chart().dataReady(() => {
-          if (showOrderLines) {
-            drawOrderLines();
-            drawPositionLine();
-          } else {
-            deleteChartLines();
-          }
+        tvWidget.headerReady().then(() => {
+          tvWidget.chart().dataReady(() => {
+            if (showOrderLines) {
+              drawOrderLines();
+              drawPositionLine();
+            } else {
+              deleteChartLines();
+            }
+          });
         });
       });
     }


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Apparently `tvWidget.chart()` can still crash on the `innerApi()` call after `onChartReady` is true 🙃 . The check for whether the inner api/window is ready is `headerReady`.

### Testing
- Tested switching networks didn't crash the page.


https://github.com/dydxprotocol/v4-web/assets/70078372/d51972ae-b95e-4ac5-abed-332f20f58c38

