### PR TITLE
fix(sltp): fix liquidation bug comparison

### DIFF
--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -59,8 +59,10 @@ export const PositionsTriggersCell = ({
       return false;
     }
     return (
-      (positionSide === AbacusPositionSide.SHORT && order.price > liquidationPrice) ||
-      (positionSide === AbacusPositionSide.LONG && order.price < liquidationPrice)
+      (positionSide === AbacusPositionSide.SHORT &&
+        (order.triggerPrice ?? order.price) > liquidationPrice) ||
+      (positionSide === AbacusPositionSide.LONG &&
+        (order.triggerPrice ?? order.price) < liquidationPrice)
     );
   };
 
@@ -73,18 +75,14 @@ export const PositionsTriggersCell = ({
           assetId,
           stopLossOrders,
           takeProfitOrders,
-          navigateToMarketOrders: onViewOrders
+          navigateToMarketOrders: onViewOrders,
         },
       })
     );
   };
 
   const viewOrdersButton = (
-    <Styled.Button
-      action={ButtonAction.Navigation}
-      size={ButtonSize.XSmall}
-      onClick={onViewOrders}
-    >
+    <Styled.Button action={ButtonAction.Navigation} size={ButtonSize.XSmall} onClick={onViewOrders}>
       {stringGetter({ key: STRING_KEYS.VIEW_ORDERS })}
       {<Styled.ArrowIcon iconName={IconName.Arrow} />}
     </Styled.Button>
@@ -140,7 +138,11 @@ export const PositionsTriggersCell = ({
       return (
         <>
           {triggerLabel({ liquidationWarningSide })}
-          <Styled.Output type={OutputType.Fiat} value={triggerPrice} fractionDigits={tickSizeDecimals} />
+          <Styled.Output
+            type={OutputType.Fiat}
+            value={triggerPrice}
+            fractionDigits={tickSizeDecimals}
+          />
           {isPartialPosition && (
             <WithHovercard
               align="end"
@@ -179,7 +181,7 @@ export const PositionsTriggersCell = ({
       </>
     );
   };
-  
+
   return (
     <Styled.Cell>
       <Styled.Row>{renderOutput({ label: 'TP', orders: takeProfitOrders })}</Styled.Row>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

Should be comparing with triggerPrice instead of price (this is calculated by abacus with some widened bounds for market orders)

| Before | After |
| ----- | ----- |
| <img width="1538" alt="Screenshot 2024-04-23 at 3 43 14 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/d849697d-b28c-49ad-ae60-67bafb22723c"> | <img width="1482" alt="Screenshot 2024-04-23 at 3 46 03 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/41ade6c1-7e39-43c4-9f9a-5ccdffca07df"> |

Confirmed that we do also show it properly:
<img width="1490" alt="Screenshot 2024-04-23 at 3 47 30 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/cd4d3218-d714-4ba2-91b9-bced7a87f44a">


