### PR TITLE
chore(sltp): bump abacus v to pull in new analytics + change sl/tp duration to 90 days

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "^1.6.50",
+    "@dydxprotocol/v4-abacus": "^1.6.54",
     "@dydxprotocol/v4-client-js": "^1.1.7",
     "@dydxprotocol/v4-localization": "^1.1.76",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: ^1.6.50
-    version: 1.6.50
+    specifier: ^1.6.54
+    version: 1.6.54
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.7
     version: 1.1.7
@@ -1946,10 +1946,10 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.6.50:
+  /@dydxprotocol/v4-abacus@1.6.54:
     resolution:
       {
-        integrity: sha512-+VN0RSY1Cgh9O8+1sQ6EWRvHozhomOvG+s3WkEqMe/rC2pPV12t3O4EM568uSxtI34v13TX6/NV+oNjvYx0Y7w==,
+        integrity: sha512-lmAaUlDq1Swx8T7bNWOpF3WRqhrEDEulrE1BDcab9b3wCA3hT9buFBU7e73JryBqDRVCyuqDIvIF0VDqZsCAKQ==,
       }
     dependencies:
       '@js-joda/core': 3.2.0
@@ -15987,6 +15987,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
+    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution:

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -275,6 +275,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 icon: assetIcon,
                 title: title,
                 body: body,
+                toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
                 renderCustomBody: ({ isToast, notification }) => (
                   <TriggerOrderNotification
                     status={status}


### PR DESCRIPTION
abacus changes to pull: [1](https://github.com/dydxprotocol/v4-abacus/pull/325), [2](https://github.com/dydxprotocol/v4-abacus/pull/330)

also added duration for TP/SL notifications (because they were never disappearing and it was driving me bonkers)

Confirmed update to 90 days:

<img width="1013" alt="Screenshot 2024-05-01 at 11 07 20 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/c3e041c1-2254-476c-8098-ec1a88f81782">

Double checked logs by building a v of abacus locally with Logger.e {}

<img width="960" alt="Screenshot 2024-05-01 at 11 17 01 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/354b4b56-efe6-46fc-bfe6-d2ce20a4f25b">


