### PR TITLE
feat: order status [0/n] nits and fixes re existing notifications

### DIFF
--- a/src/components/Loading/LoadingSpinner.tsx
+++ b/src/components/Loading/LoadingSpinner.tsx
@@ -61,6 +61,7 @@ Styled.Spinner = styled.div`
 
 Styled.LoadingSpinnerSvg = styled.svg`
   width: var(--spinner-width);
+  height: auto;
 
   animation: ${keyframes`
     to {

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -52,6 +52,7 @@ export const Notification = ({
   withClose = !isToast,
 }: NotificationProps) => {
   const { markCleared, markSeen } = useNotifications();
+  const slotContentOrDescription = slotCustomContent ?? slotDescription;
 
   return (
     <$Container className={className} isToast={isToast} onClick={onClick}>
@@ -87,7 +88,7 @@ export const Notification = ({
           </$ActionItems>
         )}
       </$Header>
-      <$Description>{slotCustomContent ?? slotDescription}</$Description>
+      {slotContentOrDescription && <$Description>{slotContentOrDescription}</$Description>}
       {slotAction && <$Action>{slotAction}</$Action>}
     </$Container>
   );

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -154,7 +154,7 @@ const $Root = styled(Root)`
           33% {
             /* scale: 1.05; */
             /* filter: brightness(120%); */
-            filter: drop-shadow(0 0 var(--color-text-1));
+            filter: drop-shadow(0 0 var(--color-text-0));
           }
         `} calc(var(--toast-transition-duration) * 3) 0.1s;
     }

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -135,9 +135,12 @@ const useNotificationsContext = () => {
     (notification: Notification, status: NotificationStatus) => {
       notification.status = status;
       notification.timestamps[notification.status] = Date.now();
-      setNotifications({ ...notifications, [getKey(notification)]: notification });
+      setNotifications((notifications) => ({
+        ...notifications,
+        [getKey(notification)]: notification,
+      }));
     },
-    [notifications, getKey]
+    [getKey]
   );
 
   const { markUnseen, markSeen, markCleared } = useMemo(


### PR DESCRIPTION
adding these in before the main feature to prevent noise
main changes are:
- visuals: toasts have a lighter drop shadow, get rid of extra padding, shorter Trade notification
- refactor: refactored Trade notification's content out so order status notification can reuse
- bug fix: `updateStatus` was called on outdated notifications, therefore the order of notifications is wrong