### PR TITLE
feat: add lowest fees decorator text to SourceSelectMenu

### DIFF
--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -58,6 +58,8 @@ export const SourceSelectMenu = ({
     return acc;
   }, {} as Record<string, TokenInfo[]>);
 
+  // withdrawals SourceSelectMenu is half width size so we must throw the decorator text
+  // in the description prop (renders below the item label) instead of in the slotAfter
   const lowestFeesDecoratorProp = type === TransferType.deposit ? 'slotAfter' : 'description';
 
   const chainItems = Object.values(chains)

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -58,6 +58,8 @@ export const SourceSelectMenu = ({
     return acc;
   }, {} as Record<string, TokenInfo[]>);
 
+  const lowestFeesDecoratorProp = type === TransferType.deposit ? 'slotAfter' : 'description';
+
   const chainItems = Object.values(chains)
     .map((chain) => ({
       value: chain.type,
@@ -66,11 +68,26 @@ export const SourceSelectMenu = ({
         onSelect(chain.type, 'chain');
       },
       slotBefore: <Styled.Img src={chain.iconUrl} alt="" />,
+      [lowestFeesDecoratorProp]: (
+        <Styled.Text>
+          {stringGetter({
+            key: STRING_KEYS.LOWEST_FEES_WITH_USDC,
+            params: {
+              LOWEST_FEES_HIGHLIGHT_TEXT: (
+                <Styled.GreenHighlight>
+                  {stringGetter({ key: STRING_KEYS.LOWEST_FEES_HIGHLIGHT_TEXT })}
+                </Styled.GreenHighlight>
+              ),
+            },
+          })}
+        </Styled.Text>
+      ),
     }))
     .filter(
       (chain) =>
         type === TransferType.deposit || !!cctpTokenssByChainId[chain.value] || !CCTPWithdrawalOnly
-    );
+    )
+    .sort((chain) => (!!cctpTokenssByChainId[chain.value] ? -1 : 1));
 
   const exchangeItems = Object.values(exchanges).map((exchange) => ({
     value: exchange.type,
@@ -136,4 +153,13 @@ Styled.ChainRow = styled.div`
   gap: 0.5rem;
   color: var(--color-text-2);
   font: var(--font-base-book);
+`;
+
+Styled.Text = styled.div`
+  font: var(--font-small-regular);
+  color: var(--color-text-0);
+`;
+
+Styled.GreenHighlight = styled.span`
+  color: var(--color-green);
 `;

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -41,7 +41,7 @@ export const SourceSelectMenu = ({
   const { CCTPWithdrawalOnly } = useEnvFeatures();
 
   const stringGetter = useStringGetter();
-  const { type, depositOptions, withdrawalOptions, resources } =
+  const { type, depositOptions, withdrawalOptions } =
     useSelector(getTransferInputs, shallowEqual) || {};
   const chains =
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.chains?.toArray() || [];
@@ -50,7 +50,7 @@ export const SourceSelectMenu = ({
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.exchanges?.toArray() ||
     [];
 
-  const cctpTokenssByChainId = cctpTokens.reduce((acc, token) => {
+  const cctpTokensByChainId = cctpTokens.reduce((acc, token) => {
     if (!acc[token.chainId]) {
       acc[token.chainId] = [];
     }
@@ -87,9 +87,9 @@ export const SourceSelectMenu = ({
     }))
     .filter(
       (chain) =>
-        type === TransferType.deposit || !!cctpTokenssByChainId[chain.value] || !CCTPWithdrawalOnly
+        type === TransferType.deposit || !!cctpTokensByChainId[chain.value] || !CCTPWithdrawalOnly
     )
-    .sort((chain) => (!!cctpTokenssByChainId[chain.value] ? -1 : 1));
+    .sort((chain) => (!!cctpTokensByChainId[chain.value] ? -1 : 1));
 
   const exchangeItems = Object.values(exchanges).map((exchange) => ({
     value: exchange.type,

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -70,7 +70,7 @@ export const SourceSelectMenu = ({
         onSelect(chain.type, 'chain');
       },
       slotBefore: <Styled.Img src={chain.iconUrl} alt="" />,
-      [lowestFeesDecoratorProp]: (
+      [lowestFeesDecoratorProp]: !!cctpTokensByChainId[chain.type] && (
         <Styled.Text>
           {stringGetter({
             key: STRING_KEYS.LOWEST_FEES_WITH_USDC,


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="493" alt="Screenshot 2024-04-30 at 12 06 24 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/6311ddff-e3ee-4b62-ac27-f82d725a8688">
<img width="449" alt="Screenshot 2024-04-30 at 1 04 06 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/ac3657fb-1df2-4293-bfd9-ef96fb6151d9">


<!-- Overall purpose of the PR -->
Add lowest fees decorator text to SourceSelectMenu.

This fulfills the last of the spec described in [Revamp Withdrawals and Deposits UI](https://www.notion.so/dydx/Revamp-withdrawal-and-deposits-UI-71d417f9c08d4c8eab2de4b27f88cbc5#d24417175fb64789b2b029129736d16b)
---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `src/views/forms/AccountManagementForms/SourceSelectMenu.tsx`
  * adds lowest fees decorator text as either descriptor or slotAfter depending on whether or not type is withdrawal or deposit (due to differing size of the select in those situations).

This is not ideal since this makes the assumption that withdraw = small width and deposit = large width. But to do this 'properly' could be very difficult and likely not worth the time it would take for this operation