### PR TITLE
chore: clean up order status icon

### DIFF
--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -4,66 +4,58 @@ import {
   AbacusOrderStatus,
   AbacusOrderType,
   AbacusOrderTypes,
+  KotlinIrEnumValues,
+  TRADE_TYPES,
   type Asset,
-  type Nullable,
   type OrderStatus,
   type PerpetualMarket,
   type SubaccountFill,
   type SubaccountFundingPayment,
   type SubaccountOrder,
 } from '@/constants/abacus';
-import { STRING_KEYS } from '@/constants/localization';
 
 import { IconName } from '@/components/Icon';
 
 import { convertAbacusOrderSide } from '@/lib/abacus/conversions';
-import { MustBigNumber } from '@/lib/numbers';
 
-export const getStatusIconInfo = ({
-  status,
-  totalFilled,
-}: {
-  status: OrderStatus;
-  totalFilled: Nullable<number>;
-}) => {
+export const getOrderStatusInfo = ({ status }: { status: string }) => {
   switch (status) {
-    case AbacusOrderStatus.open: {
-      return MustBigNumber(totalFilled).gt(0)
-        ? {
-            statusIcon: IconName.OrderPartiallyFilled,
-            statusIconColor: `var(--color-warning)`,
-            statusStringKey: STRING_KEYS.PARTIALLY_FILLED,
-          }
-        : {
-            statusIcon: IconName.OrderOpen,
-            statusIconColor: `var(--color-text-2)`,
-          };
+    case AbacusOrderStatus.open.rawValue: {
+      return {
+        statusIcon: IconName.OrderOpen,
+        statusIconColor: `var(--color-text-2)`,
+      };
     }
-    case AbacusOrderStatus.filled: {
+    case AbacusOrderStatus.partiallyFilled.rawValue:
+      return {
+        statusIcon: IconName.OrderPartiallyFilled,
+        statusIconColor: `var(--color-warning)`,
+      };
+    case AbacusOrderStatus.filled.rawValue: {
       return {
         statusIcon: IconName.OrderFilled,
         statusIconColor: `var(--color-success)`,
       };
     }
-    case AbacusOrderStatus.cancelled: {
+    case AbacusOrderStatus.cancelled.rawValue: {
       return {
         statusIcon: IconName.OrderCanceled,
         statusIconColor: `var(--color-error)`,
       };
     }
-    case AbacusOrderStatus.canceling: {
+    case AbacusOrderStatus.canceling.rawValue: {
       return {
         statusIcon: IconName.OrderPending,
         statusIconColor: `var(--color-error)`,
       };
     }
-    case AbacusOrderStatus.untriggered: {
+    case AbacusOrderStatus.untriggered.rawValue: {
       return {
         statusIcon: IconName.OrderUntriggered,
         statusIconColor: `var(--color-text-2)`,
       };
     }
-    case AbacusOrderStatus.pending:
+    case AbacusOrderStatus.pending.rawValue:
     default: {
       return {
         statusIcon: IconName.OrderPending,
@@ -131,3 +123,6 @@ export const getHydratedTradingData = ({
   tickSizeDecimals: perpetualMarkets?.[data.marketId]?.configs?.tickSizeDecimals,
   ...('side' in data && { orderSide: convertAbacusOrderSide(data.side) }),
 });
+
+export const getTradeType = (orderType: string) =>
+  TRADE_TYPES[orderType as KotlinIrEnumValues<typeof AbacusOrderType>];

--- a/src/views/OrderStatusIcon.tsx
+++ b/src/views/OrderStatusIcon.tsx
@@ -1,57 +1,20 @@
 import styled from 'styled-components';
 
-import { AbacusOrderStatus } from '@/constants/abacus';
+import { Icon } from '@/components/Icon';
 
-import { Icon, IconName } from '@/components/Icon';
+import { getOrderStatusInfo } from '@/lib/orders';
 
 type ElementProps = {
   status: string;
-  totalFilled?: number;
 };
 
 type StyleProps = {
   className?: string;
 };
 
-export const OrderStatusIcon = ({ className, status, totalFilled }: ElementProps & StyleProps) => {
-  const { iconName, color } = {
-    [AbacusOrderStatus.open.rawValue]:
-      totalFilled && totalFilled > 0
-        ? {
-            iconName: IconName.OrderPartiallyFilled,
-            color: 'var(--color-warning)',
-          }
-        : {
-            iconName: IconName.OrderOpen,
-            color: 'var(--color-text-2)',
-          },
-    [AbacusOrderStatus.partiallyFilled.rawValue]: {
-      iconName: IconName.OrderPartiallyFilled,
-      color: 'var(--color-warning)',
-    },
-    [AbacusOrderStatus.filled.rawValue]: {
-      iconName: IconName.OrderFilled,
-      color: 'var(--color-success)',
-    },
-    [AbacusOrderStatus.cancelled.rawValue]: {
-      iconName: IconName.OrderCanceled,
-      color: 'var(--color-error)',
-    },
-    [AbacusOrderStatus.canceling.rawValue]: {
-      iconName: IconName.OrderPending,
-      color: 'var(--color-error)',
-    },
-    [AbacusOrderStatus.pending.rawValue]: {
-      iconName: IconName.OrderPending,
-      color: 'var(--color-text-2)',
-    },
-    [AbacusOrderStatus.untriggered.rawValue]: {
-      iconName: IconName.OrderPending,
-      color: 'var(--color-text-2)',
-    },
-  }[status];
-
-  return <$Icon className={className} iconName={iconName} color={color} />;
+export const OrderStatusIcon = ({ className, status }: ElementProps & StyleProps) => {
+  const { statusIcon, statusIconColor } = getOrderStatusInfo({ status });
+  return <$Icon className={className} iconName={statusIcon} color={statusIconColor} />;
 };
 
 const $Icon = styled(Icon)<{ color: string }>`

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -15,9 +15,9 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { type DetailsItem } from '@/components/Details';
 import { DetailsDialog } from '@/components/DetailsDialog';
-import { Icon } from '@/components/Icon';
 import { OrderSideTag } from '@/components/OrderSideTag';
 import { Output, OutputType } from '@/components/Output';
+import { OrderStatusIcon } from '@/views/OrderStatusIcon';
 import { type OrderTableRow } from '@/views/tables/OrdersTable';
 
 import { clearOrder } from '@/state/account';
@@ -26,12 +26,7 @@ import { getOrderDetails } from '@/state/accountSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
-import {
-  getStatusIconInfo,
-  isMarketOrderType,
-  isOrderStatusClearable,
-  relativeTimeString,
-} from '@/lib/orders';
+import { isMarketOrderType, isOrderStatusClearable, relativeTimeString } from '@/lib/orders';
 
 type ElementProps = {
   orderId: string;
@@ -68,11 +63,6 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
   } = (useSelector(getOrderDetails(orderId)) as OrderTableRow) || {};
   const [isPlacingCancel, setIsPlacingCancel] = useState(false);
 
-  const { statusIcon, statusIconColor, statusStringKey } = getStatusIconInfo({
-    status,
-    totalFilled,
-  });
-
   const renderOrderPrice = ({
     type,
     price,
@@ -107,13 +97,9 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
       label: stringGetter({ key: STRING_KEYS.STATUS }),
       value: (
         <Styled.Row>
-          <Styled.StatusIcon iconName={statusIcon} color={statusIconColor} />
+          <OrderStatusIcon status={status.rawValue} />
           <Styled.Status>
-            {statusStringKey
-              ? stringGetter({ key: statusStringKey })
-              : resources.statusStringKey
-              ? stringGetter({ key: resources.statusStringKey })
-              : undefined}
+            {resources.statusStringKey && stringGetter({ key: resources.statusStringKey })}
           </Styled.Status>
         </Styled.Row>
       ),
@@ -222,10 +208,6 @@ const Styled: Record<string, AnyStyledComponent> = {};
 
 Styled.Row = styled.div`
   ${layoutMixins.inlineRow}
-`;
-
-Styled.StatusIcon = styled(Icon)<{ color: string }>`
-  color: ${({ color }) => color};
 `;
 
 Styled.Status = styled.span`

--- a/src/views/notifications/TradeNotification/index.tsx
+++ b/src/views/notifications/TradeNotification/index.tsx
@@ -61,7 +61,7 @@ export const TradeNotification = ({ isToast, data, notification }: TradeNotifica
       slotTitleRight={
         <Styled.OrderStatus>
           {stringGetter({ key: ORDER_STATUS_STRINGS[orderStatus] })}
-          <Styled.OrderStatusIcon status={orderStatus} totalFilled={parseFloat(FILLED_AMOUNT)} />
+          <Styled.OrderStatusIcon status={orderStatus} />
         </Styled.OrderStatus>
       }
       slotCustomContent={

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -46,12 +46,13 @@ import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 import { MustBigNumber } from '@/lib/numbers';
 import {
   getHydratedTradingData,
-  getStatusIconInfo,
+  getOrderStatusInfo,
   isMarketOrderType,
   isOrderStatusClearable,
 } from '@/lib/orders';
 import { getStringsForDateTimeDiff } from '@/lib/timeUtils';
 
+import { OrderStatusIcon } from '../OrderStatusIcon';
 import { OrderActionsCell } from './OrdersTable/OrderActionsCell';
 
 export enum OrdersTableColumnKey {
@@ -106,25 +107,18 @@ const getOrdersTableColumnDef = ({
         columnKey: 'status',
         getCellValue: (row) => row.status.name,
         label: stringGetter({ key: STRING_KEYS.STATUS }),
-        renderCell: ({ status, totalFilled, resources }) => {
-          const { statusIcon, statusIconColor, statusStringKey } = getStatusIconInfo({
-            status,
-            totalFilled,
-          });
-
+        renderCell: ({ status, resources }) => {
           return (
             <TableCell>
               <Styled.WithTooltip
                 tooltipString={
-                  statusStringKey
-                    ? stringGetter({ key: statusStringKey })
-                    : resources.statusStringKey
+                  resources.statusStringKey
                     ? stringGetter({ key: resources.statusStringKey })
                     : undefined
                 }
                 side="right"
               >
-                <Styled.StatusIcon iconName={statusIcon} color={statusIconColor} />
+                <OrderStatusIcon status={status.rawValue} />
               </Styled.WithTooltip>
               {resources.typeStringKey && stringGetter({ key: resources.typeStringKey })}
             </TableCell>
@@ -227,10 +221,7 @@ const getOrdersTableColumnDef = ({
           key: STRING_KEYS.FILL,
         })}`,
         renderCell: ({ asset, createdAtMilliseconds, size, status, totalFilled, resources }) => {
-          const { statusIconColor, statusStringKey } = getStatusIconInfo({
-            status,
-            totalFilled,
-          });
+          const { statusIconColor } = getOrderStatusInfo({ status: status.rawValue });
 
           return (
             <TableCell
@@ -250,9 +241,7 @@ const getOrdersTableColumnDef = ({
               }
             >
               <span>
-                {statusStringKey
-                  ? stringGetter({ key: statusStringKey })
-                  : resources.statusStringKey && stringGetter({ key: resources.statusStringKey })}
+                {resources.statusStringKey && stringGetter({ key: resources.statusStringKey })}
               </span>
               <Styled.InlineRow>
                 <Output
@@ -455,10 +444,6 @@ Styled.StatusDot = styled.div<{ color: string }>`
   border: 2px solid var(--tableRow-currentBackgroundColor);
 
   background-color: ${({ color }) => color};
-`;
-
-Styled.StatusIcon = styled(Icon)<{ color: string }>`
-  color: ${({ color }) => color};
 `;
 
 Styled.WithTooltip = styled(WithTooltip)`


### PR DESCRIPTION
some duplication and discrepancy between existing `getStatusIconInfo` and `OrderStatusIcon` -> combining and cleaning up logic
- remove open -> partially filled logic because it's now supported

to test, check fill notification and orders tab
<img width="961" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/0d3a547c-1796-470f-937a-aba8417f0b89">
