### PR TITLE
fix: action type in profile page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -44,6 +44,14 @@ import { StrideStakingPanel } from './token/staking/StrideStakingPanel';
 
 const ENS_CHAIN_ID = 1; // Ethereum
 
+type Action = {
+  key: string;
+  label: string;
+  icon: IconButtonProps;
+  href?: string;
+  onClick?: () => void;
+};
+
 const Profile = () => {
   const stringGetter = useStringGetter();
   const dispatch = useDispatch();
@@ -62,7 +70,7 @@ const Profile = () => {
 
   const currentWeekTradingReward = useSelector(getHistoricalTradingRewardsForCurrentWeek);
 
-  const actions = [
+  const actions: Action[] = [
     {
       key: 'deposit',
       label: stringGetter({ key: STRING_KEYS.DEPOSIT }),
@@ -125,13 +133,7 @@ const Profile = () => {
             dispatch(openDialog({ type: DialogTypes.Onboarding }));
           },
         },
-  ].filter(isTruthy) as {
-    key: string;
-    label: string;
-    icon: IconButtonProps;
-    href?: string;
-    onClick?: () => void;
-  }[];
+  ].filter(isTruthy);
 
   return (
     <Styled.MobileProfileLayout>


### PR DESCRIPTION
I'm not super familiar with this codebase, but I noticed a typecast that seemed odd to me. if you look at the `actions` variable in the `Profile` page, it appears to be casted instead of typed. unsure if this is necessary due to side effects not immediately noticeable from my PR, but i've submitted a potential fix

<!-- Featured screenshots/recordings -->
Before:
the 'key' property was deleted from an action but no type error pops up
<img width="675" alt="Screenshot 2024-03-14 at 8 53 53 AM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/0754177b-79c3-41e5-bf87-273d8e230544">


After:
IDE properly recognizes there's a type error since `actions` variable is typed instead of casted
<img width="801" alt="Screenshot 2024-03-14 at 8 52 02 AM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/8788c0ef-23ee-42e6-ae75-536154be22b7">

<!-- Overall purpose of the PR -->

Increase type safety of the codebase by opting for variable typing over function output typecasting. Casting the output of the filter function removes the type safety of the `action` variable's base array as it overrides any values that occur before the filter function.

---

<!-- Reorder/delete the following sections accordingly: -->


## Constants/Types

* `constants/_____`
  * Adds type to `actions` variable, removes casting