### PR TITLE
chore: add .nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+18
+engine-strict=true


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
N/A

<!-- Overall purpose of the PR -->
Adds a `.nvmrc` so you can do `nvm use` in the repo instead of checking the currently used version.

You can also enforce usage of this in your CI, depending on what tools you're using (like GitHub actions).

If you decide to use this, I'd suggest updating the README as well.
---

<!-- Reorder/delete the following sections accordingly: -->

## Views
N/A

## Components
N/A

## Styles/Mixins
N/A

## Constants/Types
N/A

## Functions
N/A

## Hooks
N/A

## State
N/A

## Packages
N/A

## Workflows
Do `nvm install` the first time in the repo, and `nvm use` to activate the correct node version.