### PR TITLE
chore: add net funding to positions table

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -378,7 +378,7 @@ const TableRoot = <TableRowData extends object | CustomRowConfig, TableRowKey ex
               key={row.key}
               item={row}
               state={state}
-              hasRowAction={!!(props.onRowAction)}
+              hasRowAction={!!props.onRowAction}
               // shouldRowRender={props.shouldRowRender}
               {...props.getRowAttributes?.(row.value!)}
               withGradientCardRows={props.withGradientCardRows}

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -1,5 +1,7 @@
 import { BigNumber } from 'bignumber.js';
 
+import { NumberSign } from '@/constants/numbers';
+
 export type BigNumberish = BigNumber | string | number;
 export type LocaleSeparators = { group?: string; decimal?: string };
 
@@ -80,3 +82,10 @@ export function bytesToBigInt(u: Uint8Array): bigint {
   const abs: bigint = BigInt(`0x${hex}`);
   return negated ? -abs : abs;
 }
+
+export const getNumberSign = (n: any): NumberSign =>
+  MustBigNumber(n).gt(0)
+    ? NumberSign.Positive
+    : MustBigNumber(n).lt(0)
+    ? NumberSign.Negative
+    : NumberSign.Neutral;

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -52,7 +52,6 @@ export const Overview = () => {
                   PositionsTableColumnKey.UnrealizedPnl,
                   PositionsTableColumnKey.RealizedPnl,
                   PositionsTableColumnKey.AverageOpenAndClose,
-                  PositionsTableColumnKey.NetFunding,
                   shouldRenderTriggers && PositionsTableColumnKey.Triggers,
                   // TODO: CT-503 re-enable when close positions dialog is created
                   // shouldRenderActions && PositionsTableColumnKey.Actions,

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -11,9 +11,7 @@ import { AttachedExpandingSection, DetachedSection } from '@/components/ContentS
 import { ContentSectionHeader } from '@/components/ContentSectionHeader';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
-import {
-  calculateShouldRenderTriggersInPositionsTable,
-} from '@/state/accountCalculators';
+import { calculateShouldRenderTriggersInPositionsTable } from '@/state/accountCalculators';
 
 import { isTruthy } from '@/lib/isTruthy';
 
@@ -26,7 +24,7 @@ export const Overview = () => {
 
   const shouldRenderTriggers = useSelector(calculateShouldRenderTriggersInPositionsTable);
   // TODO: CT-503
-  // const shouldRenderActions = useSelector(calculateShouldRenderActionsInPositionsTable); 
+  // const shouldRenderActions = useSelector(calculateShouldRenderActionsInPositionsTable);
 
   return (
     <div>
@@ -54,6 +52,7 @@ export const Overview = () => {
                   PositionsTableColumnKey.UnrealizedPnl,
                   PositionsTableColumnKey.RealizedPnl,
                   PositionsTableColumnKey.AverageOpenAndClose,
+                  PositionsTableColumnKey.NetFunding,
                   shouldRenderTriggers && PositionsTableColumnKey.Triggers,
                   // TODO: CT-503 re-enable when close positions dialog is created
                   // shouldRenderActions && PositionsTableColumnKey.Actions,

--- a/src/pages/portfolio/Positions.tsx
+++ b/src/pages/portfolio/Positions.tsx
@@ -10,9 +10,7 @@ import { AttachedExpandingSection } from '@/components/ContentSection';
 import { ContentSectionHeader } from '@/components/ContentSectionHeader';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
-import {
-  calculateShouldRenderTriggersInPositionsTable,
-} from '@/state/accountCalculators';
+import { calculateShouldRenderTriggersInPositionsTable } from '@/state/accountCalculators';
 
 import { isTruthy } from '@/lib/isTruthy';
 import { testFlags } from '@/lib/testFlags';
@@ -48,6 +46,7 @@ export const Positions = () => {
                 PositionsTableColumnKey.UnrealizedPnl,
                 PositionsTableColumnKey.RealizedPnl,
                 PositionsTableColumnKey.AverageOpenAndClose,
+                PositionsTableColumnKey.NetFunding,
                 shouldRenderTriggers && PositionsTableColumnKey.Triggers,
                 // TODO: CT-503 re-enable when close positions dialog is created
                 // shouldRenderActions && PositionsTableColumnKey.Actions,

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -134,6 +134,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                     PositionsTableColumnKey.UnrealizedPnl,
                     PositionsTableColumnKey.RealizedPnl,
                     PositionsTableColumnKey.AverageOpenAndClose,
+                    PositionsTableColumnKey.NetFunding,
                     shouldRenderTriggers && PositionsTableColumnKey.Triggers,
                     shouldRenderActions && PositionsTableColumnKey.Actions,
                   ].filter(isTruthy)

--- a/src/styles/tradeViewMixins.ts
+++ b/src/styles/tradeViewMixins.ts
@@ -10,10 +10,21 @@ export const tradeViewMixins: Record<
   FlattenSimpleInterpolation | FlattenInterpolation<ThemeProps<any>>
 > = {
   horizontalTable: css`
-    --tableCell-padding: 0.5rem 1rem;
+    --tableCell-padding: 0.5rem 0.25rem;
     --tableHeader-backgroundColor: var(--color-layer-2);
     --tableRow-backgroundColor: var(--color-layer-2);
     font: var(--font-mini-book);
+
+    tr {
+      td:first-of-type,
+      th:first-of-type {
+        --tableCell-padding: 0.5rem 0.25rem 0.5rem 1rem;
+      }
+      td:last-of-type,
+      th:last-of-type {
+        --tableCell-padding: 0.5rem 1rem 0.5rem 0.25rem;
+      }
+    }
 
     tbody {
       font: var(--font-small-book);

--- a/src/views/forms/TradeForm/AdvancedTradeOptions.tsx
+++ b/src/views/forms/TradeForm/AdvancedTradeOptions.tsx
@@ -58,66 +58,68 @@ export const AdvancedTradeOptions = () => {
       fullWidth
     >
       <Styled.AdvancedInputsContainer>
-        <Styled.AdvancedInputsRow needsGoodUntil={needsGoodUntil}>
-          {hasTimeInForce && (
-            <Styled.SelectMenu
-              value={timeInForce}
-              onValueChange={(selectedTimeInForceOption: string) =>
-                abacusStateManager.setTradeValue({
-                  value: selectedTimeInForceOption,
-                  field: TradeInputField.timeInForceType,
-                })
-              }
-              label={stringGetter({ key: STRING_KEYS.TIME_IN_FORCE })}
-            >
-              {timeInForceOptions.toArray().map(({ type, stringKey }) => (
-                <Styled.SelectItem
-                  key={type}
-                  value={type}
-                  label={stringGetter({ key: stringKey as StringKey })}
-                />
-              ))}
-            </Styled.SelectMenu>
-          )}
-          {needsGoodUntil && (
-            <Styled.FormInput
-              id="trade-good-til-time"
-              type={InputType.Number}
-              decimals={INTEGER_DECIMALS}
-              label={stringGetter({
-                key: hasTimeInForce ? STRING_KEYS.TIME : STRING_KEYS.GOOD_TIL_TIME,
-              })}
-              onChange={({ value }: NumberFormatValues) => {
-                abacusStateManager.setTradeValue({
-                  value: Number(value),
-                  field: TradeInputField.goodTilDuration,
-                });
-              }}
-              value={duration ?? ''}
-              slotRight={
-                <Styled.InnerSelectMenu
-                  value={unit}
-                  onValueChange={(goodTilTimeTimescale: string) => {
-                    abacusStateManager.setTradeValue({
-                      value: goodTilTimeTimescale,
-                      field: TradeInputField.goodTilUnit,
-                    });
-                  }}
-                >
-                  {Object.values(TimeUnitShort).map((goodTilTimeTimescale: TimeUnitShort) => (
-                    <Styled.InnerSelectItem
-                      key={goodTilTimeTimescale}
-                      value={goodTilTimeTimescale}
-                      label={stringGetter({
-                        key: GOOD_TIL_TIME_TIMESCALE_STRINGS[goodTilTimeTimescale],
-                      })}
-                    />
-                  ))}
-                </Styled.InnerSelectMenu>
-              }
-            />
-          )}
-        </Styled.AdvancedInputsRow>
+        {(hasTimeInForce || needsGoodUntil) && (
+          <Styled.AdvancedInputsRow>
+            {hasTimeInForce && (
+              <Styled.SelectMenu
+                value={timeInForce}
+                onValueChange={(selectedTimeInForceOption: string) =>
+                  abacusStateManager.setTradeValue({
+                    value: selectedTimeInForceOption,
+                    field: TradeInputField.timeInForceType,
+                  })
+                }
+                label={stringGetter({ key: STRING_KEYS.TIME_IN_FORCE })}
+              >
+                {timeInForceOptions.toArray().map(({ type, stringKey }) => (
+                  <Styled.SelectItem
+                    key={type}
+                    value={type}
+                    label={stringGetter({ key: stringKey as StringKey })}
+                  />
+                ))}
+              </Styled.SelectMenu>
+            )}
+            {needsGoodUntil && (
+              <Styled.FormInput
+                id="trade-good-til-time"
+                type={InputType.Number}
+                decimals={INTEGER_DECIMALS}
+                label={stringGetter({
+                  key: hasTimeInForce ? STRING_KEYS.TIME : STRING_KEYS.GOOD_TIL_TIME,
+                })}
+                onChange={({ value }: NumberFormatValues) => {
+                  abacusStateManager.setTradeValue({
+                    value: Number(value),
+                    field: TradeInputField.goodTilDuration,
+                  });
+                }}
+                value={duration ?? ''}
+                slotRight={
+                  <Styled.InnerSelectMenu
+                    value={unit}
+                    onValueChange={(goodTilTimeTimescale: string) => {
+                      abacusStateManager.setTradeValue({
+                        value: goodTilTimeTimescale,
+                        field: TradeInputField.goodTilUnit,
+                      });
+                    }}
+                  >
+                    {Object.values(TimeUnitShort).map((goodTilTimeTimescale: TimeUnitShort) => (
+                      <Styled.InnerSelectItem
+                        key={goodTilTimeTimescale}
+                        value={goodTilTimeTimescale}
+                        label={stringGetter({
+                          key: GOOD_TIL_TIME_TIMESCALE_STRINGS[goodTilTimeTimescale],
+                        })}
+                      />
+                    ))}
+                  </Styled.InnerSelectMenu>
+                }
+              />
+            )}
+          </Styled.AdvancedInputsRow>
+        )}
         {needsExecution && (
           <>
             {executionOptions && (
@@ -234,7 +236,7 @@ Styled.InnerSelectItem = styled(SelectItem)`
   ${formMixins.inputInnerSelectMenuItem}
 `;
 
-Styled.AdvancedInputsRow = styled.div<{ needsGoodUntil: boolean }>`
+Styled.AdvancedInputsRow = styled.div`
   ${layoutMixins.gridEqualColumns}
   gap: var(--form-input-gap);
 `;

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -13,7 +13,7 @@ import {
   POSITION_SIDES,
 } from '@/constants/abacus';
 import { StringGetterFunction, STRING_KEYS } from '@/constants/localization';
-import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
+import { NumberSign, TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { AppRoute } from '@/constants/routes';
 import { PositionSide } from '@/constants/trade';
 
@@ -37,7 +37,7 @@ import { getExistingOpenPositions, getSubaccountConditionalOrders } from '@/stat
 import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
-import { MustBigNumber } from '@/lib/numbers';
+import { MustBigNumber, getNumberSign } from '@/lib/numbers';
 
 import { PositionsActionsCell } from './PositionsTable/PositionsActionsCell';
 import { PositionsMarginCell } from './PositionsTable/PositionsMarginCell';
@@ -57,6 +57,7 @@ export enum PositionsTableColumnKey {
   UnrealizedPnl = 'UnrealizedPnl',
   RealizedPnl = 'RealizedPnl',
   AverageOpenAndClose = 'AverageOpenAndClose',
+  NetFunding = 'NetFunding',
   Triggers = 'Triggers',
   Actions = 'Actions',
 }
@@ -139,7 +140,7 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ unrealizedPnl, unrealizedPnlPercent }) => (
           <TableCell stacked>
             <Styled.OutputSigned
-              isNegative={MustBigNumber(unrealizedPnlPercent?.current).isNegative()}
+              sign={getNumberSign(unrealizedPnlPercent?.current)}
               type={OutputType.Percent}
               value={unrealizedPnlPercent?.current}
               showSign={ShowSign.None}
@@ -240,7 +241,7 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ unrealizedPnl, unrealizedPnlPercent }) => (
           <TableCell stacked>
             <Styled.OutputSigned
-              isNegative={MustBigNumber(unrealizedPnl?.current).isNegative()}
+              sign={getNumberSign(unrealizedPnl?.current)}
               type={OutputType.Fiat}
               value={unrealizedPnl?.current}
             />
@@ -256,7 +257,7 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ realizedPnl, realizedPnlPercent }) => (
           <TableCell stacked>
             <Styled.OutputSigned
-              isNegative={MustBigNumber(realizedPnl?.current).isNegative()}
+              sign={getNumberSign(realizedPnl?.current)}
               type={OutputType.Fiat}
               value={realizedPnl?.current}
               showSign={ShowSign.Negative}
@@ -278,6 +279,21 @@ const getPositionsTableColumnDef = ({
               fractionDigits={tickSizeDecimals}
             />
             <Output type={OutputType.Fiat} value={exitPrice} fractionDigits={tickSizeDecimals} />
+          </TableCell>
+        ),
+      },
+      [PositionsTableColumnKey.NetFunding]: {
+        columnKey: 'netFunding',
+        getCellValue: (row) => row.netFunding,
+        label: stringGetter({ key: STRING_KEYS.NET_FUNDING }),
+        hideOnBreakpoint: MediaQueryKeys.isDesktopSmall,
+        renderCell: ({ netFunding }) => (
+          <TableCell>
+            <Styled.OutputSigned
+              sign={getNumberSign(netFunding)}
+              type={OutputType.Fiat}
+              value={netFunding}
+            />
           </TableCell>
         ),
       },
@@ -486,8 +502,13 @@ Styled.SecondaryColor = styled.span`
   color: var(--color-text-0);
 `;
 
-Styled.OutputSigned = styled(Output)<{ isNegative?: boolean }>`
-  color: ${({ isNegative }) => (isNegative ? `var(--color-negative)` : `var(--color-positive)`)};
+Styled.OutputSigned = styled(Output)<{ sign: NumberSign }>`
+  color: ${({ sign }) =>
+    ({
+      [NumberSign.Positive]: `var(--color-positive)`,
+      [NumberSign.Negative]: `var(--color-negative)`,
+      [NumberSign.Neutral]: `var(--color-text-2)`,
+    }[sign])};
 `;
 
 Styled.HighlightOutput = styled(Output)<{ isNegative?: boolean }>`

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -90,7 +90,7 @@ const getPositionsTableColumnDef = ({
         columnKey: 'details',
         getCellValue: (row) => row.id,
         label: stringGetter({ key: STRING_KEYS.DETAILS }),
-        renderCell: ({ id, asset, leverage, resources, size }) => (
+        renderCell: ({ asset, leverage, resources, size }) => (
           <TableCell stacked slotLeft={<Styled.AssetIcon symbol={asset?.id} />}>
             <Styled.HighlightOutput
               type={OutputType.Asset}
@@ -270,7 +270,7 @@ const getPositionsTableColumnDef = ({
         columnKey: 'entryExitPrice',
         getCellValue: (row) => row.entryPrice?.current,
         label: stringGetter({ key: STRING_KEYS.AVERAGE_OPEN_CLOSE }),
-        hideOnBreakpoint: MediaQueryKeys.isDesktopSmall,
+        hideOnBreakpoint: MediaQueryKeys.isTablet,
         renderCell: ({ entryPrice, exitPrice, tickSizeDecimals }) => (
           <TableCell stacked>
             <Output
@@ -286,7 +286,7 @@ const getPositionsTableColumnDef = ({
         columnKey: 'netFunding',
         getCellValue: (row) => row.netFunding,
         label: stringGetter({ key: STRING_KEYS.NET_FUNDING }),
-        hideOnBreakpoint: MediaQueryKeys.isDesktopSmall,
+        hideOnBreakpoint: MediaQueryKeys.isTablet,
         renderCell: ({ netFunding }) => (
           <TableCell>
             <Styled.OutputSigned


### PR DESCRIPTION
net funding could only be found via single position view, with it gone, we need to show it in the positions table

1. add net funding column
2. handle neutral case for signed output (color should not be green when it's just 0)
3. reduce horizontal padding in table since we're running out of space

![image](https://github.com/dydxprotocol/v4-web/assets/9400120/73180cd3-1529-45c3-869e-f88a3ce2af9d)
