### PR TITLE
CT-525 Add liquidation position line to charts

### DIFF
--- a/src/constants/tvchart.ts
+++ b/src/constants/tvchart.ts
@@ -8,7 +8,8 @@ import type {
 
 export type TvWidget = IChartingLibraryWidget & { _id?: string; _ready?: boolean };
 
-export type ChartLineType = OrderSide | 'position';
+export type PositionLineType = 'entry' | 'liquidation';
+export type ChartLineType = OrderSide | PositionLineType;
 
 export type ChartLine = {
   line: IOrderLineAdapter | IPositionLineAdapter;

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -117,7 +117,7 @@ export const useChartLines = ({
     price?: number | null;
     size?: number | null;
   }) => {
-    const shouldShow = size && size !== 0 && price;
+    const shouldShow = size && price;
     const maybePositionLine = chartLinesRef.current[key]?.line;
 
     if (!shouldShow) {

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -64,7 +64,8 @@ export const getChartLineColors = ({
   const orderColors = {
     [OrderSide.BUY]: theme.positive,
     [OrderSide.SELL]: theme.negative,
-    ['position']: null,
+    ['entry']: null,
+    ['liquidation']: theme.warning,
   };
 
   return {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Following conversation with Se:
1. Add yellow liquidation line to charts (when applicable)
2. Removed size from entry + liquidation line (but kept on order lines)


https://github.com/dydxprotocol/v4-web/assets/70078372/d529c317-3ffa-4502-bd22-4fea032ded45


---

## Constants/Types

* `constants/tvchart.ts`
  * Add a new position line type (`liquidation`)

## Functions

* `lib/tradingView/utils.ts`
  * Add a color for liquidation line

## Hooks

* `hooks/tradingView/useChartLines.ts`
  * Update to draw a liquidation line when necessary
  * Remove quantity from entry line

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
