### PR TITLE
build: Add install-local-abacus script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coverage": "vitest run --coverage",
     "clean-install": "rm -rf node_modules/ && pnpm i",
     "preview": "vite preview",
+    "install-local-abacus": "node scripts/install-local-abacus",
     "ladle": "ladle serve",
     "ladle-b": "ladle build",
     "ladle-p": "ladle preview",

--- a/scripts/install-local-abacus.js
+++ b/scripts/install-local-abacus.js
@@ -1,0 +1,28 @@
+import { execSync } from 'child_process';
+
+console.log("Cleaning up any previously built abacus packages...")
+try {
+    execSync('rm ../v4-abacus/build/packages/*.tgz', { stdio: "inherit" });
+} catch (error) {
+    console.error('Error cleaning up:', error);
+    process.exit(1); 
+}
+
+console.log("Building abacus...")
+try {
+    execSync('cd ../v4-abacus && ./gradlew packJsPackage', { stdio: "inherit" });
+} catch (error) {
+    console.error('Error building abacus:', error);
+    process.exit(1); 
+}
+
+
+console.log("Installing local abacus package...")
+try {
+    execSync("find ../v4-abacus/build/packages -name '*.tgz' | head -n 1 | xargs pnpm install", { stdio: "inherit" });
+} catch (error) {
+    console.error('Error installing abacus:', error);
+    process.exit(1); 
+}
+
+console.log("Successfully installed local abacus package - restart pnpm dev")


### PR DESCRIPTION
Adds a new script that can be run via `pnpm run install-local-abacus`. It assumes that abacus is checked out to `../v4-abacus` relative to this repository. It handles building abacus and installing the local package.