### PR TITLE
feat: order status [5/n] cancel order toasts

### DIFF
--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -170,11 +170,22 @@ export enum OrderSubmissionStatuses {
   Filled,
 }
 
+export enum OrderCancelStatuses {
+  Submitted,
+  Canceled,
+}
+
 export type LocalOrderData = {
   marketId: string;
   clientId: number;
   orderId?: string;
   orderType: TradeTypes;
   submissionStatus: OrderSubmissionStatuses;
+  errorStringKey?: string;
+};
+
+export type CancelOrderData = {
+  orderId: string;
+  submissionStatus: OrderCancelStatuses;
   errorStringKey?: string;
 };

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -164,28 +164,28 @@ export const CLEARED_SIZE_INPUTS = {
   leverageInput: '',
 };
 
-export enum OrderSubmissionStatuses {
+export enum PlaceOrderStatuses {
   Submitted,
   Placed,
   Filled,
 }
 
-export enum OrderCancelStatuses {
+export enum CancelOrderStatuses {
   Submitted,
   Canceled,
 }
 
-export type LocalOrderData = {
+export type LocalPlaceOrderData = {
   marketId: string;
   clientId: number;
   orderId?: string;
   orderType: TradeTypes;
-  submissionStatus: OrderSubmissionStatuses;
+  submissionStatus: PlaceOrderStatuses;
   errorStringKey?: string;
 };
 
-export type CancelOrderData = {
+export type LocalCancelOrderData = {
   orderId: string;
-  submissionStatus: OrderCancelStatuses;
+  submissionStatus: CancelOrderStatuses;
   errorStringKey?: string;
 };

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -531,11 +531,12 @@ export const notificationTypes: NotificationTypeConfig[] = [
 
       useEffect(() => {
         for (const localCancel of localCancelOrders) {
+          // ensure order exists
+          const existingOrder = allOrders?.find((order) => order.id === localCancel.orderId);
+          if (!existingOrder) return;
+
           // share same notification with existing local order if exists
-          const key = (
-            allOrders?.find((order) => order.id === localCancel.orderId)?.clientId ??
-            localCancel.orderId
-          ).toString();
+          const key = (existingOrder.clientId ?? localCancel.orderId).toString();
 
           trigger(
             key,

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -27,13 +27,13 @@ import { TradeTypes } from '@/constants/trade';
 import { DydxAddress } from '@/constants/wallets';
 
 import {
+  cancelOrderConfirmed,
   cancelOrderFailed,
-  orderCanceledConfirmed,
+  cancelOrderSubmitted,
+  placeOrderFailed,
+  placeOrderSubmitted,
   setHistoricalPnl,
   setSubaccount,
-  submittedCancelOrder,
-  submittedOrder,
-  submittedOrderFailed,
 } from '@/state/account';
 import { getBalances } from '@/state/accountSelectors';
 
@@ -374,7 +374,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
 
           if (data?.clientId !== undefined) {
             dispatch(
-              submittedOrderFailed({
+              placeOrderFailed({
                 clientId: data.clientId,
                 errorStringKey: parsingError?.stringKey ?? STRING_KEYS.SOMETHING_WENT_WRONG,
               })
@@ -393,7 +393,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
 
       if (placeOrderParams?.clientId) {
         dispatch(
-          submittedOrder({
+          placeOrderSubmitted({
             marketId: placeOrderParams.marketId,
             clientId: placeOrderParams.clientId,
             orderType: placeOrderParams.type as TradeTypes,
@@ -429,7 +429,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
     }) => {
       const callback = (success: boolean, parsingError?: Nullable<ParsingError>) => {
         if (success) {
-          dispatch(orderCanceledConfirmed(orderId));
+          dispatch(cancelOrderConfirmed(orderId));
           onSuccess?.();
         } else {
           dispatch(
@@ -442,7 +442,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
         }
       };
 
-      dispatch(submittedCancelOrder(orderId));
+      dispatch(cancelOrderSubmitted(orderId));
       abacusStateManager.cancelOrder(orderId, callback);
     },
     [subaccountClient]

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -418,7 +418,7 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
   );
 
   const cancelOrder = useCallback(
-    async ({
+    ({
       orderId,
       onError,
       onSuccess,

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -27,8 +27,11 @@ import { TradeTypes } from '@/constants/trade';
 import { DydxAddress } from '@/constants/wallets';
 
 import {
+  cancelOrderFailed,
+  orderCanceledConfirmed,
   setHistoricalPnl,
   setSubaccount,
+  submittedCancelOrder,
   submittedOrder,
   submittedOrderFailed,
 } from '@/state/account';
@@ -426,12 +429,20 @@ export const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: Lo
     }) => {
       const callback = (success: boolean, parsingError?: Nullable<ParsingError>) => {
         if (success) {
+          dispatch(orderCanceledConfirmed(orderId));
           onSuccess?.();
         } else {
+          dispatch(
+            cancelOrderFailed({
+              orderId,
+              errorStringKey: parsingError?.stringKey ?? STRING_KEYS.SOMETHING_WENT_WRONG,
+            })
+          );
           onError?.({ errorStringKey: parsingError?.stringKey });
         }
       };
 
+      dispatch(submittedCancelOrder(orderId));
       abacusStateManager.cancelOrder(orderId, callback);
     },
     [subaccountClient]

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -267,8 +267,15 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       throw new Error('Missing compositeClient or localWallet');
     }
 
-    const { subaccountNumber, clientId, orderFlags, clobPairId, goodTilBlock, goodTilBlockTime } =
-      params ?? {};
+    const {
+      orderId,
+      subaccountNumber,
+      clientId,
+      orderFlags,
+      clobPairId,
+      goodTilBlock,
+      goodTilBlockTime,
+    } = params ?? {};
 
     try {
       const tx = await this.compositeClient?.cancelRawOrder(

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -36,7 +36,7 @@ import { DydxChainId, isTestnet } from '@/constants/networks';
 import { UNCOMMITTED_ORDER_TIMEOUT_MS } from '@/constants/trade';
 
 import { RootStore } from '@/state/_store';
-import { submittedOrderTimeout } from '@/state/account';
+import { submittedPlaceOrderTimeout } from '@/state/account';
 import { setInitializationError } from '@/state/app';
 
 import { signComplianceSignature } from '../compliance';
@@ -212,7 +212,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       } = params || {};
 
       setTimeout(() => {
-        this.store?.dispatch(submittedOrderTimeout(clientId));
+        this.store?.dispatch(submittedPlaceOrderTimeout(clientId));
       }, UNCOMMITTED_ORDER_TIMEOUT_MS);
 
       // Place order

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -36,7 +36,7 @@ import { DydxChainId, isTestnet } from '@/constants/networks';
 import { UNCOMMITTED_ORDER_TIMEOUT_MS } from '@/constants/trade';
 
 import { RootStore } from '@/state/_store';
-import { submittedPlaceOrderTimeout } from '@/state/account';
+import { placeOrderTimeout } from '@/state/account';
 import { setInitializationError } from '@/state/app';
 
 import { signComplianceSignature } from '../compliance';
@@ -212,7 +212,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       } = params || {};
 
       setTimeout(() => {
-        this.store?.dispatch(submittedPlaceOrderTimeout(clientId));
+        this.store?.dispatch(placeOrderTimeout(clientId));
       }, UNCOMMITTED_ORDER_TIMEOUT_MS);
 
       // Place order

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -131,6 +131,9 @@ export const accountSlice = createSlice({
                 : order
             )
           : state.submittedOrders,
+        canceledOrders: hasNewFillUpdates
+          ? state.canceledOrders.filter((order) => !filledOrderIds.includes(order.orderId))
+          : state.canceledOrders,
       };
     },
     setFundingPayments: (state, action: PayloadAction<any>) => {

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -160,6 +160,13 @@ export const getSubaccountOpenOrders = createSelector([getSubaccountOrders], (or
 
 /**
  * @param state
+ * @returns order with the specified id
+ */
+export const getOrderById = (orderId: string) =>
+  createSelector([getSubaccountOrders], (orders) => orders?.find((order) => order.id === orderId));
+
+/**
+ * @param state
  * @returns order with the specified client id
  */
 export const getOrderByClientId = (orderClientId: number) =>
@@ -279,6 +286,8 @@ export const getUncommittedOrderClientIds = (state: RootState) =>
  * @returns a list of locally submitted orders for the current FE session
  */
 export const getSubmittedOrders = (state: RootState) => state.account.submittedOrders;
+
+export const getCanceledOrders = (state: RootState) => state.account.canceledOrders;
 
 /**
  * @param orderId

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -283,11 +283,14 @@ export const getUncommittedOrderClientIds = (state: RootState) =>
   state.account.uncommittedOrderClientIds;
 
 /**
- * @returns a list of locally submitted orders for the current FE session
+ * @returns a list of locally placed orders for the current FE session
  */
-export const getSubmittedOrders = (state: RootState) => state.account.submittedOrders;
+export const getLocalPlaceOrders = (state: RootState) => state.account.localPlaceOrders;
 
-export const getCanceledOrders = (state: RootState) => state.account.canceledOrders;
+/**
+ * @returns a list of locally canceled orders for the current FE session
+ */
+export const getLocalCancelOrders = (state: RootState) => state.account.localCancelOrders;
 
 /**
  * @param orderId

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -4,7 +4,7 @@ import styled, { AnyStyledComponent } from 'styled-components';
 import { AbacusOrderStatus, AbacusOrderTypes, type Nullable } from '@/constants/abacus';
 import { ButtonAction } from '@/constants/buttons';
 import { STRING_KEYS, type StringKey } from '@/constants/localization';
-import { OrderCancelStatuses } from '@/constants/notifications';
+import { CancelOrderStatuses } from '@/constants/trade';
 
 import { useStringGetter, useSubaccount } from '@/hooks';
 
@@ -21,7 +21,7 @@ import { type OrderTableRow } from '@/views/tables/OrdersTable';
 
 import { clearOrder } from '@/state/account';
 import { calculateIsAccountViewOnly } from '@/state/accountCalculators';
-import { getCanceledOrders, getOrderDetails } from '@/state/accountSelectors';
+import { getLocalCancelOrders, getOrderDetails } from '@/state/accountSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -37,12 +37,12 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
   const dispatch = useDispatch();
   const selectedLocale = useSelector(getSelectedLocale);
   const isAccountViewOnly = useSelector(calculateIsAccountViewOnly);
-
+  const localCancelOrders = useSelector(getLocalCancelOrders, shallowEqual);
   const { cancelOrder } = useSubaccount();
-  const canceledOrders = useSelector(getCanceledOrders, shallowEqual);
-  const canceledOrder = canceledOrders.find((order) => order.orderId === orderId);
+
+  const localCancelOrder = localCancelOrders.find((order) => order.orderId === orderId);
   const isOrderCanceling =
-    canceledOrder && canceledOrder.submissionStatus < OrderCancelStatuses.Canceled;
+    localCancelOrder && localCancelOrder.submissionStatus < CancelOrderStatuses.Canceled;
 
   const {
     asset,

--- a/src/views/notifications/OrderCancelNotification.tsx
+++ b/src/views/notifications/OrderCancelNotification.tsx
@@ -1,0 +1,103 @@
+import { shallowEqual, useSelector } from 'react-redux';
+import styled, { AnyStyledComponent } from 'styled-components';
+
+import { AbacusOrderStatus, KotlinIrEnumValues, ORDER_STATUS_STRINGS } from '@/constants/abacus';
+import { CancelOrderData } from '@/constants/account';
+import { STRING_KEYS } from '@/constants/localization';
+import { OrderCancelStatuses } from '@/constants/notifications';
+import { ORDER_TYPE_STRINGS } from '@/constants/trade';
+
+import { useStringGetter } from '@/hooks';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Icon, IconName } from '@/components/Icon';
+import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
+import { Notification, NotificationProps } from '@/components/Notification';
+
+import { getOrderById } from '@/state/accountSelectors';
+import { getMarketData } from '@/state/perpetualsSelectors';
+
+import { getTradeType } from '@/lib/orders';
+
+import { OrderStatusIcon } from '../OrderStatusIcon';
+
+type ElementProps = {
+  localCancel: CancelOrderData;
+};
+
+export const OrderCancelNotification = ({
+  isToast,
+  localCancel,
+  notification,
+}: NotificationProps & ElementProps) => {
+  const stringGetter = useStringGetter();
+  const order = useSelector(getOrderById(localCancel.orderId), shallowEqual)!!;
+  const marketData = useSelector(getMarketData(order.marketId), shallowEqual);
+  const { assetId } = marketData ?? {};
+  const tradeType = getTradeType(order.type.rawValue) ?? undefined;
+  const orderTypeKey = tradeType && ORDER_TYPE_STRINGS[tradeType]?.orderTypeKey;
+  const indexedOrderStatus = order.status.rawValue;
+  const cancelStatus = localCancel.submissionStatus;
+
+  let orderStatusStringKey = STRING_KEYS.CANCELING;
+  let orderStatusIcon = <Styled.LoadingSpinner />;
+  let customContent = null;
+
+  if (cancelStatus === OrderCancelStatuses.Canceled) {
+    orderStatusStringKey =
+      ORDER_STATUS_STRINGS[
+        indexedOrderStatus as unknown as KotlinIrEnumValues<typeof AbacusOrderStatus>
+      ];
+    orderStatusIcon = <Styled.OrderStatusIcon status={indexedOrderStatus} />;
+  }
+
+  if (localCancel.errorStringKey) {
+    orderStatusStringKey = STRING_KEYS.FAILED;
+    orderStatusIcon = <Styled.WarningIcon iconName={IconName.Warning} />;
+    customContent = <span>{stringGetter({ key: localCancel.errorStringKey })}</span>;
+  }
+
+  return (
+    <Notification
+      isToast={isToast}
+      notification={notification}
+      slotIcon={<AssetIcon symbol={assetId} />}
+      slotTitle={orderTypeKey && stringGetter({ key: orderTypeKey })}
+      slotTitleRight={
+        <Styled.OrderStatus>
+          {stringGetter({ key: orderStatusStringKey })}
+          {orderStatusIcon}
+        </Styled.OrderStatus>
+      }
+      slotCustomContent={customContent}
+    />
+  );
+};
+
+const Styled: Record<string, AnyStyledComponent> = {};
+
+Styled.Label = styled.span`
+  ${layoutMixins.row}
+  gap: 0.5ch;
+`;
+
+Styled.OrderStatus = styled(Styled.Label)`
+  color: var(--color-text-0);
+  font: var(--font-small-book);
+`;
+
+Styled.LoadingSpinner = styled(LoadingSpinner)`
+  --spinner-width: 0.9375rem;
+  color: var(--color-accent);
+`;
+
+Styled.WarningIcon = styled(Icon)`
+  color: var(--color-warning);
+`;
+
+Styled.OrderStatusIcon = styled(OrderStatusIcon)`
+  width: 0.9375rem;
+  height: 0.9375rem;
+`;

--- a/src/views/notifications/OrderCancelNotification.tsx
+++ b/src/views/notifications/OrderCancelNotification.tsx
@@ -2,10 +2,8 @@ import { shallowEqual, useSelector } from 'react-redux';
 import styled, { AnyStyledComponent } from 'styled-components';
 
 import { AbacusOrderStatus, KotlinIrEnumValues, ORDER_STATUS_STRINGS } from '@/constants/abacus';
-import { CancelOrderData } from '@/constants/account';
 import { STRING_KEYS } from '@/constants/localization';
-import { OrderCancelStatuses } from '@/constants/notifications';
-import { ORDER_TYPE_STRINGS } from '@/constants/trade';
+import { CancelOrderStatuses, LocalCancelOrderData, ORDER_TYPE_STRINGS } from '@/constants/trade';
 
 import { useStringGetter } from '@/hooks';
 
@@ -24,7 +22,7 @@ import { getTradeType } from '@/lib/orders';
 import { OrderStatusIcon } from '../OrderStatusIcon';
 
 type ElementProps = {
-  localCancel: CancelOrderData;
+  localCancel: LocalCancelOrderData;
 };
 
 export const OrderCancelNotification = ({
@@ -45,7 +43,7 @@ export const OrderCancelNotification = ({
   let orderStatusIcon = <Styled.LoadingSpinner />;
   let customContent = null;
 
-  if (cancelStatus === OrderCancelStatuses.Canceled) {
+  if (cancelStatus === CancelOrderStatuses.Canceled) {
     orderStatusStringKey =
       ORDER_STATUS_STRINGS[
         indexedOrderStatus as unknown as KotlinIrEnumValues<typeof AbacusOrderStatus>

--- a/src/views/notifications/OrderStatusNotification.tsx
+++ b/src/views/notifications/OrderStatusNotification.tsx
@@ -11,8 +11,8 @@ import { STRING_KEYS } from '@/constants/localization';
 import { USD_DECIMALS } from '@/constants/numbers';
 import {
   ORDER_TYPE_STRINGS,
-  OrderSubmissionStatuses,
-  type LocalOrderData,
+  PlaceOrderStatuses,
+  type LocalPlaceOrderData,
 } from '@/constants/trade';
 
 import { useStringGetter } from '@/hooks';
@@ -33,7 +33,7 @@ import { OrderStatusIcon } from '../OrderStatusIcon';
 import { FillDetails } from './TradeNotification/FillDetails';
 
 type ElementProps = {
-  localOrder: LocalOrderData;
+  localOrder: LocalPlaceOrderData;
 };
 
 export const OrderStatusNotification = ({
@@ -55,8 +55,8 @@ export const OrderStatusNotification = ({
   let customContent = null;
 
   switch (submissionStatus) {
-    case OrderSubmissionStatuses.Placed:
-    case OrderSubmissionStatuses.Filled:
+    case PlaceOrderStatuses.Placed:
+    case PlaceOrderStatuses.Filled:
       if (indexedOrderStatus) {
         // skip pending / best effort open state -> still show as submitted (loading)
         if (indexedOrderStatus === AbacusOrderStatus.pending.rawValue) break;


### PR DESCRIPTION
add notifications for canceling order as well for more visual feedback

- notification is very similar to order status notif, but with different data
<img width="1136" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/95b0fbc3-748f-467d-a567-10c7329e8b8f">
<img width="402" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/6623b2bc-657f-409c-bdc9-451f67f29c17">

to test
- cancel orders via orders table + order details dialog
- cancel short term orders -- this is a weird flow but you should see just one toast reflecting most updated status
