### PR TITLE
fix(tradeform): Change leverage buttons based on maxLeverage

### DIFF
--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -60,6 +60,8 @@ export const MarketLeverageInput = ({
     ? BIG_NUMBERS.ONE.div(initialMarginFraction)
     : MustBigNumber(10);
 
+  const leverageOptions = maxLeverage.lt(10) ? [1, 2, 3, 4, 5] : [1, 2, 3, 5, 10];
+
   const leveragePosition = postOrderLeverage ? newPositionSide : currentPositionSide;
 
   const getSignedLeverage = (newLeverage: string | number) => {
@@ -157,12 +159,10 @@ export const MarketLeverageInput = ({
       </Styled.InputContainer>
 
       <Styled.ToggleGroup
-        items={(maxLeverage.lt(10) ? [1, 2, 3, 4, 5] : [1, 2, 3, 5, 10]).map(
-          (leverageAmount: number) => ({
-            label: `${leverageAmount}×`,
-            value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
-          })
-        )}
+        items={leverageOptions.map((leverageAmount: number) => ({
+          label: `${leverageAmount}×`,
+          value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
+        }))}
         value={MustBigNumber(formattedLeverageValue).abs().toFixed(LEVERAGE_DECIMALS)} // sign agnostic
         onValueChange={updateLeverage}
         shape={ButtonShape.Rectangle}

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -157,10 +157,12 @@ export const MarketLeverageInput = ({
       </Styled.InputContainer>
 
       <Styled.ToggleGroup
-        items={[1, 2, 3, 5, 10].map((leverageAmount: number) => ({
-          label: `${leverageAmount}×`,
-          value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
-        }))}
+        items={(maxLeverage.lt(10) ? [1, 2, 3, 4, 5] : [1, 2, 3, 5, 10]).map(
+          (leverageAmount: number) => ({
+            label: `${leverageAmount}×`,
+            value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
+          })
+        )}
         value={MustBigNumber(formattedLeverageValue).abs().toFixed(LEVERAGE_DECIMALS)} // sign agnostic
         onValueChange={updateLeverage}
         shape={ButtonShape.Rectangle}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
https://linear.app/dydx/issue/TRA-113/adjust-market-input-buttons-based-on-maxleverage-of-current-market

When maxLeverage is less than 10, display `1, 2, 3, 4, 5` or display `1, 2, 3, 5, 10`.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketLeverageInput>`
  * use `maxLeverage` to determine what the leverage inputs should contain
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
