### PR TITLE
use pessimistic collat check in non-dev/staging envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.4.9",
+    "@dydxprotocol/v4-abacus": "^1.4.12",
     "@dydxprotocol/v4-client-js": "^1.0.20",
     "@dydxprotocol/v4-localization": "^1.1.35",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.4.9
-    version: 1.4.9
+    specifier: ^1.4.12
+    version: 1.4.12
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.20
     version: 1.0.20
@@ -1290,8 +1290,8 @@ packages:
     resolution: {integrity: sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q==}
     dev: false
 
-  /@dydxprotocol/v4-abacus@1.4.9:
-    resolution: {integrity: sha512-OnrD5Db7AGSxyQE+gWRmkBuXbkZMfSEDB+v2s+ft0zgd4D5j/WTZkk1RG0fn8ISV4AffoN5T24jBWxLfqVlmZw==}
+  /@dydxprotocol/v4-abacus@1.4.12:
+    resolution: {integrity: sha512-dNQFaNrLTujyViMH2JEtf9Vn2ew2le+qTWexktK5h7AeADBbS9uxQknMIFhfwzGkbS1QqqszBT1plrDmQ+E6nQ==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.20:

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -261,7 +261,8 @@
             "faucet": "https://faucet.v4dev.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-dev-2": {
@@ -286,7 +287,8 @@
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-dev-4": {
@@ -312,7 +314,8 @@
             "faucet": "https://faucet.v4dev4.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-dev-5": {
@@ -337,7 +340,8 @@
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-staging": {
@@ -363,7 +367,8 @@
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -396,7 +401,8 @@
             }
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-staging-west": {
@@ -422,7 +428,8 @@
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false
          }
       },
       "dydxprotocol-testnet": {
@@ -452,7 +459,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -478,7 +486,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -504,7 +513,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -530,7 +540,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -556,7 +567,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -582,7 +594,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -608,7 +621,8 @@
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "featureFlags": {
-            "reduceOnlySupported": true
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": true
          }
       },
       "dydxprotocol-mainnet": {
@@ -634,7 +648,8 @@
             "nobleValidator": "[noble validator endpoint for mainnet]"
          },
          "featureFlags": {
-            "reduceOnlySupported": false
+            "reduceOnlySupported": false,
+            "usePessimisticCollateralCheck": true
          }
       }
    }


### PR DESCRIPTION
- bump abacus, which includes `usePessimisticCollateralCheck` feature flag + logic to use pessimistic collat check price (i.e. worse(limitPrice, oraclePrice) when calculating subaccount state from trade 
- add `usePessimisticCollateralCheck` to env.json