### PR TITLE
fix: memoize table data to avoid flickering

### DIFF
--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { OrderSide } from '@dydxprotocol/v4-client-js';
 import { ColumnSize } from '@react-types/table';
@@ -336,13 +336,17 @@ export const OrdersTable = ({
 
   const symbol = currentMarket ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.id : null;
 
-  const ordersData = orders.map((order: SubaccountOrder) =>
-    getHydratedTradingData({
-      data: order,
-      assets: allAssets,
-      perpetualMarkets: allPerpetualMarkets,
-    })
-  ) as OrderTableRow[];
+  const ordersData = useMemo(
+    () =>
+      orders.map((order: SubaccountOrder) =>
+        getHydratedTradingData({
+          data: order,
+          assets: allAssets,
+          perpetualMarkets: allPerpetualMarkets,
+        })
+      ) as OrderTableRow[],
+    [orders, allPerpetualMarkets, allAssets]
+  );
 
   return (
     <Styled.Table

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import type { ColumnSize } from '@react-types/table';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -371,14 +373,19 @@ export const PositionsTable = ({
     }
   });
 
-  const positionsData = openPositions.map((position: SubaccountPosition) => ({
-    tickSizeDecimals: perpetualMarkets?.[position.id]?.configs?.tickSizeDecimals || USD_DECIMALS,
-    asset: assets?.[position.assetId],
-    oraclePrice: perpetualMarkets?.[position.id]?.oraclePrice,
-    stopLossOrders: stopLossOrders.filter((order) => order.marketId === position.id),
-    takeProfitOrders: takeProfitOrders.filter((order) => order.marketId === position.id),
-    ...position,
-  }));
+  const positionsData = useMemo(
+    () =>
+      openPositions.map((position: SubaccountPosition) => ({
+        tickSizeDecimals:
+          perpetualMarkets?.[position.id]?.configs?.tickSizeDecimals || USD_DECIMALS,
+        asset: assets?.[position.assetId],
+        oraclePrice: perpetualMarkets?.[position.id]?.oraclePrice,
+        stopLossOrders: stopLossOrders.filter((order) => order.marketId === position.id),
+        takeProfitOrders: takeProfitOrders.filter((order) => order.marketId === position.id),
+        ...position,
+      })),
+    [openPositions, perpetualMarkets, assets, openOrders]
+  );
 
   return (
     <Styled.Table

--- a/src/views/tables/TradingRewardHistoryTable.tsx
+++ b/src/views/tables/TradingRewardHistoryTable.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { shallowEqual, useSelector } from 'react-redux';
 import styled, { type AnyStyledComponent } from 'styled-components';
 
@@ -12,10 +14,7 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Output, OutputType } from '@/components/Output';
 import { Table, TableCell, type ColumnDef } from '@/components/Table';
 
-import {
-  getHistoricalTradingRewards,
-  getHistoricalTradingRewardsForPeriod,
-} from '@/state/accountSelectors';
+import { getHistoricalTradingRewardsForPeriod } from '@/state/accountSelectors';
 
 export enum TradingRewardHistoryTableColumnKey {
   Event = 'Event',
@@ -105,10 +104,12 @@ export const TradingRewardHistoryTable = ({
     shallowEqual
   );
 
+  const rewardsData = useMemo(() => periodTradingRewards?.toArray() ?? [], [periodTradingRewards]);
+
   return (
     <Styled.Table
       label={stringGetter({ key: STRING_KEYS.REWARD_HISTORY })}
-      data={periodTradingRewards?.toArray() ?? []}
+      data={rewardsData}
       getRowKey={(row: any) => row.startedAtInMilliseconds}
       columns={columnKeys.map((key: TradingRewardHistoryTableColumnKey) =>
         getTradingRewardHistoryTableColumnDef({


### PR DESCRIPTION
we observe that certain tables are flickering (orders table, positions table and trading rewards table in particular)
fix: memoize the data transformation to avoid additional renders / weird flickering in tables


testing instructions in slack