### PR TITLE
feat(isolated-positions): Scaffold Unoponed Isolated Position cards

### DIFF
--- a/src/components/CollapsibleTabs.tsx
+++ b/src/components/CollapsibleTabs.tsx
@@ -24,7 +24,7 @@ import { Toolbar } from '@/components/Toolbar';
 type ElementProps<TabItemsValue> = {
   defaultTab?: TabItemsValue;
   tab: TabItemsValue;
-  setTab?: Dispatch<SetStateAction<string>>;
+  setTab?: Dispatch<SetStateAction<TabItemsValue>>;
   tabItems: TabItem<TabItemsValue>[];
   slotToolbar?: ReactNode;
   defaultOpen?: boolean;
@@ -68,12 +68,8 @@ export const CollapsibleTabs = <TabItemsValue extends string>({
       >
         <Styled.Header>
           <Styled.TabsList $fullWidthTabs={fullWidthTabs}>
-            {tabItems.map(({value, label, tag, slotRight}) => (
-              <Styled.TabsTrigger
-                key={value}
-                value={value}
-                onClick={() => onOpenChange?.(true)}
-              >
+            {tabItems.map(({ value, label, tag, slotRight }) => (
+              <Styled.TabsTrigger key={value} value={value} onClick={() => onOpenChange?.(true)}>
                 {label}
                 {tag && <Tag>{tag}</Tag>}
                 {slotRight}

--- a/src/components/PotentialPositionCard.tsx
+++ b/src/components/PotentialPositionCard.tsx
@@ -1,0 +1,83 @@
+import styled, { type AnyStyledComponent } from 'styled-components';
+
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AssetIcon } from './AssetIcon';
+import { Icon, IconName } from './Icon';
+import { Link } from './Link';
+import { Output, OutputType } from './Output';
+
+type PotentialPositionCardProps = {
+  onViewOrders: (marketId: string) => void;
+};
+
+export const PotentialPositionCard = ({ onViewOrders }: PotentialPositionCardProps) => {
+  const stringGetter = useStringGetter();
+
+  return (
+    <Styled.PotentialPositionCard>
+      <Styled.MarketRow>
+        <AssetIcon symbol="ETH" /> Market Name
+      </Styled.MarketRow>
+      <Styled.MarginRow>
+        <Styled.MarginLabel>{stringGetter({ key: STRING_KEYS.MARGIN })}</Styled.MarginLabel>{' '}
+        <Styled.Output type={OutputType.Fiat} value={1_000} />
+      </Styled.MarginRow>
+      <Styled.ActionRow>
+        <Styled.Link onClick={() => onViewOrders('UNI-USD')}>
+          {stringGetter({ key: STRING_KEYS.VIEW_ORDERS })} <Icon iconName={IconName.Arrow} />
+        </Styled.Link>
+      </Styled.ActionRow>
+    </Styled.PotentialPositionCard>
+  );
+};
+
+const Styled = {
+  PotentialPositionCard: styled.div`
+    ${layoutMixins.flexColumn}
+    width: 14rem;
+    min-width: 14rem;
+    height: 6.5rem;
+    background-color: var(--color-layer-3);
+    overflow: hidden;
+    padding: 0.75rem 0;
+    border-radius: 0.625rem;
+  `,
+  MarketRow: styled.div`
+    ${layoutMixins.row}
+    gap: 0.5rem;
+    padding: 0 0.625rem;
+    font: var(--font-small-book);
+
+    img {
+      font-size: 1.25rem; // 20px x 20px
+    }
+  `,
+  MarginRow: styled.div`
+    ${layoutMixins.spacedRow}
+    padding: 0 0.625rem;
+    margin-top: 0.625rem;
+  `,
+  MarginLabel: styled.span`
+    color: var(--color-text-0);
+    font: var(--font-mini-book);
+  `,
+  Output: styled(Output)`
+    font: var(--font-small-book);
+  `,
+  ActionRow: styled.div`
+    ${layoutMixins.spacedRow}
+    border-top: var(--border);
+    margin-top: 0.5rem;
+    padding: 0 0.625rem;
+    padding-top: 0.5rem;
+  `,
+  Link: styled(Link)`
+    --link-color: var(--color-accent);
+    font: var(--font-small-book);
+  `,
+} satisfies Record<string, AnyStyledComponent>;

--- a/src/pages/trade/UnopenedIsolatedPositions.tsx
+++ b/src/pages/trade/UnopenedIsolatedPositions.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+import styled, { AnyStyledComponent } from 'styled-components';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { Button } from '@/components/Button';
+import { Icon, IconName } from '@/components/Icon';
+import { PotentialPositionCard } from '@/components/PotentialPositionCard';
+
+type UnopenedIsolatedPositionsProps = {
+  onViewOrders: (marketId: string) => void;
+};
+
+export const UnopenedIsolatedPositions = ({ onViewOrders }: UnopenedIsolatedPositionsProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  return (
+    <Styled.UnopenedIsolatedPositions>
+      <Styled.Button isOpen={isVisible} onClick={() => setIsVisible(!isVisible)}>
+        Unopened Isolated Positions
+        <Icon iconName={IconName.Caret} />
+      </Styled.Button>
+
+      {isVisible && (
+        <Styled.CardRow>
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+          <PotentialPositionCard onViewOrders={onViewOrders} />
+        </Styled.CardRow>
+      )}
+    </Styled.UnopenedIsolatedPositions>
+  );
+};
+
+const Styled = {
+  UnopenedIsolatedPositions: styled.div`
+    overflow: hidden;
+    border-top: var(--border);
+  `,
+  Button: styled(Button)<{ isOpen?: boolean }>`
+    gap: 1rem;
+    background-color: transparent;
+    border: none;
+    margin: 0 1rem;
+
+    ${({ isOpen }) =>
+      isOpen &&
+      `
+      svg {
+        transform: rotate(180deg);
+      }
+    `}
+  `,
+  CardRow: styled.div`
+    ${layoutMixins.row}
+    overflow-x: auto;
+    gap: 1rem;
+    scroll-snap-align: none;
+    padding: 0 1rem 1rem;
+  `,
+} satisfies Record<string, AnyStyledComponent>;

--- a/src/pages/trade/UnopenedIsolatedPositions.tsx
+++ b/src/pages/trade/UnopenedIsolatedPositions.tsx
@@ -22,7 +22,7 @@ export const UnopenedIsolatedPositions = ({ onViewOrders }: UnopenedIsolatedPosi
       </Styled.Button>
 
       {isVisible && (
-        <Styled.CardRow>
+        <Styled.Cards>
           <PotentialPositionCard onViewOrders={onViewOrders} />
           <PotentialPositionCard onViewOrders={onViewOrders} />
           <PotentialPositionCard onViewOrders={onViewOrders} />
@@ -32,7 +32,7 @@ export const UnopenedIsolatedPositions = ({ onViewOrders }: UnopenedIsolatedPosi
           <PotentialPositionCard onViewOrders={onViewOrders} />
           <PotentialPositionCard onViewOrders={onViewOrders} />
           <PotentialPositionCard onViewOrders={onViewOrders} />
-        </Styled.CardRow>
+        </Styled.Cards>
       )}
     </Styled.UnopenedIsolatedPositions>
   );
@@ -40,11 +40,14 @@ export const UnopenedIsolatedPositions = ({ onViewOrders }: UnopenedIsolatedPosi
 
 const Styled = {
   UnopenedIsolatedPositions: styled.div`
-    overflow: hidden;
+    overflow: auto;
     border-top: var(--border);
   `,
   Button: styled(Button)<{ isOpen?: boolean }>`
+    position: sticky;
+    top: 0;
     gap: 1rem;
+    backdrop-filter: blur(4px) contrast(1.01);
     background-color: transparent;
     border: none;
     margin: 0 1rem;
@@ -57,9 +60,8 @@ const Styled = {
       }
     `}
   `,
-  CardRow: styled.div`
-    ${layoutMixins.row}
-    overflow-x: auto;
+  Cards: styled.div`
+    ${layoutMixins.flexWrap}
     gap: 1rem;
     scroll-snap-align: none;
     padding: 0 1rem 1rem;

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -53,6 +53,11 @@ export const layoutMixins: Record<
     min-width: max-content;
   `,
 
+  flexWrap: css`
+    display: flex;
+    flex-wrap: wrap;
+  `,
+
   // A column with a fixed header and expanding content
   expandingColumnWithHeader: css`
     // Expand if within a flexColumn


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/dydxprotocol/v4-web/assets/13111994/11155585-a954-4714-a322-dae455f17123


<!-- Overall purpose of the PR -->
Scaffold `Unopened Isolated Positions` section in the `<HorizontalPanel>`. This will help to navigate users to their orders on Isolated Markets before the position has been made available.


In order to test add `?isolatedMargin=1` query param

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* New: `<UnopenedIsolatedPositions>`
  * Smart container that will eventually take Abacus state to populate a carousel of `PotentialPositionCards`.

* `<HorizontalPanel>`
  * Add `slotBottom` to display component outside of the `HorizontalPanel`
  * Updated `Styled` Record
  * Note: `styled` method from `styled-components` does not persist generic types. Had to cast `as CollapsibleTabs<InfoSection>` to get typing to work.

## Components

* New: `<PotentialPositionCard>`
  * component to display the market and margin put forth each Isolated Market

* `<CollapsibleTabs>`
  * Fix typing in `setTab` prop.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
