### PR TITLE
build: Add v4-abacus to VSCode file watcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "explorer.sortOrder": "mixed",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "files.watcherExclude": {
+        "**/.git": true,
+        "**/node_modules/*": true,
+        "**/node_modules/@dydxprotocol/v4-abacus": false
+    }
 }


### PR DESCRIPTION
Turn on file watching for v4-abacus node module so types get re-indexed automatically.