### PR TITLE
Lower safe num oracles

### DIFF
--- a/src/constants/potentialMarkets.ts
+++ b/src/constants/potentialMarkets.ts
@@ -35,4 +35,4 @@ export type NewMarketProposal = {
   baseAsset: string;
 };
 
-export const NUM_ORACLES_TO_QUALIFY_AS_SAFE = 6;
+export const NUM_ORACLES_TO_QUALIFY_AS_SAFE = 5;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Constants

* `potentialMarkets`
  * Lower valid amount of oracles from `6` -> `5` 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
