### PR TITLE
fix: unavailable place order button

### DIFF
--- a/src/hooks/useTriggerOrdersFormInputs.ts
+++ b/src/hooks/useTriggerOrdersFormInputs.ts
@@ -119,7 +119,7 @@ export const useTriggerOrdersFormInputs = ({
     }
 
     return () => {
-      abacusStateManager.clearTriggerOrdersInputValues();
+      abacusStateManager.resetInputState();
     };
   }, []);
 

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -207,8 +207,8 @@ class AbacusStateManager {
       field: TransferInputField.type,
       value: null,
     });
-    this.clearTradeInputValues();
     this.clearTriggerOrdersInputValues();
+    this.clearTradeInputValues({ shouldResetSize: true });
   };
 
   // ------ Set Data ------ //

--- a/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
@@ -18,6 +18,7 @@ import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getSubaccount } from '@/state/accountSelectors';
 import { getSelectedNetwork } from '@/state/appSelectors';
 
+import abacusStateManager from '@/lib/abacus';
 import { log } from '@/lib/telemetry';
 
 type DepositFormProps = {
@@ -42,6 +43,12 @@ export const TestnetDepositForm = ({ onDeposit, onError }: DepositFormProps) => 
       getSubaccounts({ dydxAddress });
     }
   }, [subAccount]);
+
+  useEffect(() => {
+    return () => {
+      abacusStateManager.resetInputState();
+    };
+  }, []);
 
   return (
     <Styled.Form


### PR DESCRIPTION
because of the only one input at a time constraint in abacus, we should pretty much always reset to focused input to trade when transfers/triggers dialogs are closed, so that the trade button has the right validation state (i.e. usually "enter amount")

<img width="231" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/619603f8-25c3-492d-9771-3489d6c29ec2">
<img width="304" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/1f82c3b4-e93f-4c53-b3f6-c41746ba9c4b">


places that use that clear the input state -> refocus to trade input:
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/af134821-2ad3-4758-a1d1-c0ba4b3abc23)
