### PR TITLE
Remove unnecessary border on Portfolio Overview "Open Positions" table

### DIFF
--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -46,7 +46,6 @@ export const Overview = () => {
           }
           currentRoute={AppRoute.Portfolio}
           withGradientCardRows
-          withOuterBorder
         />
       </Styled.AttachedExpandingSection>
     </div>


### PR DESCRIPTION
this was killing me to see

was looking at code to scope out linear tix anyways

| Before | After |
| ----- | ----- |
<img width="1401" alt="Screenshot 2024-02-27 at 3 21 02 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/e6d74f99-298e-4040-8720-02818b8b5a92"> | <img width="1376" alt="Screenshot 2024-02-27 at 3 24 04 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/00d1c16d-16e9-4232-a7f2-1a5ce2566c3c"> |

