### PR TITLE
CT-653 Render Triggers Column skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "^1.4.13",
     "@dydxprotocol/v4-client-js": "^1.0.20",
-    "@dydxprotocol/v4-localization": "^1.1.36",
+    "@dydxprotocol/v4-localization": "^1.1.39",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.0.20
     version: 1.0.20
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.36
-    version: 1.1.36
+    specifier: ^1.1.39
+    version: 1.1.39
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1373,8 +1373,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.36:
-    resolution: {integrity: sha512-7ddsTCUe62ici/qniHoh/0CIkdYhKxADU35smQTqsc+6h+GKWA+UJNpRpi685HsJ3A0UgZOsrljQqkA2vR6uSg==}
+  /@dydxprotocol/v4-localization@1.1.39:
+    resolution: {integrity: sha512-dK8cbvwsUdKOIU1Z15N6rP5Q5pIg1yvuGxw9fBJcM47Fb3YSu9E4otW5VajHpJM81fLQhoueVJ1PeTzl+iB47Q==}
     dev: false
 
   /@dydxprotocol/v4-proto@3.0.0:

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,6 +1,5 @@
 import styled, { type AnyStyledComponent } from 'styled-components';
 
-import { layoutMixins } from '@/styles/layoutMixins';
 import { tableMixins } from '@/styles/tableMixins';
 
 export const TableCell = ({

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -181,6 +181,7 @@ export type AbacusOrderTypes = Abacus.exchange.dydx.abacus.output.input.OrderTyp
 export type AbacusOrderSides = Abacus.exchange.dydx.abacus.output.input.OrderSide;
 export const AbacusOrderType = Abacus.exchange.dydx.abacus.output.input.OrderType;
 export const AbacusOrderSide = Abacus.exchange.dydx.abacus.output.input.OrderSide;
+export const AbacusOrderTimeInForce = Abacus.exchange.dydx.abacus.output.input.OrderTimeInForce;
 
 export const AbacusPositionSide = Abacus.exchange.dydx.abacus.output.PositionSide;
 export type AbacusPositionSides = Abacus.exchange.dydx.abacus.output.PositionSide;

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -179,6 +179,7 @@ export type ValidationError = Abacus.exchange.dydx.abacus.output.input.Validatio
 export const TradeInputErrorAction = Abacus.exchange.dydx.abacus.output.input.ErrorAction;
 export type AbacusOrderTypes = Abacus.exchange.dydx.abacus.output.input.OrderType;
 export type AbacusOrderSides = Abacus.exchange.dydx.abacus.output.input.OrderSide;
+export type AbacusOrderTimeInForces = Abacus.exchange.dydx.abacus.output.input.OrderTimeInForce;
 export const AbacusOrderType = Abacus.exchange.dydx.abacus.output.input.OrderType;
 export const AbacusOrderSide = Abacus.exchange.dydx.abacus.output.input.OrderSide;
 export const AbacusOrderTimeInForce = Abacus.exchange.dydx.abacus.output.input.OrderTimeInForce;

--- a/src/constants/styles/colors.ts
+++ b/src/constants/styles/colors.ts
@@ -27,6 +27,7 @@ export type ThemeColorBase = BaseColors &
   Filters;
 
 type BaseColors = {
+  black: string;
   white: string;
   green: string;
   red: string;

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -6,7 +6,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { type PerpetualMarketOrderbookLevel } from '@/constants/abacus';
 import { DepthChartSeries, DepthChartDatum } from '@/constants/charts';
 
-import { getSubaccountOpenOrdersBySideAndPrice } from '@/state/accountSelectors';
+import { getSubaccountOpenStatusOrdersBySideAndPrice } from '@/state/accountSelectors';
 import { getCurrentMarketOrderbook } from '@/state/perpetualsSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -15,7 +15,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
   const orderbook = useSelector(getCurrentMarketOrderbook, shallowEqual);
 
   const openOrdersBySideAndPrice =
-    useSelector(getSubaccountOpenOrdersBySideAndPrice, shallowEqual) || {};
+    useSelector(getSubaccountOpenStatusOrdersBySideAndPrice, shallowEqual) || {};
 
   return useMemo(() => {
     const asks: Array<PerpetualMarketOrderbookLevel | undefined> = (

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,4 +1,4 @@
-qgimport { DateTime } from 'luxon';
+import { DateTime } from 'luxon';
 
 import {
   AbacusOrderStatus,

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -92,15 +92,15 @@ export const isStopLossOrder = (order: SubaccountOrder) =>
   [AbacusOrderType.stopLimit, AbacusOrderType.stopMarket].some(
     ({ ordinal }) => ordinal === order.type.ordinal
   ) &&
-  order.reduceOnly &&
-  order.timeInForce?.name === TimeInForceOptions.IOC;
+  [TimeInForceOptions.IOC, TimeInForceOptions.FOK].includes(order.timeInForce.name) &&
+  order.reduceOnly;
 
 export const isTakeProfitOrder = (order: SubaccountOrder) =>
   [AbacusOrderType.takeProfitLimit, AbacusOrderType.takeProfitMarket].some(
     ({ ordinal }) => ordinal === order.type.ordinal
   ) &&
-  order.reduceOnly &&
-  order.timeInForce?.name === TimeInForceOptions.IOC;
+  [TimeInForceOptions.IOC, TimeInForceOptions.FOK].includes(order.timeInForce.name) &&
+  order.reduceOnly;
 
 export const relativeTimeString = ({
   timeInMs,

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+qgimport { DateTime } from 'luxon';
 
 import {
   AbacusOrderStatus,

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 
 import {
   AbacusOrderStatus,
+  AbacusOrderTimeInForce,
   AbacusOrderType,
   AbacusOrderTypes,
   type Asset,
@@ -13,7 +14,6 @@ import {
   type PerpetualMarket,
 } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
-import { TimeInForceOptions } from '@/constants/trade';
 
 import { IconName } from '@/components/Icon';
 
@@ -92,14 +92,18 @@ export const isStopLossOrder = (order: SubaccountOrder) =>
   [AbacusOrderType.stopLimit, AbacusOrderType.stopMarket].some(
     ({ ordinal }) => ordinal === order.type.ordinal
   ) &&
-  [TimeInForceOptions.IOC, TimeInForceOptions.FOK].includes(order.timeInForce.name) &&
+  [AbacusOrderTimeInForce.IOC, AbacusOrderTimeInForce.FOK].some(
+    ({ ordinal }) => ordinal === order.timeInForce?.ordinal
+  ) &&
   order.reduceOnly;
 
 export const isTakeProfitOrder = (order: SubaccountOrder) =>
   [AbacusOrderType.takeProfitLimit, AbacusOrderType.takeProfitMarket].some(
     ({ ordinal }) => ordinal === order.type.ordinal
   ) &&
-  [TimeInForceOptions.IOC, TimeInForceOptions.FOK].includes(order.timeInForce.name) &&
+  [AbacusOrderTimeInForce.IOC, AbacusOrderTimeInForce.FOK].some(
+    ({ ordinal }) => ordinal === order.timeInForce?.ordinal
+  ) &&
   order.reduceOnly;
 
 export const relativeTimeString = ({

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -12,7 +12,6 @@ import {
   type OrderStatus,
   type PerpetualMarket,
 } from '@/constants/abacus';
-
 import { STRING_KEYS } from '@/constants/localization';
 import { TimeInForceOptions } from '@/constants/trade';
 
@@ -94,7 +93,7 @@ export const isStopLossOrder = (order: SubaccountOrder) =>
     ({ ordinal }) => ordinal === order.type.ordinal
   ) &&
   order.reduceOnly &&
-  order.timeInForce?.name === TimeInForceOptions.IOC; // is it possible for reduceONly + size > what we have
+  order.timeInForce?.name === TimeInForceOptions.IOC;
 
 export const isTakeProfitOrder = (order: SubaccountOrder) =>
   [AbacusOrderType.takeProfitLimit, AbacusOrderType.takeProfitMarket].some(

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -12,7 +12,9 @@ import {
   type OrderStatus,
   type PerpetualMarket,
 } from '@/constants/abacus';
+
 import { STRING_KEYS } from '@/constants/localization';
+import { TimeInForceOptions } from '@/constants/trade';
 
 import { IconName } from '@/components/Icon';
 
@@ -86,6 +88,20 @@ export const isMarketOrderType = (type?: AbacusOrderTypes) =>
     AbacusOrderType.takeProfitMarket,
     AbacusOrderType.trailingStop,
   ].some(({ ordinal }) => ordinal === type.ordinal);
+
+export const isStopLossOrder = (order: SubaccountOrder) =>
+  [AbacusOrderType.stopLimit, AbacusOrderType.stopMarket].some(
+    ({ ordinal }) => ordinal === order.type.ordinal
+  ) &&
+  order.reduceOnly &&
+  order.timeInForce?.name === TimeInForceOptions.IOC; // is it possible for reduceONly + size > what we have
+
+export const isTakeProfitOrder = (order: SubaccountOrder) =>
+  [AbacusOrderType.takeProfitLimit, AbacusOrderType.takeProfitMarket].some(
+    ({ ordinal }) => ordinal === order.type.ordinal
+  ) &&
+  order.reduceOnly &&
+  order.timeInForce?.name === TimeInForceOptions.IOC;
 
 export const relativeTimeString = ({
   timeInMs,

--- a/src/pages/portfolio/Positions.tsx
+++ b/src/pages/portfolio/Positions.tsx
@@ -10,13 +10,15 @@ import { ContentSectionHeader } from '@/components/ContentSectionHeader';
 
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
-import { calculateShouldRenderActionsInPositionsTable } from '@/state/accountCalculators';
+import { calculateShouldRenderActionsInPositionsTable, calculateShouldRenderTriggersInPositionsTable} from '@/state/accountCalculators';
 
 import { isTruthy } from '@/lib/isTruthy';
 
 export const Positions = () => {
   const stringGetter = useStringGetter();
   const { isTablet, isNotTablet } = useBreakpoints();
+
+  const shouldRenderTriggers = useSelector(calculateShouldRenderTriggersInPositionsTable);
   const shouldRenderActions = useSelector(calculateShouldRenderActionsInPositionsTable);
 
   return (
@@ -40,6 +42,7 @@ export const Positions = () => {
                 PositionsTableColumnKey.UnrealizedPnl,
                 PositionsTableColumnKey.RealizedPnl,
                 PositionsTableColumnKey.AverageOpenAndClose,
+                shouldRenderTriggers && PositionsTableColumnKey.Triggers,
                 shouldRenderActions && PositionsTableColumnKey.Actions
               ].filter(isTruthy)
         }

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -22,6 +22,7 @@ import {
   calculateHasUncommittedOrders,
   calculateIsAccountViewOnly,
   calculateShouldRenderActionsInPositionsTable,
+  calculateShouldRenderTriggersInPositionsTable,
 } from '@/state/accountCalculators';
 import {
   getCurrentMarketTradeInfoNumbers,
@@ -68,6 +69,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
   const hasUnseenOrderUpdates = useSelector(getHasUnseenOrderUpdates);
   const hasUnseenFillUpdates = useSelector(getHasUnseenFillUpdates);
   const isAccountViewOnly = useSelector(calculateIsAccountViewOnly);
+  const shouldRenderTriggers = useSelector(calculateShouldRenderTriggersInPositionsTable);
   const shouldRenderActions = useSelector(calculateShouldRenderActionsInPositionsTable);
   const isWaitingForOrderToIndex = useSelector(calculateHasUncommittedOrders);
   const showCurrentMarket = isTablet || view === PanelView.CurrentMarket;
@@ -108,7 +110,8 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                     PositionsTableColumnKey.UnrealizedPnl,
                     PositionsTableColumnKey.RealizedPnl,
                     PositionsTableColumnKey.AverageOpenAndClose,
-                   shouldRenderActions && PositionsTableColumnKey.Actions,
+                    shouldRenderTriggers && PositionsTableColumnKey.Triggers,
+                    shouldRenderActions && PositionsTableColumnKey.Actions,
                   ].filter(isTruthy)
             }
             onNavigate={() => setView(PanelView.CurrentMarket)}

--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -88,6 +88,14 @@ export const calculateIsAccountLoading = createSelector(
 );
 
 /**
+ * @description calculate whether positions table should render triggers column
+ */
+export const calculateShouldRenderTriggersInPositionsTable = createSelector(
+  [calculateIsAccountViewOnly],
+  (isAccountViewOnly: boolean) => !isAccountViewOnly && testFlags.configureSlTpFromPositionsTable
+);
+
+/**
  * @description calculate whether positions table should render actions column
  */
 export const calculateShouldRenderActionsInPositionsTable = createSelector(

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -103,14 +103,25 @@ export const getSubaccountUnclearedOrders = createSelector(
 
 /**
  * @param state
- * @returns list of orders that are in the open status
+ * @returns list of orders that have not been filled or cancelled
  */
 export const getSubaccountOpenOrders = createSelector([getSubaccountOrders], (orders) =>
+  orders?.filter(
+    (order) =>
+      order.status !== AbacusOrderStatus.filled && order.status !== AbacusOrderStatus.cancelled
+  )
+);
+
+/**
+ * @param state
+ * @returns list of orders that are in the open status
+ */
+export const getSubaccountOpenStatusOrders = createSelector([getSubaccountOrders], (orders) =>
   orders?.filter((order) => order.status === AbacusOrderStatus.open)
 );
 
-export const getSubaccountOpenOrdersBySideAndPrice = createSelector(
-  [getSubaccountOpenOrders],
+export const getSubaccountOpenStatusOrdersBySideAndPrice = createSelector(
+  [getSubaccountOpenStatusOrders],
   (openOrders = []) => {
     const ordersBySide: Partial<Record<OrderSide, Record<number, SubaccountOrder>>> = {};
     openOrders.forEach((order) => {

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -3,6 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 export const GlobalStyle = createGlobalStyle`
   :root {
     --color-white: ${({ theme }) => theme.white};
+    --color-black: ${({ theme }) => theme.black};
     --color-green: ${({ theme }) => theme.green};
     --color-red: ${({ theme }) => theme.red};
 

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -4,6 +4,7 @@ import { BrightnessFilterToken, ColorToken, OpacityToken } from '@/constants/sty
 import { generateFadedColorVariant } from '@/lib/styles';
 
 const ClassicThemeBase: ThemeColorBase = {
+  black: ColorToken.Black,
   white: ColorToken.White,
   green: ColorToken.Green1,
   red: ColorToken.Red2,
@@ -64,6 +65,7 @@ const ClassicThemeBase: ThemeColorBase = {
 };
 
 const DarkThemeBase: ThemeColorBase = {
+  black: ColorToken.Black,
   white: ColorToken.White,
   green: ColorToken.Green0,
   red: ColorToken.Red0,
@@ -124,6 +126,7 @@ const DarkThemeBase: ThemeColorBase = {
 };
 
 const LightThemeBase: ThemeColorBase = {
+  black: ColorToken.Black,
   white: ColorToken.White,
   green: ColorToken.Green2,
   red: ColorToken.Red1,

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -20,7 +20,7 @@ import { type CustomRowConfig, TableRow } from '@/components/Table';
 import { WithTooltip } from '@/components/WithTooltip';
 
 import { calculateCanViewAccount } from '@/state/accountCalculators';
-import { getSubaccountOpenOrdersBySideAndPrice } from '@/state/accountSelectors';
+import { getSubaccountOpenStatusOrdersBySideAndPrice } from '@/state/accountSelectors';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
 import { getCurrentInput } from '@/state/inputsSelectors';
@@ -51,7 +51,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
   const orderbook = useSelector(getCurrentMarketOrderbook, shallowEqual);
 
   const openOrdersBySideAndPrice =
-    useSelector(getSubaccountOpenOrdersBySideAndPrice, shallowEqual) || {};
+    useSelector(getSubaccountOpenStatusOrdersBySideAndPrice, shallowEqual) || {};
 
   return useMemo(() => {
     const asks = (orderbook?.asks?.toArray() ?? [])

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -9,6 +9,7 @@ import {
   type Nullable,
   type SubaccountPosition,
   POSITION_SIDES,
+  SubaccountOrder,
 } from '@/constants/abacus';
 import { StringGetterFunction, STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
@@ -324,8 +325,16 @@ export const PositionsTable = ({
   const openPositions = useSelector(getExistingOpenPositions, shallowEqual) || [];
   const openOrders = useSelector(getSubaccountOpenOrders, shallowEqual) || [];
 
-  const stopLossOrders = openOrders.filter(isStopLossOrder); 
-  const takeProfitOrders = openOrders.filter(isTakeProfitOrder);
+  const stopLossOrders: SubaccountOrder[] = [];
+  const takeProfitOrders: SubaccountOrder[] = [];
+
+  openOrders.map((order: SubaccountOrder) => {
+    if (isStopLossOrder(order)) {
+      stopLossOrders.push(order);
+    } else if (isTakeProfitOrder(order)) {
+      takeProfitOrders.push(order);
+    }
+  });
 
   const positionsData = openPositions.map((position: SubaccountPosition) => ({
     tickSizeDecimals: perpetualMarkets?.[position.id]?.configs?.tickSizeDecimals || USD_DECIMALS,
@@ -334,7 +343,7 @@ export const PositionsTable = ({
     stopLossOrders: stopLossOrders.filter((order) => order.marketId === position.id),
     takeProfitOrders: takeProfitOrders.filter((order) => order.marketId === position.id),
     ...position,
-  })) as PositionTableRow[];
+  }));
 
   return (
     <Styled.Table

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import styled, { type AnyStyledComponent } from 'styled-components';
 
 import {
+  AbacusOrderType,
   type Asset,
   type Nullable,
   type SubaccountPosition,
@@ -29,13 +30,18 @@ import { TableCell } from '@/components/Table/TableCell';
 import { TagSize } from '@/components/Tag';
 
 import { calculateIsAccountViewOnly } from '@/state/accountCalculators';
-import { getExistingOpenPositions } from '@/state/accountSelectors';
+import { getExistingOpenPositions, getSubaccountOpenOrders } from '@/state/accountSelectors';
 import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
+import { isStopLossOrder, isTakeProfitOrder } from '@/lib/orders';
 
 import { PositionsActionsCell } from './PositionsTable/PositionsActionsCell';
+import {
+  type PositionTableConditionalOrder,
+  PositionsTriggersCell,
+} from './PositionsTable/PositionsTriggersCell';
 
 export enum PositionsTableColumnKey {
   Details = 'Details',
@@ -50,6 +56,7 @@ export enum PositionsTableColumnKey {
   UnrealizedPnl = 'UnrealizedPnl',
   RealizedPnl = 'RealizedPnl',
   AverageOpenAndClose = 'AverageOpenAndClose',
+  Triggers = 'Triggers',
   Actions = 'Actions',
 }
 
@@ -57,6 +64,8 @@ type PositionTableRow = {
   asset: Asset;
   oraclePrice: Nullable<number>;
   tickSizeDecimals: number;
+  stopLossOrders: PositionTableConditionalOrder[];
+  takeProfitOrders: PositionTableConditionalOrder[];
 } & SubaccountPosition;
 
 const getPositionsTableColumnDef = ({
@@ -259,6 +268,21 @@ const getPositionsTableColumnDef = ({
           </TableCell>
         ),
       },
+      [PositionsTableColumnKey.Triggers]: {
+        columnKey: 'triggers',
+        label: stringGetter({ key: STRING_KEYS.TRIGGERS }),
+        isActionable: true,
+        allowsSorting: false,
+        hideOnBreakpoint: MediaQueryKeys.isTablet,
+        renderCell: ({ size, stopLossOrders, takeProfitOrders }) => (
+          <PositionsTriggersCell
+            stopLossOrders={stopLossOrders}
+            takeProfitOrders={takeProfitOrders}
+            positionSize={size?.current}
+            isDisabled={isAccountViewOnly}
+          />
+        ),
+      },
       [PositionsTableColumnKey.Actions]: {
         columnKey: 'actions',
         label: stringGetter({ key: STRING_KEYS.ACTION }), // TODO: CT-639
@@ -298,13 +322,21 @@ export const PositionsTable = ({
   const perpetualMarkets = useSelector(getPerpetualMarkets, shallowEqual) || {};
   const assets = useSelector(getAssets, shallowEqual) || {};
   const openPositions = useSelector(getExistingOpenPositions, shallowEqual) || [];
+  const openOrders = useSelector(getSubaccountOpenOrders, shallowEqual) || [];
+
+  const stopLossOrders = openOrders.filter(isStopLossOrder); //xcc check to make sure we don't count filled / cancelled orders
+  const takeProfitOrders = openOrders.filter(isTakeProfitOrder);
+
+  console.log('Xcxc sl', stopLossOrders, takeProfitOrders, openPositions);
 
   const positionsData = openPositions.map((position: SubaccountPosition) => ({
     tickSizeDecimals: perpetualMarkets?.[position.id]?.configs?.tickSizeDecimals || USD_DECIMALS,
     asset: assets?.[position.assetId],
     oraclePrice: perpetualMarkets?.[position.id]?.oraclePrice,
+    stopLossOrders: stopLossOrders.filter((order) => order.marketId === position.id),
+    takeProfitOrders: takeProfitOrders.filter((order) => order.marketId === position.id),
     ...position,
-  })) as PositionTableRow[];
+  })) as PositionTableRow[]; //xcxc
 
   return (
     <Styled.Table

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -324,10 +324,8 @@ export const PositionsTable = ({
   const openPositions = useSelector(getExistingOpenPositions, shallowEqual) || [];
   const openOrders = useSelector(getSubaccountOpenOrders, shallowEqual) || [];
 
-  const stopLossOrders = openOrders.filter(isStopLossOrder); //xcc check to make sure we don't count filled / cancelled orders
+  const stopLossOrders = openOrders.filter(isStopLossOrder); 
   const takeProfitOrders = openOrders.filter(isTakeProfitOrder);
-
-  console.log('Xcxc sl', stopLossOrders, takeProfitOrders, openPositions);
 
   const positionsData = openPositions.map((position: SubaccountPosition) => ({
     tickSizeDecimals: perpetualMarkets?.[position.id]?.configs?.tickSizeDecimals || USD_DECIMALS,
@@ -336,7 +334,7 @@ export const PositionsTable = ({
     stopLossOrders: stopLossOrders.filter((order) => order.marketId === position.id),
     takeProfitOrders: takeProfitOrders.filter((order) => order.marketId === position.id),
     ...position,
-  })) as PositionTableRow[]; //xcxc
+  })) as PositionTableRow[];
 
   return (
     <Styled.Table

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import styled, { type AnyStyledComponent } from 'styled-components';
 
 import {
-  AbacusOrderType,
   type Asset,
   type Nullable,
   type SubaccountPosition,

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -6,9 +6,9 @@ import styled, { type AnyStyledComponent } from 'styled-components';
 import {
   type Asset,
   type Nullable,
+  type SubaccountOrder,
   type SubaccountPosition,
   POSITION_SIDES,
-  SubaccountOrder,
 } from '@/constants/abacus';
 import { StringGetterFunction, STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -1,6 +1,6 @@
 import styled, { type AnyStyledComponent, css } from 'styled-components';
 
-import { AbacusOrderType, AbacusOrderTypes } from '@/constants/abacus';
+import { AbacusOrderTypes, Nullable } from '@/constants/abacus';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 
@@ -17,7 +17,7 @@ import { isMarketOrderType } from '@/lib/orders';
 export type PositionTableConditionalOrder = {
   price: number;
   size: number;
-  triggerPrice: number;
+  triggerPrice: Nullable<number>;
   type: AbacusOrderTypes;
 };
 
@@ -32,11 +32,13 @@ export const PositionsTriggersCell = ({
   stopLossOrders,
   takeProfitOrders,
   positionSize,
-  isDisabled, // TODO: CT-656 Disable onMultipleOrdersClick behavior when isDisabled
+  isDisabled, // TODO: CT-656 Disable onViewOrdersClick behavior when isDisabled
 }: ElementProps) => {
   const stringGetter = useStringGetter();
 
-  const onMultipleOrdersClick = () => {};
+  const onViewOrdersClick = () => {
+    // TODO: CT-655
+  };
 
   const renderOutput = ({
     label,
@@ -53,7 +55,7 @@ export const PositionsTriggersCell = ({
         type={ButtonType.Link}
         action={ButtonAction.Navigation}
         size={ButtonSize.XSmall}
-        onClick={onMultipleOrdersClick}
+        onClick={onViewOrdersClick}
       >
         {stringGetter({ key: STRING_KEYS.VIEW_ORDERS })}
         {<Icon iconName={IconName.Arrow} />}
@@ -105,11 +107,13 @@ const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.Cell = styled.div`
   ${layoutMixins.column}
-  gap: 0.5ch;
+  gap: 0.25em;
 `;
 
 Styled.Row = styled.span`
   ${layoutMixins.inlineRow}
+
+  --item-height: 1.25rem;
 `;
 
 Styled.Label = styled.div<{ warning?: boolean }>`
@@ -118,7 +122,7 @@ Styled.Label = styled.div<{ warning?: boolean }>`
   border-radius: 0.5em;
   display: flex;
   font: var(--font-tiny-book);
-  height: 1.25rem;
+  height: var(--item-height);
   padding: 0 0.25rem;
 
   ${({ warning }) =>
@@ -134,6 +138,6 @@ Styled.Output = styled(Output)`
 `;
 
 Styled.Button = styled(Button)`
-  --button-height: 1.25rem;
+  --button-height: var(--item-height);
   --button-padding: 0;
 `;

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -70,7 +70,9 @@ export const PositionsTriggersCell = ({
           {triggerLabel()} <Styled.Output type={OutputType.Fiat} value={null} />
         </>
       );
-    } else if (orders.length === 1) {
+    }
+
+    if (orders.length === 1) {
       const { price, size, triggerPrice, timeInForce, type } = orders[0];
 
       const isPartial = !!(positionSize && Math.abs(size) < Math.abs(positionSize));
@@ -78,26 +80,23 @@ export const PositionsTriggersCell = ({
         timeInForce?.name === TimeInForceOptions.IOC &&
         (isMarketOrderType(type) || price === triggerPrice);
 
-      return shouldRenderValue ? (
-        <>
-          {triggerLabel(isPartial)}
-          <Styled.Output type={OutputType.Fiat} value={triggerPrice} />
-          {/* // TODO: CT-654 Update styling + confirm logic for partial positions */}
-        </>
-      ) : (
-        <>
-          {triggerLabel()}
-          {viewOrdersButton}
-        </>
-      );
-    } else {
-      return (
-        <>
-          {triggerLabel()}
-          {viewOrdersButton}
-        </>
-      );
+      if (shouldRenderValue) {
+        return (
+          <>
+            {triggerLabel(isPartial)}
+            <Styled.Output type={OutputType.Fiat} value={triggerPrice} />
+            {/* // TODO: CT-654 Update styling + confirm logic for partial positions */}
+          </>
+        );
+      }
     }
+    
+    return (
+      <>
+        {triggerLabel()}
+        {viewOrdersButton}
+      </>
+    );
   };
   return (
     <Styled.Cell>

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -1,0 +1,123 @@
+import styled, { type AnyStyledComponent, css } from 'styled-components';
+
+import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { Button } from '@/components/Button';
+import { Icon, IconName } from '@/components/Icon';
+import { Output, OutputType } from '@/components/Output';
+
+import { useStringGetter } from '@/hooks';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+export type PositionTableConditionalOrder = {
+  size: number;
+  triggerPrice: number;
+};
+
+type ElementProps = {
+  stopLossOrders: PositionTableConditionalOrder[];
+  takeProfitOrders: PositionTableConditionalOrder[];
+  positionSize?: number;
+  isDisabled?: boolean;
+};
+
+export const PositionsTriggersCell = ({
+  stopLossOrders,
+  takeProfitOrders,
+  positionSize,
+  isDisabled,
+}: ElementProps) => {
+  const stringGetter = useStringGetter();
+
+  const onMultipleOrdersClick = () => {};
+
+  const renderOutput = ({
+    label,
+    orders,
+  }: {
+    label: string;
+    orders: PositionTableConditionalOrder[];
+  }) => {
+    if (orders.length === 0) {
+      return (
+        <>
+          <Styled.Label>{label}</Styled.Label> <Styled.Output type={OutputType.Fiat} value={null} />
+        </>
+      );
+    } else if (orders.length === 1) {
+      const { triggerPrice, size } = orders[0];
+      console.log(Math.abs(size), positionSize && Math.abs(positionSize))
+      const isPartial = positionSize && Math.abs(size) < Math.abs(positionSize);
+
+      return (
+        <>
+          <Styled.Label warning={isPartial}>{label}</Styled.Label>
+          <Styled.Output type={OutputType.Fiat} value={triggerPrice} />
+        </>
+      ); //xcxc should i use limit or trigger price?
+    } else {
+      return (
+        <>
+          <Styled.Label>{label}</Styled.Label>
+          <Styled.Button
+            type={ButtonType.Link}
+            action={ButtonAction.Navigation}
+            size={ButtonSize.XSmall}
+            onClick={onMultipleOrdersClick}
+          >
+            {stringGetter({ key: STRING_KEYS.VIEW_MORE })}
+            {<Icon iconName={IconName.Arrow} />}
+          </Styled.Button>
+        </>
+      );
+    }
+  };
+  return (
+    <Styled.Cell>
+      <Styled.Row>
+        {renderOutput({label: 'TP', orders: takeProfitOrders})}
+      </Styled.Row>
+      <Styled.Row>
+        {renderOutput({label: 'SL', orders: stopLossOrders})}
+      </Styled.Row>
+    </Styled.Cell>
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Cell = styled.div`
+  ${layoutMixins.column}
+  gap: 0.5ch;
+`;
+
+Styled.Row = styled.span`
+  ${layoutMixins.inlineRow}
+`;
+
+Styled.Label = styled.div<{ warning?: boolean }>`
+  align-items: center;
+  border: solid var(--border-width) var(--color-border);
+  border-radius: 0.5em;
+  display: flex;
+  font: var(--font-tiny-book);
+  height: 1.25rem;
+  padding: 0 0.25rem;
+
+  ${({ warning }) =>
+    warning &&
+    css`
+      background-color: var(--color-warning);
+      color: var(--color-black);
+    `}
+`;
+
+Styled.Output = styled(Output)`
+  font: var(--font-mini-medium);
+`;
+
+Styled.Button = styled(Button)`
+  --button-padding: 0;
+`;

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -1,10 +1,6 @@
 import styled, { type AnyStyledComponent, css } from 'styled-components';
 
-import {
-  OrderTimeInForce,
-} from '@dydxprotocol/v4-client-js';
-
-import { AbacusOrderTypes, Nullable } from '@/constants/abacus';
+import { AbacusOrderTimeInForces, AbacusOrderTypes, Nullable } from '@/constants/abacus';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { TimeInForceOptions } from '@/constants/trade';
@@ -23,7 +19,7 @@ export type PositionTableConditionalOrder = {
   price: number;
   size: number;
   triggerPrice: Nullable<number>;
-  timeInForce: OrderTimeInForce;
+  timeInForce: Nullable<AbacusOrderTimeInForces>;
   type: AbacusOrderTypes;
 };
 
@@ -78,7 +74,9 @@ export const PositionsTriggersCell = ({
       const { price, size, triggerPrice, timeInForce, type } = orders[0];
 
       const isPartial = !!(positionSize && Math.abs(size) < Math.abs(positionSize));
-      const shouldRenderValue = timeInForce.name === TimeInForceOptions.IOC && (isMarketOrderType(type) || price === triggerPrice);
+      const shouldRenderValue =
+        timeInForce?.name === TimeInForceOptions.IOC &&
+        (isMarketOrderType(type) || price === triggerPrice);
 
       return shouldRenderValue ? (
         <>

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -1,8 +1,13 @@
 import styled, { type AnyStyledComponent, css } from 'styled-components';
 
+import {
+  OrderTimeInForce,
+} from '@dydxprotocol/v4-client-js';
+
 import { AbacusOrderTypes, Nullable } from '@/constants/abacus';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
+import { TimeInForceOptions } from '@/constants/trade';
 
 import { useStringGetter } from '@/hooks';
 
@@ -18,6 +23,7 @@ export type PositionTableConditionalOrder = {
   price: number;
   size: number;
   triggerPrice: Nullable<number>;
+  timeInForce: OrderTimeInForce;
   type: AbacusOrderTypes;
 };
 
@@ -69,10 +75,10 @@ export const PositionsTriggersCell = ({
         </>
       );
     } else if (orders.length === 1) {
-      const { price, size, triggerPrice, type } = orders[0];
+      const { price, size, triggerPrice, timeInForce, type } = orders[0];
 
       const isPartial = !!(positionSize && Math.abs(size) < Math.abs(positionSize));
-      const shouldRenderValue = isMarketOrderType(type) || price === triggerPrice;
+      const shouldRenderValue = timeInForce.name === TimeInForceOptions.IOC && (isMarketOrderType(type) || price === triggerPrice);
 
       return shouldRenderValue ? (
         <>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
1. Create the skeleton for the `Triggers` column in SL/TP (flagged behind `sltp`)
    1. Doesn't implement a lot of the functionality yet, partial states also not implemented
    2. Does implement logic for finding any SL/TP orders (if they exist) for a position 

<!-- Overall purpose of the PR -->
| Classic | Dark | Light |
| ----- | ----- | ----- |
| <img width="1295" alt="Screenshot 2024-03-04 at 2 11 49 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/7dea0641-6f46-4029-9fe6-8eda66baed45"> | <img width="1306" alt="Screenshot 2024-03-04 at 2 12 18 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/7b68ae50-d02b-410f-8ea6-2b34868d883e"> | <img width="1305" alt="Screenshot 2024-03-04 at 2 12 29 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/bab484b0-9d43-44f9-963e-a8e863ba3929"> |


---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `tables/PositionsTable`
  * Add `PositionsTableColumnKey.Triggers` type
  * Add render function for `Triggers` column

* `portfolio/Positions.tsx`
  * Add logic to conditionally render triggers column
  
* `trade/HorizontalPanel.tsx`
  * Add logic to conditionally render triggers column in positions table

* `tables/Orderbook.tsx`
  * small change due to function rename in `accountSelectors`
  
## Components

* New: `PositionsTriggersCell`
  * mocks loosely shown [here](https://www.figma.com/file/fMQodZKzn9B5aZTN5G0fLJ/dYdX-%E2%80%BA-Desktop?type=design&node-id=24785-424&mode=design&t=CXnbXWjBM5GFmfST-0)
  * Decisions made offline w/ design + product:
    * TP to be rendered above SL
    * `Multiple` to be replaced with `View Orders`
    * `View Orders` should be rendered if
      * A user has multiple orders that qualify as SL (or TP); or
      * A user has a SL limit or TP limit order (where trigger price != price)

* `Table/TableCell.tsx`
  * delete unnecessary import

## Styles/Mixins

* `styles/themes`, `styles/globalStyle`
  * add `black` color token for each theme

## Constants/Types

* `constants/styles.colors.ts`
  * Add `black` color token

## Functions

* `lib/orders.ts`
  * Add helper functions to determine if an existing order qualifies as stop loss / take profit
    * From discussions with product, should be if IOC, RO, StopLimit/TakeProfit

## State

* `state/accountCalculators`
  * `calculateShouldRenderTriggersInPositionsTable`: new function with logic to determine if should render `triggers` column. 

* `state/accountSelectors`
  * rename `getSubaccountOpenOrdersBySideAndPrice` -> `getSubaccountOpenStatusOrdersBySideAndPrice`
  * create new `getSubaccountOpenOrdersBySideAndPrice` which filters out filled + cancelled orders (used to find stop loss + take profit orders)
  
## Packages

* `package.json`
  * Update `v4-localization` (1.1.36 -> 1.1.39) for new translations

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
