### PR TITLE
chore(closepositions): clean up trade form stage between market changes

### DIFF
--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -65,16 +65,16 @@ export const useCurrentMarketId = () => {
         // If marketId is valid, set currentMarketId
         setLastViewedMarket(marketId);
         dispatch(setCurrentMarketId(marketId));
-        dispatch(closeDialogInTradeBox());
-        if (activeTradeBoxDialog) {
-          // Reopen active trade box dialog with cleared values
-          if (
-            activeTradeBoxDialog.type === TradeBoxDialogTypes.ClosePosition &&
-            openPositions?.find((position: SubaccountPosition) => position.id === marketId)
-          ) {
-            dispatch(openDialogInTradeBox(activeTradeBoxDialog));
-          }
+
+        if (
+          activeTradeBoxDialog?.type === TradeBoxDialogTypes.ClosePosition &&
+          openPositions?.find((position: SubaccountPosition) => position.id === marketId)
+        ) {
+          // Keep the close positions dialog open between market changes as long as there exists an open position
+          return;
         }
+
+        dispatch(closeDialogInTradeBox());
       }
     }
   }, [hasMarketIds, marketId]);

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -118,18 +118,16 @@ export const ClosePositionForm = ({
   useEffect(() => {
     if (currentStep && currentStep !== MobilePlaceOrderSteps.EditOrder) return;
 
-    if (currentInput !== 'closePosition') {
-      abacusStateManager.setClosePositionValue({
-        value: market,
-        field: ClosePositionInputField.market,
-      });
+    abacusStateManager.setClosePositionValue({
+      value: market,
+      field: ClosePositionInputField.market,
+    });
 
-      abacusStateManager.setClosePositionValue({
-        value: SIZE_PERCENT_OPTIONS[MAX_KEY],
-        field: ClosePositionInputField.percent,
-      });
-    }
-  }, [currentInput, market, currentStep]);
+    abacusStateManager.setClosePositionValue({
+      value: SIZE_PERCENT_OPTIONS[MAX_KEY],
+      field: ClosePositionInputField.percent,
+    });
+  }, [market, currentStep]);
 
   const onLastOrderIndexed = useCallback(() => {
     if (!isFirstRender) {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

Follow up to: https://github.com/dydxprotocol/v4-web/pull/407#discussion_r1552125968

Updated `ClosePositionForm`'s `useEffect` update so that it resets market regardless of `currentInput`.

Verified:
- Close positions dialog stays open between market changes when there is a market change to a market w/ an open position
- Close positions dialog closes (we reset to trade form) when there is a market change to a market w/o an open position


https://github.com/dydxprotocol/v4-web/assets/70078372/8f08fcb5-6f47-4f2b-b00f-0dc6262c23da


