### PR TITLE
fix(orderbook): rows missing/duplicated in transition state

### DIFF
--- a/src/constants/orderbook.ts
+++ b/src/constants/orderbook.ts
@@ -2,7 +2,7 @@
  * @description Orderbook display constants
  */
 export const ORDERBOOK_MAX_ROWS_PER_SIDE = 30;
-export const ORDERBOOK_ANIMATION_DURATION = 400;
+export const ORDERBOOK_ANIMATION_DURATION = 100;
 
 /**
  * @description Orderbook pixel constants

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -143,13 +143,13 @@ export const useDrawOrderbook = ({
     if (ctx.roundRect) {
       ctx.roundRect(
         bar.x1,
-        y + 1,
+        y,
         bar.x2,
-        rowHeight - 4,
-        histogramSide === 'right' ? [1, 0, 0, 1] : [0, 1, 1, 0]
+        rowHeight - 2,
+        histogramSide === 'right' ? [2, 0, 0, 2] : [0, 2, 2, 0]
       );
     } else {
-      ctx.rect(bar.x1, y + 1, bar.x2, rowHeight - 4);
+      ctx.rect(bar.x1, y, bar.x2, rowHeight - 2);
     }
 
     ctx.fill();

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -312,7 +312,7 @@ export const useDrawOrderbook = ({
 
     setTimeout(() => {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-      prevData.current.forEach((row, idx) => drawOrderbookRow({ ctx, idx, rowToRender: row }));
+      data.forEach((row, idx) => drawOrderbookRow({ ctx, idx, rowToRender: row }));
     }, ORDERBOOK_ANIMATION_DURATION);
 
     prevData.current = data;

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -295,45 +295,24 @@ export const useDrawOrderbook = ({
     // Animate row removal and update
     const mapOfOrderbookPriceLevels =
       side && currentOrderbookMap?.[side === 'ask' ? 'asks' : 'bids'];
-    const empty: number[] = [];
-    const removed: number[] = [];
-    const updated: number[] = [];
-    const unchanged: number[] = [];
 
     prevData.current.forEach((row, idx) => {
-      if (!row) {
-        empty.push(idx);
-        return;
-      }
+      if (!row) return;
 
       let animationType = OrderbookRowAnimationType.NEW;
 
       if (mapOfOrderbookPriceLevels?.[row.price] === 0) {
-        removed.push(idx);
         animationType = OrderbookRowAnimationType.REMOVE;
       } else if (mapOfOrderbookPriceLevels?.[row.price] === row.size) {
-        unchanged.push(idx);
         animationType = OrderbookRowAnimationType.NONE;
-      } else {
-        updated.push(idx);
       }
 
       drawOrderbookRow({ ctx, idx, rowToRender: row, animationType });
     });
 
     setTimeout(() => {
-      [...empty, ...removed, ...updated, ...unchanged].forEach((idx) => {
-        const { x1, y1, x2, y2 } = getRektFromIdx({
-          idx,
-          rowHeight,
-          canvasWidth,
-          canvasHeight,
-          side,
-        });
-
-        ctx.clearRect(x1, y1, x2 - x1, y2 - y1);
-        drawOrderbookRow({ ctx, idx, rowToRender: data[idx] });
-      });
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+      prevData.current.forEach((row, idx) => drawOrderbookRow({ ctx, idx, rowToRender: row }));
     }, ORDERBOOK_ANIMATION_DURATION);
 
     prevData.current = data;

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { OrderSide } from '@dydxprotocol/v4-client-js';
+import _ from 'lodash';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import { type PerpetualMarketOrderbookLevel } from '@/constants/abacus';
@@ -26,7 +27,10 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
           ({
             key: `ask-${idx}`,
             side: 'ask',
-            mine: openOrdersBySideAndPrice[OrderSide.SELL]?.[row.price]?.size,
+            mine: _.sumBy(
+              openOrdersBySideAndPrice[OrderSide.SELL]?.[row.price],
+              (order) => order.price
+            ),
             ...row,
           } as PerpetualMarketOrderbookLevel)
       )
@@ -40,7 +44,10 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
           ({
             key: `bid-${idx}`,
             side: 'bid',
-            mine: openOrdersBySideAndPrice[OrderSide.BUY]?.[row.price]?.size,
+            mine: _.sumBy(
+              openOrdersBySideAndPrice[OrderSide.BUY]?.[row.price],
+              (order) => order.size
+            ),
             ...row,
           } as PerpetualMarketOrderbookLevel)
       )

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { OrderSide } from '@dydxprotocol/v4-client-js';
-import _ from 'lodash';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import { OrderbookLine, type PerpetualMarketOrderbookLevel } from '@/constants/abacus';

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -142,20 +142,20 @@ export const getSubaccountOpenStatusOrders = createSelector([getSubaccountOrders
   orders?.filter((order) => order.status === AbacusOrderStatus.open)
 );
 
-export const getSubaccountOpenStatusOrdersBySideAndPrice = createSelector(
+export const getSubaccountOrderSizeBySideAndPrice = createSelector(
   [getSubaccountOpenStatusOrders],
   (openOrders = []) => {
-    const ordersBySide: Partial<Record<OrderSide, Record<number, SubaccountOrder[]>>> = {};
-    openOrders.forEach((order) => {
+    const orderSizeBySideAndPrice: Partial<Record<OrderSide, Record<number, number>>> = {};
+    openOrders.forEach((order: SubaccountOrder) => {
       const side = ORDER_SIDES[order.side.name];
-      const byPrice = (ordersBySide[side] ??= {});
+      const byPrice = (orderSizeBySideAndPrice[side] ??= {});
       if (byPrice[order.price]) {
-        byPrice[order.price].push(order);
+        byPrice[order.price] += order.size;
       } else {
-        byPrice[order.price] = [order];
+        byPrice[order.price] = order.size;
       }
     });
-    return ordersBySide;
+    return orderSizeBySideAndPrice;
   }
 );
 

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -145,11 +145,15 @@ export const getSubaccountOpenStatusOrders = createSelector([getSubaccountOrders
 export const getSubaccountOpenStatusOrdersBySideAndPrice = createSelector(
   [getSubaccountOpenStatusOrders],
   (openOrders = []) => {
-    const ordersBySide: Partial<Record<OrderSide, Record<number, SubaccountOrder>>> = {};
+    const ordersBySide: Partial<Record<OrderSide, Record<number, SubaccountOrder[]>>> = {};
     openOrders.forEach((order) => {
       const side = ORDER_SIDES[order.side.name];
       const byPrice = (ordersBySide[side] ??= {});
-      byPrice[order.price] = order;
+      if (byPrice[order.price]) {
+        byPrice[order.price].push(order);
+      } else {
+        byPrice[order.price] = [order];
+      }
     });
     return ordersBySide;
   }

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { OrderSide } from '@dydxprotocol/v4-client-js';
+import _ from 'lodash';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import styled, { type AnyStyledComponent, css, keyframes } from 'styled-components';
 
@@ -60,7 +61,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
           ({
             key: `ask-${idx}`,
             side: 'ask',
-            mine: openOrdersBySideAndPrice[OrderSide.SELL]?.[row.price]?.size,
+            mine: _.sumBy(openOrdersBySideAndPrice[OrderSide.SELL]?.[row.price], (row) => row.size),
             ...row,
           } as RowData)
       )
@@ -72,7 +73,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
           ({
             key: `bid-${idx}`,
             side: 'bid',
-            mine: openOrdersBySideAndPrice[OrderSide.BUY]?.[row.price]?.size,
+            mine: _.sumBy(openOrdersBySideAndPrice[OrderSide.BUY]?.[row.price], (row) => row.size),
             ...row,
           } as RowData)
       )

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { OrderSide } from '@dydxprotocol/v4-client-js';
-import _ from 'lodash';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import styled, { type AnyStyledComponent, css, keyframes } from 'styled-components';
 

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -21,7 +21,7 @@ import { type CustomRowConfig, TableRow } from '@/components/Table';
 import { WithTooltip } from '@/components/WithTooltip';
 
 import { calculateCanViewAccount } from '@/state/accountCalculators';
-import { getSubaccountOpenStatusOrdersBySideAndPrice } from '@/state/accountSelectors';
+import { getSubaccountOrderSizeBySideAndPrice } from '@/state/accountSelectors';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
 import { getCurrentInput } from '@/state/inputsSelectors';
@@ -51,8 +51,8 @@ type RowData = Pick<OrderbookLine, 'depth' | 'offset' | 'price' | 'size'> & {
 const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number }) => {
   const orderbook = useSelector(getCurrentMarketOrderbook, shallowEqual);
 
-  const openOrdersBySideAndPrice =
-    useSelector(getSubaccountOpenStatusOrdersBySideAndPrice, shallowEqual) || {};
+  const subaccountOrderSizeBySideAndPrice =
+    useSelector(getSubaccountOrderSizeBySideAndPrice, shallowEqual) || {};
 
   return useMemo(() => {
     const asks = (orderbook?.asks?.toArray() ?? [])
@@ -61,8 +61,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
           ({
             key: `ask-${idx}`,
             side: 'ask',
-            mine: _.sumBy(openOrdersBySideAndPrice[OrderSide.SELL]?.[row.price], (row) => row.size),
-            ...row,
+            mine: subaccountOrderSizeBySideAndPrice[OrderSide.SELL]?.[row.price],
           } as RowData)
       )
       .slice(0, maxRowsPerSide);
@@ -73,7 +72,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
           ({
             key: `bid-${idx}`,
             side: 'bid',
-            mine: _.sumBy(openOrdersBySideAndPrice[OrderSide.BUY]?.[row.price], (row) => row.size),
+            mine: subaccountOrderSizeBySideAndPrice[OrderSide.BUY]?.[row.price],
             ...row,
           } as RowData)
       )
@@ -142,7 +141,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
     }
 
     return { asks, bids, spread, spreadPercent, histogramRange, hasOrderbook: !!orderbook };
-  }, [orderbook, openOrdersBySideAndPrice]);
+  }, [orderbook, subaccountOrderSizeBySideAndPrice]);
 };
 
 const OrderbookTable = ({


### PR DESCRIPTION
fix same orderbook row showing twice or not at all during the prev data canvas draw
bug:


https://github.com/dydxprotocol/v4-web/assets/9400120/7b7717b2-67e3-4eeb-8629-680b9079c4e6


make it look "sharper" by increase contrast of
- rows getting removed state (darker text)
- bars are less rounded and more gap
- shorter transition state
