### PR TITLE
fix(sltp): bump abacus for updated perc calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.6.37",
+    "@dydxprotocol/v4-abacus": "^1.6.39",
     "@dydxprotocol/v4-client-js": "^1.1.5",
     "@dydxprotocol/v4-localization": "^1.1.61",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.6.39",
+    "@dydxprotocol/v4-abacus": "^1.6.40",
     "@dydxprotocol/v4-client-js": "^1.1.5",
     "@dydxprotocol/v4-localization": "^1.1.61",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.6.39
-    version: 1.6.39
+    specifier: ^1.6.40
+    version: 1.6.40
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.5
     version: 1.1.5
@@ -1946,10 +1946,10 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.6.39:
+  /@dydxprotocol/v4-abacus@1.6.40:
     resolution:
       {
-        integrity: sha512-ha3PayT/mNcba2xvJodugsXE74GMp+Wb7D9ChSQtaWYozUKTy724RXPMgiGMqARQOMtRrmiZG50v6sY6ptHUiQ==,
+        integrity: sha512-6+lnkYoScbkvK31Zvk0aSxnOLf/xYY5NnFDQUc18PyDAuRi347kIVkJeOEel+gHlykv93RHN0W7jQqAG3dKF2Q==,
       }
     dependencies:
       '@js-joda/core': 3.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.6.37
-    version: 1.6.37
+    specifier: ^1.6.39
+    version: 1.6.39
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.5
     version: 1.1.5
@@ -1946,10 +1946,10 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.6.37:
+  /@dydxprotocol/v4-abacus@1.6.39:
     resolution:
       {
-        integrity: sha512-tgYIusiUwnhtW7DOsEMm8bhgkjLNDpBIxNliypzeS7nnx7rkrR/PV9J2GA9PuxqtUE3FCr7qDlgG9iq9/88C/g==,
+        integrity: sha512-ha3PayT/mNcba2xvJodugsXE74GMp+Wb7D9ChSQtaWYozUKTy724RXPMgiGMqARQOMtRrmiZG50v6sY6ptHUiQ==,
       }
     dependencies:
       '@js-joda/core': 3.2.0


### PR DESCRIPTION
Pulls in this fix: https://github.com/dydxprotocol/v4-abacus/commit/3b13ccb7df9c43e431226197b0a7ebd952587177

Verified by checking percentage on Bitcoin position locally:

| Testnet (before) | Local (after) |
| ---- | ---- | 
| <img width="541" alt="Screenshot 2024-04-11 at 2 50 26 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/8aadf02f-f392-4a01-b17a-3d65a1ca8d62"> | <img width="535" alt="Screenshot 2024-04-11 at 2 50 23 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/396c0e52-be6a-4886-93c8-c914d0a0c2e9"> |

Also confirmed error handling on SLTP still works (which is the majority of the changes between v.37->.40)
 
Note sl/tp is still gated; to test, use `?sltp=true`.