### PR TITLE
build: Trigger Vite restart when install-local-abacus is run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dist-ssr
 # Charting Library
 public/tradingview
 public/datafeed
+
+local-abacus-hash

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "url-polyfill": "^1.1.12",
     "util": "^0.12.5",
     "vite": "^4.3.9",
+    "vite-plugin-restart": "^0.4.0",
     "vite-plugin-svgr": "^3.2.0",
     "vitest": "^0.32.2",
     "w3name": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ devDependencies:
   vite:
     specifier: ^4.3.9
     version: 4.3.9(@types/node@20.3.1)
+  vite-plugin-restart:
+    specifier: ^0.4.0
+    version: 0.4.0(vite@4.3.9)
   vite-plugin-svgr:
     specifier: ^3.2.0
     version: 3.2.0(vite@4.3.9)
@@ -18492,6 +18495,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite-plugin-restart@0.4.0(vite@4.3.9):
+    resolution: {integrity: sha512-SXeyKQAzRFmEmEyGP2DjaTbx22D1K5MapyNiAP7Xa14UyFgNSDjZ86bfjWksA0pqn+bZyxnVLJpCiqDuG+tOcg==}
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+    dependencies:
+      micromatch: 4.0.5
+      vite: 4.3.9(@types/node@20.3.1)
     dev: true
 
   /vite-plugin-svgr@3.2.0(vite@4.3.9):

--- a/scripts/install-local-abacus.js
+++ b/scripts/install-local-abacus.js
@@ -23,5 +23,13 @@ try {
     console.error('Error installing abacus:', error);
     process.exit(1); 
 }
+console.log("Successfully installed local abacus package.")
 
-console.log("Successfully installed local abacus package - restart pnpm dev")
+console.log("Generating local-abacus-hash...")
+try {
+    execSync("find ../v4-abacus/build/packages -name '*.tgz' | head -n 1 | shasum > local-abacus-hash", { stdio: "inherit" });
+} catch (error) {
+    console.error('Error generating local-abacus-hash:', error);
+    console.error('You may need to manually restart pnpm dev.')
+    process.exit(1); 
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
+import ViteRestart from 'vite-plugin-restart';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -50,6 +51,14 @@ export default defineConfig(({ mode }) => ({
     svgr({
       exportAsDefault: true,
     }),
+    // Currently, the Vite file watcher is unable to watch folders within node_modules.
+    // Workaround is to use ViteRestart plugin + a generated file to trigger the restart.
+    // See https://github.com/vitejs/vite/issues/8619
+    ViteRestart({
+      restart: [
+        'local-abacus-hash',
+      ]
+    })
   ],
   publicDir: 'public',
   test: {


### PR DESCRIPTION
Ideally we'd do this through Vite's `server.watch` config. But it currently doesn't work with subdirectories of `node_modules`. Tried a couple different workarounds in this thread: https://github.com/vitejs/vite/issues/8619, ultimately this is the solution that worked.

This does introduce a new dev dependency (https://www.npmjs.com/package/vite-plugin-restart), but it seems pretty widely used (ton of sponsors, including Vite) and somewhat recently maintained (Nov 2023).