### PR TITLE
feat(positiontable): add column for margin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "explorer.sortOrder": "mixed"
+    "explorer.sortOrder": "mixed",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "^1.4.13",
     "@dydxprotocol/v4-client-js": "^1.0.20",
-    "@dydxprotocol/v4-localization": "^1.1.42",
+    "@dydxprotocol/v4-localization": "^1.1.45",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.0.20
     version: 1.0.20
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.42
-    version: 1.1.42
+    specifier: ^1.1.45
+    version: 1.1.45
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1373,8 +1373,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.42:
-    resolution: {integrity: sha512-sFfDkNatG+6UZVsNxD/8KLA4BQrmBVIqJQP4VwcrkoiPUfZEdQ6eT3s6MfDdSTJmcoKJod3BoMqGAkdCIIpnOg==}
+  /@dydxprotocol/v4-localization@1.1.45:
+    resolution: {integrity: sha512-fVF2Av2J3/LMlKe+Jr3ApCq4SwAnTNIz8m+HA9nOYRRaxhPTd6Xla+hDBDskK+mcYAEmQMSEdeMcRW+xxHHZAg==}
     dev: false
 
   /@dydxprotocol/v4-proto@3.0.0:

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -43,6 +43,10 @@ class TestFlags {
   get configureSlTpFromPositionsTable() {
     return !!this.queryParams.sltp;
   }
+
+  get isolatedMargin() {
+    return !!this.queryParams.isolatedmargin;
+  }
 }
 
 export const testFlags = new TestFlags();

--- a/src/pages/portfolio/Positions.tsx
+++ b/src/pages/portfolio/Positions.tsx
@@ -7,12 +7,15 @@ import { useBreakpoints, useStringGetter } from '@/hooks';
 
 import { AttachedExpandingSection } from '@/components/ContentSection';
 import { ContentSectionHeader } from '@/components/ContentSectionHeader';
-
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
-import { calculateShouldRenderActionsInPositionsTable, calculateShouldRenderTriggersInPositionsTable} from '@/state/accountCalculators';
+import {
+  calculateShouldRenderActionsInPositionsTable,
+  calculateShouldRenderTriggersInPositionsTable,
+} from '@/state/accountCalculators';
 
 import { isTruthy } from '@/lib/isTruthy';
+import { testFlags } from '@/lib/testFlags';
 
 export const Positions = () => {
   const stringGetter = useStringGetter();
@@ -39,11 +42,12 @@ export const Positions = () => {
                 PositionsTableColumnKey.Size,
                 PositionsTableColumnKey.Leverage,
                 PositionsTableColumnKey.LiquidationAndOraclePrice,
+                testFlags.isolatedMargin && PositionsTableColumnKey.Margin,
                 PositionsTableColumnKey.UnrealizedPnl,
                 PositionsTableColumnKey.RealizedPnl,
                 PositionsTableColumnKey.AverageOpenAndClose,
                 shouldRenderTriggers && PositionsTableColumnKey.Triggers,
-                shouldRenderActions && PositionsTableColumnKey.Actions
+                shouldRenderActions && PositionsTableColumnKey.Actions,
               ].filter(isTruthy)
         }
         currentRoute={`${AppRoute.Portfolio}/${PortfolioRoute.Positions}`}

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -34,6 +34,7 @@ import { getCurrentMarketAssetId, getCurrentMarketId } from '@/state/perpetualsS
 
 import { isTruthy } from '@/lib/isTruthy';
 import { shortenNumberForDisplay } from '@/lib/numbers';
