### PR TITLE
Add transfer button to AccountInfoConnected Header (OTE-186)

### DIFF
--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -5,6 +5,7 @@ import type { Nullable, TradeState } from '@/constants/abacus';
 import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
+import { DydxChainAsset } from '@/constants/wallets';
 
 import { useAccounts, useBreakpoints, useStringGetter } from '@/hooks';
 
@@ -14,6 +15,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { Button } from '@/components/Button';
 import { Details } from '@/components/Details';
 import { Icon, IconName } from '@/components/Icon';
+import { IconButton } from '@/components/IconButton';
 import { MarginUsageRing } from '@/components/MarginUsageRing';
 import { Output, OutputType } from '@/components/Output';
 import { UsageBars } from '@/components/UsageBars';
@@ -29,8 +31,6 @@ import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 import { isNumber, MustBigNumber } from '@/lib/numbers';
 
 import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
-import { DydxChainAsset } from '@/constants/wallets';
-import { IconButton } from '@/components/IconButton';
 
 enum AccountInfoItem {
   BuyingPower = 'buying-power',

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -326,13 +326,7 @@ Styled.Button = styled(Button)`
   }
 `;
 
-Styled.IconButton = styled(IconButton)<{ iconName: IconName }>`
+Styled.IconButton = styled(IconButton)`
   --button-padding: 0 0.25rem;
   --button-border: solid var(--border-width) var(--color-layer-6);
-
-  ${({ iconName }) =>
-    [IconName.Withdraw, IconName.Deposit].includes(iconName) &&
-    css`
-      --button-icon-size: 1.375em;
-    `}
 `;

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -94,7 +94,6 @@ export const AccountInfoConnectedState = () => {
               {stringGetter({ key: STRING_KEYS.DEPOSIT })}
             </Styled.Button>
             <Styled.IconButton
-              key={DialogTypes.Withdraw}
               action={ButtonAction.Base}
               shape={ButtonShape.Square}
               iconName={IconName.Send}

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -2,7 +2,7 @@ import styled, { type AnyStyledComponent, css } from 'styled-components';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import type { Nullable, TradeState } from '@/constants/abacus';
-import { ButtonShape, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
@@ -29,6 +29,8 @@ import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 import { isNumber, MustBigNumber } from '@/lib/numbers';
 
 import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
+import { DydxChainAsset } from '@/constants/wallets';
+import { IconButton } from '@/components/IconButton';
 
 enum AccountInfoItem {
   BuyingPower = 'buying-power',
@@ -91,6 +93,13 @@ export const AccountInfoConnectedState = () => {
             >
               {stringGetter({ key: STRING_KEYS.DEPOSIT })}
             </Styled.Button>
+            <Styled.IconButton
+              key={DialogTypes.Withdraw}
+              action={ButtonAction.Base}
+              shape={ButtonShape.Square}
+              iconName={IconName.Send}
+              onClick={() => dispatch(openDialog({ type: DialogTypes.Transfer, dialogProps: {selectedAsset: DydxChainAsset.USDC} }))}
+            />
           </Styled.TransferButtons>
         </Styled.Header>
       )}
@@ -315,4 +324,15 @@ Styled.Button = styled(Button)`
     width: 1.25em;
     height: 1.25em;
   }
+`;
+
+Styled.IconButton = styled(IconButton)<{ iconName: IconName }>`
+  --button-padding: 0 0.25rem;
+  --button-border: solid var(--border-width) var(--color-layer-6);
+
+  ${({ iconName }) =>
+    [IconName.Withdraw, IconName.Deposit].includes(iconName) &&
+    css`
+      --button-icon-size: 1.375em;
+    `}
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="654" alt="Screenshot 2024-02-27 at 12 29 49 PM" src="https://github.com/dydxprotocol/v4-web/assets/677820/702748e2-a6b8-4917-8a7d-1211d3845ee5">



<!-- Overall purpose of the PR -->
Add transfer button to the Account Connected Header next to withdraw and deposit
