### PR TITLE
Adam/ote 207 user local storage exceeding limits

### DIFF
--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -118,7 +118,11 @@ const useNotificationsContext = () => {
     (notification: Notification, status: NotificationStatus) => {
       notification.status = status;
       notification.timestamps[notification.status] = Date.now();
-      setNotifications({ ...notifications, [getKey(notification)]: notification });
+      // Don't save AbacusGenerated notifcations to LocalStorage, these are triggered by
+      // Orders, Fills, Trading Rewards etc. and we don't need to know if they've already been seen
+      if (notification.type != NotificationType.AbacusGenerated) {
+        setNotifications({ ...notifications, [getKey(notification)]: notification });
+      }
     },
     [notifications, getKey]
   );

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -67,6 +67,16 @@ const useNotificationsContext = () => {
     setNotificationsLastUpdated(Date.now());
   }, [notifications]);
 
+  const clearAbacusGeneratedNotifications = useCallback((notifications: Notifications) => {
+    const newNotifications:Notifications = {}
+    for (const [key, value] of Object.entries(notifications)) {
+      if (value.type != NotificationType.AbacusGenerated) {
+        newNotifications[getKey(value)] = value
+      }
+    }
+    setNotifications(newNotifications)
+  }, [notifications])
+
   const getKey = useCallback(
     <T extends string | number>(notification: Pick<Notification<T>, 'type' | 'id'>) =>
       `${notification.type}/${notification.id}`,
@@ -85,6 +95,11 @@ const useNotificationsContext = () => {
 
   // Check for version changes
   useEffect(() => {
+    const MAX_NOTIFICATIONS = 50;
+    if (Object.keys(notifications).length > MAX_NOTIFICATIONS) {
+      clearAbacusGeneratedNotifications(notifications)
+    }
+
     if (
       notificationPreferences.version !==
       LOCAL_STORAGE_VERSIONS[LocalStorageKey.NotificationPreferences]


### PR DESCRIPTION
Addresses an issue where some API traders end up with full local storage as we never clear saved notifications. 

This PR does two things: 
1) Doesn't save AbacusGenerated notifications. I can't think of the use case for saving these but might be missing something.
2) Clears the local storage of any users with >50 AbacusGenerated notifications

