### PR TITLE
place/cancel stateful order reliability with transaction queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.4.15",
+    "@dydxprotocol/v4-abacus": "^1.4.14",
     "@dydxprotocol/v4-client-js": "^1.0.24",
     "@dydxprotocol/v4-localization": "^1.1.45",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.4.13",
+    "@dydxprotocol/v4-abacus": "^1.4.15",
     "@dydxprotocol/v4-client-js": "^1.0.24",
     "@dydxprotocol/v4-localization": "^1.1.45",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "^1.4.13",
-    "@dydxprotocol/v4-client-js": "^1.0.20",
+    "@dydxprotocol/v4-client-js": "^1.0.24",
     "@dydxprotocol/v4-localization": "^1.1.45",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: ^1.4.13
     version: 1.4.13
   '@dydxprotocol/v4-client-js':
-    specifier: ^1.0.20
-    version: 1.0.20
+    specifier: ^1.0.21
+    version: 1.0.21
   '@dydxprotocol/v4-localization':
     specifier: ^1.1.45
     version: 1.1.45
@@ -1515,8 +1515,8 @@ packages:
     resolution: {integrity: sha512-+Avd0TvbdQ4OvwwMOpQgLMW0+yQ87FTYTWHZIkmsMsBH5yoYHG751i2bsGp0z+VUKMScCpcibUIGFkgTqLHIlA==}
     dev: false
 
-  /@dydxprotocol/v4-client-js@1.0.20:
-    resolution: {integrity: sha512-dXKW2NC1XlVVIRKvHWVDofLZSCPTJAaRY5eXzxH5CcXpnl2kdXorr7ykqWZxW0jHFPWWvRSJtUDqZN1qFrEe/w==}
+  /@dydxprotocol/v4-client-js@1.0.21:
+    resolution: {integrity: sha512-ZdlXs9DkdsyoE8ajOnZPYuOo7XDlKB3XiO7POGnbv9ZHGV63R+sxypiL2bHv7CLgXKoAvbsFq+3XdGHp5cE9Ww==}
     dependencies:
       '@cosmjs/amino': 0.32.2
       '@cosmjs/encoding': 0.32.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.4.13
-    version: 1.4.13
+    specifier: file:/Users/aleka/Documents/dydx/v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz
+    version: file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.21
     version: 1.0.21
@@ -1509,10 +1509,6 @@ packages:
 
   /@cosmjs/utils@0.32.2:
     resolution: {integrity: sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q==}
