### PR TITLE
build: Run continuous abacus build after installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@datadog/browser-logs": "^5.23.3",
-    "@dydxprotocol/v4-abacus": "1.9.7",
+    "@dydxprotocol/v4-abacus": "1.9.14",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.190",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: ^5.23.3
     version: 5.23.3
   '@dydxprotocol/v4-abacus':
-    specifier: 1.9.7
-    version: 1.9.7
+    specifier: 1.9.14
+    version: 1.9.14
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
@@ -3155,8 +3155,8 @@ packages:
       '@datadog/browser-core': 5.23.3
     dev: false
 
-  /@dydxprotocol/v4-abacus@1.9.7:
-    resolution: {integrity: sha512-tj2ZwQ2CHFXxtqJrUcvZ6Owiyx/7VDa/ie3QxfCNRp7RANuBBdFY4rRvmSz+7whGmnEdUVk7GszZxi+Wvqct1w==}
+  /@dydxprotocol/v4-abacus@1.9.14:
+    resolution: {integrity: sha512-7snu7fYBQsrZhJ8o46Scyd/yX+7GZaEtYi07t8z58+6s5f2vnQ3hDwwmTDCfOedptdW3FY9DZ5yIGMCRYYeYag==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/scripts/install-local-abacus.js
+++ b/scripts/install-local-abacus.js
@@ -27,6 +27,9 @@ fatalExec(
 
 infoMessage('Vite dev server should have restarted automatically.');
 
+infoMessage('Starting continuous Abacus build.');
+fatalExec("cd ../v4-abacus && ./gradlew v4WebHotSwapTrigger --continuous");
+
 function nonFatalExec(cmd) {
   try {
     execSync(cmd, { stdio: 'inherit' });


### PR DESCRIPTION
Update `install-local-abacus` to run a continuous abacus build after initial package installation, so that when making changes to abacus files, they are immediately recompiled and installed (and Vite is restarted).

This continuous build is kind of hacky, and just copies over js files directly into `node_modules` but is much faster: https://github.com/dydxprotocol/v4-abacus/pull/279 This is also why the command does a full `pnpm remove` at the beginning, to ensure we're in a cleaner state.