### PR TITLE
fix: move usdc to top of TokenSelectMenu dropdown

### DIFF
--- a/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
@@ -40,6 +40,9 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
 
   const tokens =
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.assets?.toArray() || [];
+
+  console.log('tokens by addy', cctpTokensByAddress);
+  console.log('all tokens', tokens);
   const tokenItems = Object.values(tokens)
     .map((token) => ({
       value: token.type,

--- a/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
@@ -41,8 +41,6 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
   const tokens =
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.assets?.toArray() || [];
 
-  console.log('tokens by addy', cctpTokensByAddress);
-  console.log('all tokens', tokens);
   const tokenItems = Object.values(tokens)
     .map((token) => ({
       value: token.type,
@@ -71,7 +69,8 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
     .filter(
       (token) =>
         type === TransferType.deposit || !!cctpTokensByAddress[token.value] || !CCTPWithdrawalOnly
-    );
+    )
+    .sort((token) => (!!cctpTokensByAddress[token.value] ? -1 : 1));
 
   return (
     <SearchSelectMenu


### PR DESCRIPTION
<img width="400" alt="Screenshot 2024-04-30 at 11 15 01 AM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/b73b952b-cbdb-466b-9a15-6087db03d73f">
<img width="400" alt="Screenshot 2024-04-30 at 11 18 09 AM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/43217178-59c5-471d-8f65-4b2b3ab563ed">

<!-- Overall purpose of the PR -->
moves cctp tokens to the top (in this case, usdc for the token search select item)
