### PR TITLE
Update env config to enable reduce only in testnet

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -725,7 +725,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -812,7 +812,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -899,7 +899,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -986,7 +986,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -1073,7 +1073,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -1151,7 +1151,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -1238,7 +1238,7 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-mainnet": {

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -452,7 +452,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -478,7 +478,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -504,7 +504,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -530,7 +530,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -556,7 +556,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -582,7 +582,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -608,7 +608,7 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": true
          }
       },
       "dydxprotocol-mainnet": {


### PR DESCRIPTION
Updates the 7 testnet envs, RO is still disabled on mainnet. Updated both versions of `env.json`.

Verified reduce only now shows on testnet environments.
<img width="1488" alt="Screenshot 2024-02-21 at 5 50 41 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/859a0f2e-6339-49c4-a9ae-5bf743281943">


https://github.com/dydxprotocol/v4-web/assets/70078372/708d8610-288f-47c9-a21f-7010c69967ed