-    dev: false
-
-  /@dydxprotocol/v4-abacus@1.4.13:
-    resolution: {integrity: sha512-+Avd0TvbdQ4OvwwMOpQgLMW0+yQ87FTYTWHZIkmsMsBH5yoYHG751i2bsGp0z+VUKMScCpcibUIGFkgTqLHIlA==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.21:
@@ -16556,3 +16552,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+  file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz:
+    resolution: {integrity: sha512-BJq3V2u9kapcVTBGG+CUsmK6dPS84omfDy66ESBsKNh/i0+XGeSr30U0aJxFvdzYMumXH+Q5YaHgImTf5gV1Yg==, tarball: file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz}
+    name: '@dydxprotocol/v4-abacus'
+    version: 1.4.13
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: file:/Users/aleka/Documents/dydx/v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz
     version: file:../v4-abacus/build/packages/js/dydxprotocol-v4-abacus-1.4.13.tgz
   '@dydxprotocol/v4-client-js':
-    specifier: ^1.0.21
-    version: 1.0.21
+    specifier: ^1.0.22
+    version: 1.0.25
   '@dydxprotocol/v4-localization':
     specifier: ^1.1.45
     version: 1.1.45
@@ -1511,8 +1511,8 @@ packages:
     resolution: {integrity: sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q==}
     dev: false
 
-  /@dydxprotocol/v4-client-js@1.0.21:
-    resolution: {integrity: sha512-ZdlXs9DkdsyoE8ajOnZPYuOo7XDlKB3XiO7POGnbv9ZHGV63R+sxypiL2bHv7CLgXKoAvbsFq+3XdGHp5cE9Ww==}
+  /@dydxprotocol/v4-client-js@1.0.25:
+    resolution: {integrity: sha512-WBJHq2asJExqgA2zQZL6H7DKx4golG96HANcUOtZDbe9RwhjZGPb7v9XMN3iBPBH4VJQSWrI6rSNRwxJ3H04Ww==}
     dependencies:
       '@cosmjs/amino': 0.32.2
       '@cosmjs/encoding': 0.32.2

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -42,8 +42,8 @@ import { openDialog } from '@/state/dialogs';
 import { StatefulOrderError } from '../errors';
 import { bytesToBigInt } from '../numbers';
 import { log } from '../telemetry';
-import TransactionQueue from '../transactionQueue';
 import { hashFromTx, getMintscanTxLink } from '../txUtils';
+import StatefulOrdersTransactionQueue from './statefulOrdersTransactionQueue';
 
 (BigInt.prototype as any).toJSON = function () {
   return this.toString();
@@ -55,12 +55,12 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
   private store: RootStore | undefined;
   private localWallet: LocalWallet | undefined;
   private nobleWallet: LocalWallet | undefined;
-  private transactionQueue: TransactionQueue;
+  private statefulOrdersTransactionQueue: StatefulOrdersTransactionQueue;
 
   constructor() {
     this.compositeClient = undefined;
     this.store = undefined;
-    this.transactionQueue = new TransactionQueue(
+    this.statefulOrdersTransactionQueue = new StatefulOrdersTransactionQueue(
       this.placeOrderTransaction.bind(this),
       this.cancelOrderTransaction.bind(this)
     );
@@ -517,7 +517,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
             const result = await this.placeOrderTransaction(params);
             callback(result);
           } else {
-            this.transactionQueue.enqueue({ type, payload: params, callback });
+            this.statefulOrdersTransactionQueue.enqueue({ type, payload: params, callback });
           }
 
           break;
@@ -527,7 +527,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
             const result = await this.cancelOrderTransaction(params);
             callback(result);
           } else {
-            this.transactionQueue.enqueue({ type, payload: params, callback });
+            this.statefulOrdersTransactionQueue.enqueue({ type, payload: params, callback });
           }
 
           break;

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -510,32 +510,24 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
 
       switch (type) {
         case TransactionType.PlaceOrder: {
-          const isLongTermOrder =
-            calculateOrderFlags(params.type, params.timeInForce) === OrderFlags.LONG_TERM;
+          const isShortTermOrder =
+            calculateOrderFlags(params.type, params.timeInForce) === OrderFlags.SHORT_TERM;
 
-          if (isLongTermOrder) {
-            this.transactionQueue.enqueue({
-              type,
-              payload: params,
-              callback,
-            });
-          } else {
+          if (isShortTermOrder) {
             const result = await this.placeOrderTransaction(params);
             callback(result);
+          } else {
+            this.transactionQueue.enqueue({ type, payload: params, callback });
           }
 
           break;
         }
         case TransactionType.CancelOrder: {
-          if (params.orderFlags === OrderFlags.LONG_TERM) {
-            this.transactionQueue.enqueue({
-              type,
-              payload: params,
-              callback,
-            });
-          } else {
+          if (params.orderFlags === OrderFlags.SHORT_TERM) {
             const result = await this.cancelOrderTransaction(params);
             callback(result);
+          } else {
+            this.transactionQueue.enqueue({ type, payload: params, callback });
           }
 
           break;

--- a/src/lib/transactionQueue.ts
+++ b/src/lib/transactionQueue.ts
@@ -1,0 +1,98 @@
+import Abacus from '@dydxprotocol/v4-abacus';
+
+import {
+  type HumanReadableCancelOrderPayload,
+  type HumanReadablePlaceOrderPayload,
+  type TransactionTypes,
+  TransactionType,
+} from '@/constants/abacus';
+
+interface TransactionParams {
+  type: TransactionTypes;
+  callback: (p0: Abacus.Nullable<string>) => void;
+}
+
+interface PlaceOrderParams extends TransactionParams {
+  payload: HumanReadablePlaceOrderPayload;
+}
+
+interface CancelOrderParams extends TransactionParams {
+  payload: HumanReadableCancelOrderPayload;
+}
+
+type AnyTransactionParams = PlaceOrderParams | CancelOrderParams;
+
+class TransactionQueue {
+  private queue: Array<{ params: AnyTransactionParams; status: string }>;
+  private isProcessing: boolean;
+
+  private placeOrder: (params: HumanReadablePlaceOrderPayload) => Promise<string>;
+  private cancelOrder: (params: HumanReadableCancelOrderPayload) => Promise<string>;
+
+  constructor(
+    placeOrder: (params: HumanReadablePlaceOrderPayload) => Promise<string>,
+    cancelOrder: (params: HumanReadableCancelOrderPayload) => Promise<string>
+  ) {
+    this.queue = [];
+    this.isProcessing = false;
+
+    this.placeOrder = placeOrder;
+    this.cancelOrder = cancelOrder;
+  }
+
+  enqueue(params: AnyTransactionParams): void {
+    this.queue.push({
+      params,
+      status: 'pending',
+    });
+    this.processQueue();
+  }
+
+
+  private dequeue(): void {
+    this.queue.shift();
+  }
+
+  private peek(): { params: AnyTransactionParams; status: string } | null {
+    return this.queue.length > 0 ? this.queue[0] : null;
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.isProcessing) return;
+
+    this.isProcessing = true;
+
+    while (this.queue.length > 0) {
+      const currentTransaction = this.peek();
+
+      if (currentTransaction && currentTransaction.status === 'pending') {
+        try {
+          const result = await this.sendTransaction(currentTransaction.params);
+          currentTransaction.params.callback(result);
+          currentTransaction.status = 'sent';
+        } catch (error) {
+          // Expected errors are handled within the transaction functions
+          // log
+          currentTransaction.status = 'failed';
+        } finally {
+          this.dequeue();
+        }
+      }
+    }
+
+    this.isProcessing = false;
+  }
+
+  private async sendTransaction(params: AnyTransactionParams): Promise<any> {
+    switch (params.type) {
+      case TransactionType.PlaceOrder:
+        return this.placeOrder((params as PlaceOrderParams).payload);
+      case TransactionType.CancelOrder:
+        return this.cancelOrder((params as CancelOrderParams).payload);
+      default:
+        throw new Error('Unsupported transaction type');
+    }
+  }
+}
+
+export default TransactionQueue;


### PR DESCRIPTION
note: waiting for both [abacus](https://github.com/dydxprotocol/v4-abacus/pull/231) + [v4-clients](https://github.com/dydxprotocol/v4-clients/pull/127#issue-2171966488) change to be pushed

Context: Traders have encountered an issue where canceling long-term orders can be unreliable. Root cause appears to be broadcast errors related to sequence numbers when placing or canceling stateful orders in rapid succession.

To address this, I'm adding a transaction queue for placing and canceling stateful orders.
- `v4-clients` change: placing and canceling long term and conditional orders now default to use `Method.BroadcastTxCommit`. Thus the action will only complete after tx has been fully committed.
- transaction queue: stateful orders are processed sequentially without block UI interactions

Testing steps:
1. Cancel multiple stateful orders in quick succession - observe that they should all be eventually canceled (at least not fail with broadcast errors), instead of being stuck in loading state / no action.
2. Place and cancel multiple orders in quick succession, can be either short term, long term, or conditional. They should not fail with broadcast errors.
