### PR TITLE
fix(tradingview): handle case when initial price scale doesnt need to be set

### DIFF
--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -61,7 +61,7 @@ export const useTradingView = ({
     // we only need tick size from current market for the price scale settings
     // if markets haven't been loaded via abacus, get the current market info from indexer
     (async () => {
-      if (marketId && !hasMarkets) {
+      if (marketId && !hasPriceScaleInfo) {
         const marketTickSize = await getMarketTickSize(marketId);
         const priceScale = BigNumber(10).exponentiatedBy(
           BigNumber(marketTickSize).decimalPlaces() ?? 2
@@ -69,7 +69,7 @@ export const useTradingView = ({
         setInitialPriceScale(priceScale.toNumber());
       }
     })();
-  }, [!!marketId, hasMarkets]);
+  }, [marketId, hasPriceScaleInfo]);
 
   useEffect(() => {
     if (marketId && hasPriceScaleInfo) {

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -51,11 +51,15 @@ export const useTradingView = ({
   });
 
   const savedResolution = getSavedResolution({ savedConfig: savedTvChartConfig });
-  const hasMarkets = marketIds.length > 0;
 
   const [initialPriceScale, setInitialPriceScale] = useState<number | null>(null);
 
+  const hasMarkets = marketIds.length > 0;
+  const hasPriceScaleInfo = initialPriceScale !== null || hasMarkets;
+
   useEffect(() => {
+    // we only need tick size from current market for the price scale settings
+    // if markets haven't been loaded via abacus, get the current market info from indexer
     (async () => {
       if (marketId && !hasMarkets) {
         const marketTickSize = await getMarketTickSize(marketId);
@@ -65,10 +69,10 @@ export const useTradingView = ({
         setInitialPriceScale(priceScale.toNumber());
       }
     })();
-  }, [marketId!!, hasMarkets]);
+  }, [!!marketId, hasMarkets]);
 
   useEffect(() => {
-    if (marketId && initialPriceScale !== null) {
+    if (marketId && hasPriceScaleInfo) {
       const widgetOptions = getWidgetOptions();
       const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
       const options = {
@@ -113,7 +117,7 @@ export const useTradingView = ({
       tvWidgetRef.current = null;
       setIsChartReady(false);
     };
-  }, [selectedLocale, selectedNetwork, initialPriceScale, !!marketId]);
+  }, [selectedLocale, selectedNetwork, !!marketId, hasPriceScaleInfo]);
 
   return { savedResolution };
 };

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -47,7 +47,7 @@ const configurationData: DatafeedConfiguration = {
 export const getDydxDatafeed = (
   store: RootStore,
   getCandlesForDatafeed: ReturnType<typeof useDydxClient>['getCandlesForDatafeed'],
-  initialPriceScale: number
+  initialPriceScale: number | null
 ) => ({
   onReady: (callback: OnReadyCallback) => {
     setTimeout(() => callback(configurationData), 0);
@@ -70,7 +70,7 @@ export const getDydxDatafeed = (
     const symbolItem = getSymbol(symbolName || DEFAULT_MARKETID);
     const { tickSizeDecimals } = getMarketConfig(symbolItem.symbol)(store.getState()) || {};
 
-    const pricescale = tickSizeDecimals ? 10 ** tickSizeDecimals : initialPriceScale;
+    const pricescale = tickSizeDecimals ? 10 ** tickSizeDecimals : initialPriceScale ?? 100;
 
     const symbolInfo: LibrarySymbolInfo = {
       ticker: symbolItem.full_name,


### PR DESCRIPTION
when navigating from portfolio -> trade, chart doesn't load because `hasMarkets` was set to true and no `initialPriceScale` needs to be set


test:
1. navigate from portfolio -> trade
2. change markets
3. observe trading view chart loads