### PR TITLE
chore: add position size to liquidation + entry lines

### DIFF
--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -129,10 +129,14 @@ export const useChartLines = ({
     }
 
     const formattedPrice = MustBigNumber(price).toNumber();
+    const quantity = Math.abs(size).toString();
 
     if (maybePositionLine) {
       if (maybePositionLine.getPrice() !== formattedPrice) {
         maybePositionLine.setPrice(formattedPrice);
+      }
+      if (size && maybePositionLine.getQuantity() !== quantity) {
+        maybePositionLine.setQuantity(quantity)
       }
     } else {
       const positionLine = tvWidget
@@ -140,7 +144,7 @@ export const useChartLines = ({
         .createPositionLine({ disableUndo: false })
         .setText(label)
         .setPrice(formattedPrice)
-        .setQuantity('');
+        .setQuantity(quantity);
 
       if (positionLine) {
         const chartLine: ChartLine = { line: positionLine, chartLineType };

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -135,8 +135,8 @@ export const useChartLines = ({
       if (maybePositionLine.getPrice() !== formattedPrice) {
         maybePositionLine.setPrice(formattedPrice);
       }
-      if (size && maybePositionLine.getQuantity() !== quantity) {
-        maybePositionLine.setQuantity(quantity)
+      if (maybePositionLine.getQuantity() !== quantity) {
+        maybePositionLine.setQuantity(quantity);
       }
     } else {
       const positionLine = tvWidget


### PR DESCRIPTION
Add (quantity) size to position lines (liquidation + entry).

<img width="1500" alt="Screenshot 2024-04-23 at 3 33 31 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/d3006441-8a3e-4d2d-ad0e-2a06e6ea3d93">
<img width="1503" alt="Screenshot 2024-04-23 at 3 33 13 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/347bd9b2-297e-4cae-ba4c-64c6a5f12f21">


Noticed an existing bug: the decimal precision on the quantity of the position lines (entry, liquidation) isn't quite right when switching between markets - it uses the decimal precision of the last market (see below). 


https://github.com/dydxprotocol/v4-web/assets/70078372/f2484123-4bd3-4795-828f-1da87f103d4d



Spent a lil too long trying to fix it by rounding the number passed in, only to realize this is (supposedly) controlled by the [priceScale](https://github.com/dydxprotocol/v4-web/blob/main/src/lib/tradingView/dydxfeed/index.ts#L73) of the chart widget api. It seems like it's not quite set properly between markets because we only [set](https://github.com/dydxprotocol/v4-web/blob/a28eae9e8dfd8aa2cb5915099135b9f159e9e2cd/src/hooks/tradingView/useTradingView.ts#L81) the priceScale the first time the chart widget is created. I can't quite trace back how this priceScale is getting updated (doesn't seem like it is) and I can't quite pinpoint why this bug seems to impact only the position lines (and not the orderlines) but unsure if it's worth spending more time here - filed a linear [tix](https://linear.app/dydx/issue/CT-777/position-entry-liquidation-lines-on-chart-have-wrong-precision-when) to follow up, but probably low prio given that toggling the chart lines fixes this.
- Briefly considered re-creating the chart with a new price scale, but scrapped because it was unideal (whole chart unmounts and re-mounts which looks sorta glitchy)