### PR TITLE
fix: update status dot for connecting state and actually degraded

### DIFF
--- a/src/layout/Footer/FooterDesktop.tsx
+++ b/src/layout/Footer/FooterDesktop.tsx
@@ -30,16 +30,22 @@ export const FooterDesktop = () => {
   const { height, indexerHeight, status, statusErrorMessage } = useApiState();
   const { statusPage } = useURLConfigs();
 
-  const { exchangeStatus, label } =
-    !status || status === AbacusApiStatus.NORMAL
-      ? {
-          exchangeStatus: ExchangeStatus.Operational,
-          label: stringGetter({ key: STRING_KEYS.OPERATIONAL }),
-        }
-      : {
-          exchangeStatus: ExchangeStatus.Degraded,
-          label: stringGetter({ key: STRING_KEYS.DEGRADED }),
-        };
+  const isStatusLoading = !status && !statusErrorMessage;
+
+  const { exchangeStatus, label } = isStatusLoading
+    ? {
+        exchangeStatus: undefined,
+        label: stringGetter({ key: STRING_KEYS.CONNECTING }),
+      }
+    : status === AbacusApiStatus.NORMAL
+    ? {
+        exchangeStatus: ExchangeStatus.Operational,
+        label: stringGetter({ key: STRING_KEYS.OPERATIONAL }),
+      }
+    : {
+        exchangeStatus: ExchangeStatus.Degraded,
+        label: stringGetter({ key: STRING_KEYS.DEGRADED }),
+      };
 
   return (
     <Styled.Footer>
@@ -117,17 +123,19 @@ Styled.Row = styled.div`
   border-right: 1px solid var(--color-border);
 `;
 
-Styled.StatusDot = styled.div<{ exchangeStatus: ExchangeStatus }>`
+Styled.StatusDot = styled.div<{ exchangeStatus?: ExchangeStatus }>`
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
   margin-right: 0.25rem;
+  background-color: var(--color-text-0);
 
   background-color: ${({ exchangeStatus }) =>
-    ({
+    exchangeStatus &&
+    {
       [ExchangeStatus.Degraded]: css`var(--color-warning)`,
       [ExchangeStatus.Operational]: css`var(--color-success)`,
-    }[exchangeStatus])};
+    }[exchangeStatus]};
 `;
 
 Styled.FooterButton = styled(Button)`


### PR DESCRIPTION
match status dot to status error

previously when status is undefined, status dot will just be shown as operational which is inaccurate (since we do show chain disruption error)

fix is add a connecting state, so it will accurately switch to either operational / degraded after


<img width="1283" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/b6c69a86-c017-4051-8c95-0c3caab16e76">

https://github.com/dydxprotocol/v4-web/assets/9400120/3330aa5a-b98a-4dcb-b664-59055130559d

https://github.com/dydxprotocol/v4-web/assets/9400120/1a50f0a4-cb4d-476e-8ca0-e60b48e6ccc5


