### PR TITLE
chore: update dydx ref to latest tag when validating `otherMarketData.json`

### DIFF
--- a/.github/workflows/validate-other-market-data.yml
+++ b/.github/workflows/validate-other-market-data.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'public/configs/otherMarketData.json'
+      - 'scripts/validate-other-market-data.ts'
 
 jobs:
   validate:

--- a/.github/workflows/validate-other-market-data.yml
+++ b/.github/workflows/validate-other-market-data.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'dydxprotocol/v4-chain'
-          ref: '7604f974a699efa8d15a8a70bfc85d8b5b2e2d58'
+          ref: 'd866d2be9361e6809a01804a1b9434a6cd4355ca'
           path: 'v4-chain'
       
       - name: Start v4 localnet

--- a/scripts/validate-other-market-data.ts
+++ b/scripts/validate-other-market-data.ts
@@ -20,7 +20,7 @@ import {
   VoteOption,
 } from '@dydxprotocol/v4-client-js';
 import {
-  Perpetual, // PerpetualMarketType,
+  Perpetual, PerpetualMarketType,
 } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/dydxprotocol/perpetuals/perpetual';
 import { MsgVote } from '@dydxprotocol/v4-proto/src/codegen/cosmos/gov/v1/tx';
 import { ClobPair } from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/clob/clob_pair';
@@ -389,10 +389,10 @@ async function validateAgainstLocalnet(proposals: Proposal[]): Promise<void> {
             stepBaseQuantums: Long.fromNumber(proposal.params.stepBaseQuantums),
             subticksPerTick: proposal.params.subticksPerTick,
             delayBlocks: proposal.params.delayBlocks,
-            // marketType:
-            //   proposal.params.marketType === 'PERPETUAL_MARKET_TYPE_ISOLATED'
-            //     ? PerpetualMarketType.PERPETUAL_MARKET_TYPE_ISOLATED
-            //     : PerpetualMarketType.PERPETUAL_MARKET_TYPE_CROSS,
+            marketType:
+              proposal.params.marketType === 'PERPETUAL_MARKET_TYPE_ISOLATED'
+                ? PerpetualMarketType.PERPETUAL_MARKET_TYPE_ISOLATED
+                : PerpetualMarketType.PERPETUAL_MARKET_TYPE_CROSS,
           },
           proposal.title,
           proposal.summary,


### PR DESCRIPTION
## In This PR
- I update the `scripts/validate-other-market-data.ts` to be compatible with the v5 release of v4-chain
    - Specifically, all markets created in `x/perpetuals` now have their market-type determined in accordance w/ the corresponding proposal's parameters
- I update the v4-chain ref used for simulation of markets in the `otherMarketData.json` to the [v5 release candidate](https://github.com/dydxprotocol/v4-chain/tree/v5.0.0-dev0)
- I update the `validate-other-market-data.yml` workflow file to use the v5.0.0-dev0 release tag of v4-chain + trigger the workflow to execute on changes to the `validate-other-market-data.ts` script