### PR TITLE
feat(performance): trading view kick off getBars / request candles sooner

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.6.17",
+    "@dydxprotocol/v4-abacus": "^1.6.20",
     "@dydxprotocol/v4-client-js": "^1.0.25",
     "@dydxprotocol/v4-localization": "^1.1.51",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.6.17
-    version: 1.6.19
+    specifier: ^1.6.20
+    version: 1.6.22
   '@dydxprotocol/v4-client-js':
     specifier: ^1.0.25
     version: 1.0.26
@@ -1565,8 +1565,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.6.19:
-    resolution: {integrity: sha512-IYqUfs3t0X1ikymYe92nLEpvZFdninRmrfU6kAMT1p9T/sjjCV4bLrsPbaZJxm6rzebxY37Ryd8KIqr/KeNQnw==}
+  /@dydxprotocol/v4-abacus@1.6.22:
+    resolution: {integrity: sha512-A10isY6Klt6SuSZMioxq2n4DHLXBVjWH0eLOJkMxwFACfxLE0HeWD2sglgXK3qbDBd9RZ4rlnCC/2d8b+zreFA==}
     dev: false
 
   /@dydxprotocol/v4-client-js@1.0.26:

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -68,41 +68,43 @@ export const useTradingView = ({
   }, [marketId!!, hasMarkets]);
 
   useEffect(() => {
-    const widgetOptions = getWidgetOptions();
-    const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
-    const options = {
-      ...widgetOptions,
-      ...widgetOverrides,
-      datafeed: getDydxDatafeed(store, getCandlesForDatafeed, initialPriceScale),
-      interval: (savedResolution || DEFAULT_RESOLUTION) as ResolutionString,
-      locale: SUPPORTED_LOCALE_BASE_TAGS[selectedLocale] as LanguageCode,
-      symbol: marketId,
-      saved_data: !isEmpty(savedTvChartConfig) ? savedTvChartConfig : undefined,
-    };
+    if (marketId) {
+      const widgetOptions = getWidgetOptions();
+      const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
+      const options = {
+        ...widgetOptions,
+        ...widgetOverrides,
+        datafeed: getDydxDatafeed(store, getCandlesForDatafeed, initialPriceScale),
+        interval: (savedResolution || DEFAULT_RESOLUTION) as ResolutionString,
+        locale: SUPPORTED_LOCALE_BASE_TAGS[selectedLocale] as LanguageCode,
+        symbol: marketId,
+        saved_data: !isEmpty(savedTvChartConfig) ? savedTvChartConfig : undefined,
+      };
 
-    const tvChartWidget = new widget(options);
-    tvWidgetRef.current = tvChartWidget;
+      const tvChartWidget = new widget(options);
+      tvWidgetRef.current = tvChartWidget;
 
-    tvWidgetRef.current.onChartReady(() => {
-      tvWidgetRef.current?.headerReady().then(() => {
-        if (displayButtonRef && tvWidgetRef.current) {
-          displayButtonRef.current = tvWidgetRef.current.createButton();
-          displayButtonRef.current.innerHTML = `<span>${stringGetter({
-            key: STRING_KEYS.ORDER_LINES,
-          })}</span> <div class="displayOrdersButton-toggle"></div>`;
-          displayButtonRef.current.setAttribute(
-            'title',
-            stringGetter({ key: STRING_KEYS.ORDER_LINES_TOOLTIP })
-          );
-        }
+      tvWidgetRef.current.onChartReady(() => {
+        tvWidgetRef.current?.headerReady().then(() => {
+          if (displayButtonRef && tvWidgetRef.current) {
+            displayButtonRef.current = tvWidgetRef.current.createButton();
+            displayButtonRef.current.innerHTML = `<span>${stringGetter({
+              key: STRING_KEYS.ORDER_LINES,
+            })}</span> <div class="displayOrdersButton-toggle"></div>`;
+            displayButtonRef.current.setAttribute(
+              'title',
+              stringGetter({ key: STRING_KEYS.ORDER_LINES_TOOLTIP })
+            );
+          }
+        });
+
+        tvWidgetRef?.current?.subscribe('onAutoSaveNeeded', () =>
+          tvWidgetRef?.current?.save((chartConfig: object) => setTvChartConfig(chartConfig))
+        );
+
+        setIsChartReady(true);
       });
-
-      tvWidgetRef?.current?.subscribe('onAutoSaveNeeded', () =>
-        tvWidgetRef?.current?.save((chartConfig: object) => setTvChartConfig(chartConfig))
-      );
-
-      setIsChartReady(true);
-    });
+    }
 
     return () => {
       displayButtonRef.current?.remove();
@@ -111,7 +113,7 @@ export const useTradingView = ({
       tvWidgetRef.current = null;
       setIsChartReady(false);
     };
-  }, [selectedLocale, selectedNetwork, initialPriceScale]);
+  }, [selectedLocale, selectedNetwork, initialPriceScale, marketId!!]);
 
   return { savedResolution };
 };

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 import { LanguageCode, ResolutionString, widget } from 'public/tradingview/charting_library';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { DEFAULT_RESOLUTION } from '@/constants/candles';
 import { LocalStorageKey } from '@/constants/localStorage';

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -24,7 +24,7 @@ import { useSelectedNetwork } from './useSelectedNetwork';
 export const useAnalytics = () => {
   const { walletType, walletConnectionType, evmAddress, dydxAddress, selectedWalletType } =
     useAccounts();
-  const { compositeClient } = useDydxClient();
+  const { indexerClient } = useDydxClient();
 
   /** User properties */
 
@@ -99,7 +99,7 @@ export const useAnalytics = () => {
 
   useEffect(() => {
     if (status) {
-      const websocketEndpoint = compositeClient?.indexerClient?.config.websocketEndpoint;
+      const websocketEndpoint = indexerClient.config.websocketEndpoint;
 
       const lastSuccessfulIndexerRpcQuery =
         (websocketEndpoint &&

--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -59,6 +59,7 @@ const useDydxClientContext = () => {
   const [compositeClient, setCompositeClient] = useState<CompositeClient>();
   const [faucetClient, setFaucetClient] = useState<FaucetClient>();
 
+  // assume there's only one option for indexer endpoints
   const indexerEndpoints = ENVIRONMENT_CONFIG_MAP[selectedNetwork].endpoints.indexers[0];
   const indexerConfig = new IndexerConfig(indexerEndpoints.api, indexerEndpoints.socket);
   const indexerClient = new IndexerClient(indexerConfig);

--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -18,7 +18,6 @@ import { useSelector } from 'react-redux';
 import type { ConnectNetworkEvent, NetworkConfig } from '@/constants/abacus';
 import { DEFAULT_TRANSACTION_MEMO } from '@/constants/analytics';
 import { type Candle, RESOLUTION_MAP } from '@/constants/candles';
-import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
 
@@ -134,6 +133,16 @@ const useDydxClientContext = () => {
     } catch (error) {
       log('useDydxClient/getPerpetualMarkets', error);
       return [];
+    }
+  };
+
+  const getMarketTickSize = async (marketId: string) => {
+    try {
+      const { markets } = (await indexerClient.markets.getPerpetualMarkets(marketId)) || {};
+      console.log({ markets });
+      return markets?.[marketId]?.tickSize;
+    } catch (error) {
+      log('useDydxClient/getMarketTickSize', error);
     }
   };
 
@@ -278,6 +287,7 @@ const useDydxClientContext = () => {
     requestAllPerpetualMarkets,
     requestAllGovernanceProposals,
     getCandlesForDatafeed,
+    getMarketTickSize,
     getPerpetualMarketSparklines,
     screenAddresses,
     getWithdrawalAndTransferGatingStatus,

--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -139,7 +139,6 @@ const useDydxClientContext = () => {
   const getMarketTickSize = async (marketId: string) => {
     try {
       const { markets } = (await indexerClient.markets.getPerpetualMarkets(marketId)) || {};
-      console.log({ markets });
       return markets?.[marketId]?.tickSize;
     } catch (error) {
       log('useDydxClient/getMarketTickSize', error);

--- a/src/hooks/useEndpointsConfig.ts
+++ b/src/hooks/useEndpointsConfig.ts
@@ -1,0 +1,29 @@
+import { useSelector } from 'react-redux';
+
+import { ENVIRONMENT_CONFIG_MAP } from '@/constants/networks';
+
+import { getSelectedNetwork } from '@/state/appSelectors';
+
+interface EndpointsConfig {
+  indexers: {
+    api: string;
+    socket: string;
+  }[];
+  validators: string[];
+  '0xsquid': string;
+  nobleValidator: string;
+  faucet?: string;
+}
+
+export const useEndpointsConfig = () => {
+  const selectedNetwork = useSelector(getSelectedNetwork);
+  const endpointsConfig = ENVIRONMENT_CONFIG_MAP[selectedNetwork].endpoints as EndpointsConfig;
+
+  return {
+    indexer: endpointsConfig.indexers[0], // assume there's only one option for indexer endpoints
+    validators: endpointsConfig.validators,
+    '0xsquid': endpointsConfig['0xsquid'],
+    nobleValidator: endpointsConfig.nobleValidator,
+    faucet: endpointsConfig['faucet'],
+  };
+};

--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -19,11 +19,11 @@ import type { PerpetualMarketResponse } from '@/constants/indexer';
 import { useDydxClient } from '@/hooks/useDydxClient';
 
 export const useNextClobPairId = () => {
-  const { isConnected, requestAllPerpetualMarkets, requestAllGovernanceProposals } =
+  const { isCompositeClientConnected, requestAllPerpetualMarkets, requestAllGovernanceProposals } =
     useDydxClient();
 
   const { data: perpetualMarkets, status: perpetualMarketsStatus } = useQuery({
-    enabled: isConnected,
+    enabled: true,
     queryKey: 'requestAllPerpetualMarkets',
     queryFn: requestAllPerpetualMarkets,
     refetchInterval: 60_000,
@@ -31,7 +31,7 @@ export const useNextClobPairId = () => {
   });
 
   const { data: allGovProposals, status: allGovProposalsStatus } = useQuery({
-    enabled: isConnected,
+    enabled: isCompositeClientConnected,
     queryKey: 'requestAllActiveGovernanceProposals',
     queryFn: () => requestAllGovernanceProposals(),
     refetchInterval: 10_000,

--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -23,7 +23,6 @@ export const useNextClobPairId = () => {
     useDydxClient();
 
   const { data: perpetualMarkets, status: perpetualMarketsStatus } = useQuery({
-    enabled: true,
     queryKey: 'requestAllPerpetualMarkets',
     queryFn: requestAllPerpetualMarkets,
     refetchInterval: 60_000,

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -50,7 +50,7 @@ export const getDydxDatafeed = (
   initialPriceScale: number
 ) => ({
   onReady: (callback: OnReadyCallback) => {
-    callback(configurationData);
+    setTimeout(() => callback(configurationData), 0);
   },
 
   searchSymbols: (
@@ -94,7 +94,7 @@ export const getDydxDatafeed = (
       format: 'price',
     };
 
-    onSymbolResolvedCallback(symbolInfo);
+    setTimeout(() => onSymbolResolvedCallback(symbolInfo), 0);
   },
 
   getBars: async (

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -24,14 +24,13 @@ export const mapCandle = ({
   volume: Math.ceil(Number(baseTokenVolume)),
 });
 
-export const getAllSymbols = (marketIds: string[]): TradingViewSymbol[] =>
-  marketIds.map((marketId) => ({
-    description: marketId,
-    exchange: 'dYdX',
-    full_name: marketId,
-    symbol: marketId,
-    type: 'crypto',
-  }));
+export const getSymbol = (marketId: string): TradingViewSymbol => ({
+  description: marketId,
+  exchange: 'dYdX',
+  full_name: marketId,
+  symbol: marketId,
+  type: 'crypto',
+});
 
 export const getHistorySlice = ({
   bars,


### PR DESCRIPTION
Trading view chart loads pretty slowly, especially on first load

1. Separate indexer client out
- api calls from indexer client were previously blocked by abacus connection to validator(s) to initialize the compositeClient. Since we only offer one option for indexer endpoint, there's no advantage to getting indexer client from composite client, and indexer api calls can be kicked off faster without that dependency.
2. Removing markets dependency for rendering trading view
- previously we only initialize trading view after markets are fetched
- by not caring about the markets, network calls to get candles are now queued at 2s instead of 4s on average
- this sacrifices setting price scale by ignoring tickSizeDecimals (this might be fixed with auto price scale in newer versions of TradingView)
- this might be further improved by skipping the candles calls from abacus (v2 has a config for skipping that, will follow up after we move on to v2)