+import { testFlags } from '@/lib/testFlags';
 
 enum InfoSection {
   Position = 'Position',
@@ -107,7 +108,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                     PositionsTableColumnKey.Size,
                     PositionsTableColumnKey.Leverage,
                     PositionsTableColumnKey.LiquidationAndOraclePrice,
-                    PositionsTableColumnKey.Margin,
+                    testFlags.isolatedMargin && PositionsTableColumnKey.Margin,
                     PositionsTableColumnKey.UnrealizedPnl,
                     PositionsTableColumnKey.RealizedPnl,
                     PositionsTableColumnKey.AverageOpenAndClose,

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -107,6 +107,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                     PositionsTableColumnKey.Size,
                     PositionsTableColumnKey.Leverage,
                     PositionsTableColumnKey.LiquidationAndOraclePrice,
+                    PositionsTableColumnKey.Margin,
                     PositionsTableColumnKey.UnrealizedPnl,
                     PositionsTableColumnKey.RealizedPnl,
                     PositionsTableColumnKey.AverageOpenAndClose,

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -38,6 +38,7 @@ import { MustBigNumber } from '@/lib/numbers';
 import { isStopLossOrder, isTakeProfitOrder } from '@/lib/orders';
 
 import { PositionsActionsCell } from './PositionsTable/PositionsActionsCell';
+import { PositionsMarginCell } from './PositionsTable/PositionsMarginCell';
 import {
   type PositionTableConditionalOrder,
   PositionsTriggersCell,
@@ -53,6 +54,7 @@ export enum PositionsTableColumnKey {
   Size = 'Size',
   Leverage = 'Leverage',
   LiquidationAndOraclePrice = 'LiquidationAndOraclePrice',
+  Margin = 'Margin',
   UnrealizedPnl = 'UnrealizedPnl',
   RealizedPnl = 'RealizedPnl',
   AverageOpenAndClose = 'AverageOpenAndClose',
@@ -197,6 +199,16 @@ const getPositionsTableColumnDef = ({
         hideOnBreakpoint: MediaQueryKeys.isMobile,
         renderCell: ({ leverage }) => (
           <Output type={OutputType.Multiple} value={leverage?.current} showSign={ShowSign.None} />
+        ),
+      },
+      [PositionsTableColumnKey.Margin]: {
+        columnKey: 'margin',
+        getCellValue: (row) => row.leverage?.current,
+        label: stringGetter({ key: STRING_KEYS.MARGIN }),
+        hideOnBreakpoint: MediaQueryKeys.isMobile,
+        isActionable: true,
+        renderCell: ({ notionalTotal, adjustedMmf }) => (
+          <PositionsMarginCell notionalTotal={notionalTotal} adjustedMmf={adjustedMmf} />
         ),
       },
       [PositionsTableColumnKey.LiquidationAndOraclePrice]: {

--- a/src/views/tables/PositionsTable/PositionsMarginCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsMarginCell.tsx
@@ -2,7 +2,10 @@ import styled, { AnyStyledComponent } from 'styled-components';
 
 import { type SubaccountPosition } from '@/constants/abacus';
 import { ButtonShape } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
 import { USD_DECIMALS } from '@/constants/numbers';
+
+import { useStringGetter } from '@/hooks';
 
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
@@ -22,9 +25,14 @@ export const PositionsMarginCell = ({
   isDisabled,
   notionalTotal,
 }: PositionsMarginCellProps) => {
+  const stringGetter = useStringGetter();
   const notionalTotalBN = MustBigNumber(notionalTotal?.current);
   const adjustedMmfBN = MustBigNumber(adjustedMmf?.current);
   const margin = notionalTotalBN.times(adjustedMmfBN).toFixed(USD_DECIMALS);
+
+  const marginModeLabel = true
+    ? stringGetter({ key: STRING_KEYS.CROSS })
+    : stringGetter({ key: STRING_KEYS.ISOLATED });
 
   return (
     <TableCell
@@ -39,7 +47,7 @@ export const PositionsMarginCell = ({
       }
     >
       <Output type={OutputType.Fiat} value={margin} showSign={ShowSign.None} />
-      {true ? <span>Cross</span> : <span>Isolated</span>}
+      <span>{marginModeLabel}</span>
     </TableCell>
   );
 };

--- a/src/views/tables/PositionsTable/PositionsMarginCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsMarginCell.tsx
@@ -3,7 +3,6 @@ import styled, { AnyStyledComponent } from 'styled-components';
 import { type SubaccountPosition } from '@/constants/abacus';
 import { ButtonShape } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
-import { USD_DECIMALS } from '@/constants/numbers';
 
 import { useStringGetter } from '@/hooks';
 
@@ -28,7 +27,7 @@ export const PositionsMarginCell = ({
   const stringGetter = useStringGetter();
   const notionalTotalBN = MustBigNumber(notionalTotal?.current);
   const adjustedMmfBN = MustBigNumber(adjustedMmf?.current);
-  const margin = notionalTotalBN.times(adjustedMmfBN).toFixed(USD_DECIMALS);
+  const margin = notionalTotalBN.times(adjustedMmfBN);
 
   const marginModeLabel = true
     ? stringGetter({ key: STRING_KEYS.CROSS })

--- a/src/views/tables/PositionsTable/PositionsMarginCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsMarginCell.tsx
@@ -1,0 +1,54 @@
+import styled, { AnyStyledComponent } from 'styled-components';
+
+import { type SubaccountPosition } from '@/constants/abacus';
+import { ButtonShape } from '@/constants/buttons';
+import { USD_DECIMALS } from '@/constants/numbers';
+
+import { IconName } from '@/components/Icon';
+import { IconButton } from '@/components/IconButton';
+import { Output, OutputType, ShowSign } from '@/components/Output';
+import { TableCell } from '@/components/Table/TableCell';
+
+import { MustBigNumber } from '@/lib/numbers';
+
+type PositionsMarginCellProps = {
+  isDisabled?: boolean;
+  notionalTotal: SubaccountPosition['notionalTotal'];
+  adjustedMmf: SubaccountPosition['adjustedMmf'];
+};
+
+export const PositionsMarginCell = ({
+  adjustedMmf,
+  isDisabled,
+  notionalTotal,
+}: PositionsMarginCellProps) => {
+  const notionalTotalBN = MustBigNumber(notionalTotal?.current);
+  const adjustedMmfBN = MustBigNumber(adjustedMmf?.current);
+  const margin = notionalTotalBN.times(adjustedMmfBN).toFixed(USD_DECIMALS);
+
+  return (
+    <TableCell
+      stacked
+      slotRight={
+        <Styled.EditButton
+          key="edit-margin"
+          iconName={IconName.Pencil}
+          shape={ButtonShape.Square}
+          isDisabled={isDisabled}
+        />
+      }
+    >
+      <Output type={OutputType.Fiat} value={margin} showSign={ShowSign.None} />
+      {true ? <span>Cross</span> : <span>Isolated</span>}
+    </TableCell>
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.EditButton = styled(IconButton)`
+  svg {
+    width: 1.5em;
+    height: 1.5em;
+  }
+`;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1012" alt="Screen Shot 2024-03-06 at 10 37 52 AM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/c3e2b688-295e-44e9-8b0e-0445314ac671">

<!-- Overall purpose of the PR -->
https://linear.app/dydx/issue/TRA-90/add-margin-column-to-positionstable

Add column in the `<PositionsTable>` to display USDC margin. This will only be displayed with the `?isolatedmargin=1` query param.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<PositionsTable>`
  * Add `margin` column to column definitions

* `<HorizontalPanel>`
  * Add `margin` column based on query flag

## Components

* New: `<PositionsMarginCell>`
  * Add table cell that displays position's margin

## Functions

* `lib/testFlags`
  * add `isolatedmargin` query flag

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
