### PR TITLE
chore(trade): add CTA to place limit order on liquidity error

### DIFF
--- a/src/constants/styles/colors.ts
+++ b/src/constants/styles/colors.ts
@@ -31,6 +31,8 @@ type BaseColors = {
   white: string;
   green: string;
   red: string;
+
+  whiteFaded: string;
 };
 
 type LayerColors = {

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -2,7 +2,6 @@ import { DateTime } from 'luxon';
 
 import {
   AbacusOrderStatus,
-  AbacusOrderTimeInForce,
   AbacusOrderType,
   AbacusOrderTypes,
   type Asset,

--- a/src/lib/tradeData.ts
+++ b/src/lib/tradeData.ts
@@ -104,7 +104,7 @@ export const getTradeInputAlert = ({
   stepSizeDecimals: Nullable<number>;
   tickSizeDecimals: Nullable<number>;
 }) => {
-  const inputAlerts = abacusInputErrors.map(({ action: errorAction, resources, type }) => {
+  const inputAlerts = abacusInputErrors.map(({ action: errorAction, resources, type, code }) => {
     const { action, text } = resources || {};
     const { stringKey: actionStringKey } = action || {};
     const { stringKey: alertStringKey, params: stringParams } = text || {};
@@ -126,6 +126,7 @@ export const getTradeInputAlert = ({
       alertStringKey,
       alertString: alertStringKey && stringGetter({ key: alertStringKey, params }),
       type: type === ErrorType.warning ? AlertType.Warning : AlertType.Error,
+      code,
     };
   });
 

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -7,6 +7,8 @@ export const GlobalStyle = createGlobalStyle`
     --color-green: ${({ theme }) => theme.green};
     --color-red: ${({ theme }) => theme.red};
 
+    --color-white-faded: ${({ theme }) => theme.whiteFaded};
+
     --color-layer-0: ${({ theme }) => theme.layer0};
     --color-layer-1: ${({ theme }) => theme.layer1};
     --color-layer-2: ${({ theme }) => theme.layer2};

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -11,6 +11,8 @@ const ClassicThemeBase: ThemeColorBase = {
   green: ColorToken.Green1,
   red: ColorToken.Red2,
 
+  whiteFaded: generateFadedColorVariant(ColorToken.White, OpacityToken.Opacity16),
+
   layer0: ColorToken.GrayBlue7,
   layer1: ColorToken.GrayBlue6,
   layer2: ColorToken.GrayBlue5,
@@ -72,6 +74,8 @@ const DarkThemeBase: ThemeColorBase = {
   green: ColorToken.Green0,
   red: ColorToken.Red0,
 
+  whiteFaded: generateFadedColorVariant(ColorToken.White, OpacityToken.Opacity16),
+
   layer0: ColorToken.Black,
   layer1: ColorToken.DarkGray11,
   layer2: ColorToken.DarkGray13,
@@ -132,6 +136,8 @@ const LightThemeBase: ThemeColorBase = {
   white: ColorToken.White,
   green: ColorToken.Green2,
   red: ColorToken.Red1,
+
+  whiteFaded: generateFadedColorVariant(ColorToken.White, OpacityToken.Opacity16),
 
   layer0: ColorToken.White,
   layer1: ColorToken.LightGray6,

--- a/src/views/TradeBoxOrderView.tsx
+++ b/src/views/TradeBoxOrderView.tsx
@@ -80,7 +80,7 @@ export const TradeBoxOrderView = () => {
       onValueChange={onTradeTypeChange}
       sharedContent={
         <Styled.Container>
-          <TradeForm setCurrentTradeType={onTradeTypeChange} />
+          <TradeForm />
         </Styled.Container>
       }
       fullWidthTabs

--- a/src/views/TradeBoxOrderView.tsx
+++ b/src/views/TradeBoxOrderView.tsx
@@ -80,7 +80,7 @@ export const TradeBoxOrderView = () => {
       onValueChange={onTradeTypeChange}
       sharedContent={
         <Styled.Container>
-          <TradeForm />
+          <TradeForm setCurrentTradeType={onTradeTypeChange} />
         </Styled.Container>
       }
       fullWidthTabs

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -38,6 +38,7 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { FormInput } from '@/components/FormInput';
 import { Icon, IconName } from '@/components/Icon';
+import { IconButton } from '@/components/IconButton';
 import { InputType } from '@/components/Input';
 import { Tag } from '@/components/Tag';
 import { ToggleButton } from '@/components/ToggleButton';
@@ -81,6 +82,7 @@ type ElementProps = {
   currentStep?: MobilePlaceOrderSteps;
   setCurrentStep?: (step: MobilePlaceOrderSteps) => void;
   onConfirm?: () => void;
+  setCurrentTradeType: (tradeType: TradeTypes) => void;
 };
 
 type StyleProps = {
@@ -91,6 +93,7 @@ export const TradeForm = ({
   currentStep,
   setCurrentStep,
   onConfirm,
+  setCurrentTradeType,
   className,
 }: ElementProps & StyleProps) => {
   const [isPlacingOrder, setIsPlacingOrder] = useState(false);
@@ -185,6 +188,10 @@ export const TradeForm = ({
     alertContent = inputAlert?.alertString;
     alertType = inputAlert?.type;
   }
+
+  const isLiquidationError = ['MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE'].some(
+    (errorCode) => inputAlert?.code === errorCode
+  );
 
   const orderSideAction = {
     [OrderSide.BUY]: ButtonAction.Create,
@@ -388,7 +395,26 @@ export const TradeForm = ({
 
               {needsAdvancedOptions && <AdvancedTradeOptions />}
 
-              {alertContent && <AlertMessage type={alertType}>{alertContent}</AlertMessage>}
+              {alertContent && (
+                <AlertMessage type={alertType}>
+                  {isLiquidationError ? (
+                    <Styled.MessageWithPrompt>
+                      {alertContent}
+                      {
+                        <Styled.IconButton
+                          iconName={IconName.Arrow}
+                          shape={ButtonShape.Circle}
+                          action={ButtonAction.Navigation}
+                          size={ButtonSize.XSmall}
+                          onClick={() => setCurrentTradeType(TradeTypes.LIMIT)}
+                        ></Styled.IconButton>
+                      }
+                    </Styled.MessageWithPrompt>
+                  ) : (
+                    alertContent
+                  )}
+                </AlertMessage>
+              )}
             </Styled.InputsColumn>
           </Styled.OrderbookAndInputs>
         </>
@@ -572,6 +598,21 @@ Styled.ToggleGroup = styled(ToggleGroup)`
 
 Styled.InputsColumn = styled.div`
   ${formMixins.inputsColumn}
+`;
+
+Styled.MessageWithPrompt = styled.div`
+  ${layoutMixins.row}
+  gap: 0.75rem;
+`;
+
+Styled.IconButton = styled(IconButton)`
+  --button-backgroundColor: var(--color-white-faded);
+  flex-shrink: 0;
+
+  svg {
+    width: 1.25em;
+    height: 1.25em;
+  }
 `;
 
 Styled.ButtonRow = styled.div`

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -404,7 +404,7 @@ export const TradeForm = ({
                         action={ButtonAction.Navigation}
                         size={ButtonSize.XSmall}
                         onClick={() => onTradeTypeChange(TradeTypes.LIMIT)}
-                      ></Styled.IconButton>
+                      />
                     )}
                   </Styled.Message>
                 </AlertMessage>

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -189,7 +189,7 @@ export const TradeForm = ({
     alertType = inputAlert?.type;
   }
 
-  const isLiquidationError = ['MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE'].some(
+  const shouldPromptUserToPlaceLimitOrder = ['MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE'].some(
     (errorCode) => inputAlert?.code === errorCode
   );
 
@@ -397,7 +397,7 @@ export const TradeForm = ({
 
               {alertContent && (
                 <AlertMessage type={alertType}>
-                  {isLiquidationError ? (
+                  {shouldPromptUserToPlaceLimitOrder ? (
                     <Styled.MessageWithPrompt>
                       {alertContent}
                       {

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -82,7 +82,6 @@ type ElementProps = {
   currentStep?: MobilePlaceOrderSteps;
   setCurrentStep?: (step: MobilePlaceOrderSteps) => void;
   onConfirm?: () => void;
-  setCurrentTradeType: (tradeType: TradeTypes) => void;
 };
 
 type StyleProps = {
@@ -93,7 +92,6 @@ export const TradeForm = ({
   currentStep,
   setCurrentStep,
   onConfirm,
-  setCurrentTradeType,
   className,
 }: ElementProps & StyleProps) => {
   const [isPlacingOrder, setIsPlacingOrder] = useState(false);
@@ -397,22 +395,18 @@ export const TradeForm = ({
 
               {alertContent && (
                 <AlertMessage type={alertType}>
-                  {shouldPromptUserToPlaceLimitOrder ? (
-                    <Styled.MessageWithPrompt>
-                      {alertContent}
-                      {
-                        <Styled.IconButton
-                          iconName={IconName.Arrow}
-                          shape={ButtonShape.Circle}
-                          action={ButtonAction.Navigation}
-                          size={ButtonSize.XSmall}
-                          onClick={() => setCurrentTradeType(TradeTypes.LIMIT)}
-                        ></Styled.IconButton>
-                      }
-                    </Styled.MessageWithPrompt>
-                  ) : (
-                    alertContent
-                  )}
+                  <Styled.Message>
+                    {alertContent}
+                    {shouldPromptUserToPlaceLimitOrder && (
+                      <Styled.IconButton
+                        iconName={IconName.Arrow}
+                        shape={ButtonShape.Circle}
+                        action={ButtonAction.Navigation}
+                        size={ButtonSize.XSmall}
+                        onClick={() => onTradeTypeChange(TradeTypes.LIMIT)}
+                      ></Styled.IconButton>
+                    )}
+                  </Styled.Message>
                 </AlertMessage>
               )}
             </Styled.InputsColumn>
@@ -600,7 +594,7 @@ Styled.InputsColumn = styled.div`
   ${formMixins.inputsColumn}
 `;
 
-Styled.MessageWithPrompt = styled.div`
+Styled.Message = styled.div`
   ${layoutMixins.row}
   gap: 0.75rem;
 `;


### PR DESCRIPTION
<!-- Overall purpose of the PR -->
Improve market order volatility experience by re-directing a user to create a limit order when they receive a blocking error due to liquidity conditions.
- Confirmed this should only happen on "error" (when user is blocked from placing an order) and not "warning"

*This only triggers when slippage > 10%; I just modified abacus locally for testing purposes

---

https://github.com/dydxprotocol/v4-web/assets/70078372/86db03a1-8d3b-4977-bec3-766646b51688



## Views

* `TradeForm.tsx`
  * Updated error code here to check if the errorCode to be displayed is a liquidation error; if so, render an arrow CTA which navigates the user to a limit order


## Styles/Mixins

* `styles/colors.ts`, `styles/themes.ts`
  * Added a `whiteFaded` color token for the background of the button
* `styles/globalStyle.ts`
  * Added a `--color-white-faded ` variable

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
