### PR TITLE
chore(sltp): create notification for sltp

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "^1.6.54",
     "@dydxprotocol/v4-client-js": "^1.1.7",
-    "@dydxprotocol/v4-localization": "^1.1.76",
+    "@dydxprotocol/v4-localization": "^1.1.78",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@privy-io/react-auth": "^1.59.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.1.7
     version: 1.1.7
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.76
-    version: 1.1.76
+    specifier: ^1.1.78
+    version: 1.1.78
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1988,10 +1988,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.76:
+  /@dydxprotocol/v4-localization@1.1.78:
     resolution:
       {
-        integrity: sha512-xEiup6axrLKvM5cqEGr51EzJLnbcQrNQo6q6s7E+KbVMVxsXcMdyfrJBBEpFVnlCIrPIjt9S2rAq7NHDbMsSNA==,
+        integrity: sha512-zyPPa8i9pi8Qmj4vhryAec50Bund1KQyAGF5inpJ0gZNhTjGer3KEvWSUOGCODkZxasn4RKsGvtioiYynCzCMg==,
       }
     dev: false
 

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -153,6 +153,7 @@ const $Description = styled.div`
   margin-top: 0.5rem;
   color: var(--color-text-0);
   font: var(--font-small-book);
+  white-space: break-spaces;
 `;
 
 const $Action = styled.div`

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -185,6 +185,7 @@ export type TriggerOrderNotification = {
 };
 
 export enum ReleaseUpdateNotificationIds {
+  RevampedConditionalOrders = 'revamped-conditional-orders',
   IncentivesS4 = 'incentives-s4',
   IncentivesDistributedS3 = 'incentives-distributed-s3',
 }

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -494,9 +494,6 @@ const $Output = styled(Output)`
   display: inline-block;
 `;
 
-const $Body = styled.p`
-  white-space: nowrap;
-`;
 const $Link = styled(Link)`
   --link-color: var(--color-accent);
   display: inline-block;

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -305,11 +305,14 @@ export const notificationTypes: NotificationTypeConfig[] = [
     useTrigger: ({ trigger }) => {
       const { chainTokenLabel } = useTokenConfigs();
       const stringGetter = useStringGetter();
-      const expirationDate = new Date('2024-05-09T23:59:59');
+
+      const incentivesExpirationDate = new Date('2024-05-09T23:59:59');
+      const conditionalOrdersExpirationDate = new Date('2024-06-01T23:59:59');
+
       const currentDate = new Date();
 
       useEffect(() => {
-        if (currentDate <= expirationDate) {
+        if (currentDate <= incentivesExpirationDate) {
           trigger(
             ReleaseUpdateNotificationIds.IncentivesS4,
             {
@@ -328,6 +331,31 @@ export const notificationTypes: NotificationTypeConfig[] = [
               }),
               toastSensitivity: 'foreground',
               groupKey: ReleaseUpdateNotificationIds.IncentivesS4,
+            },
+            []
+          );
+        }
+
+        if (currentDate <= conditionalOrdersExpirationDate) {
+          trigger(
+            ReleaseUpdateNotificationIds.RevampedConditionalOrders,
+            {
+              icon: <AssetIcon symbol={chainTokenLabel} />,
+              title: stringGetter({
+                key: 'NOTIFICATIONS.CONDITIONAL_ORDERS_REVAMP.TITLE',
+              }),
+              body: stringGetter({
+                key: 'NOTIFICATIONS.CONDITIONAL_ORDERS_REVAMP.BODY',
+                params: {
+                  TWITTER_LINK: (
+                    <$Link href="https://twitter.com/dYdX/status/1785339109268935042">
+                      {stringGetter({ key: STRING_KEYS.HERE })}
+                    </$Link>
+                  ),
+                },
+              }),
+              toastSensitivity: 'foreground',
+              groupKey: ReleaseUpdateNotificationIds.RevampedConditionalOrders,
             },
             []
           );
@@ -463,5 +491,13 @@ const $WarningIcon = styled(Icon)`
 `;
 
 const $Output = styled(Output)`
+  display: inline-block;
+`;
+
+const $Body = styled.p`
+  white-space: nowrap;
+`;
+const $Link = styled(Link)`
+  --link-color: var(--color-accent);
   display: inline-block;
 `;

--- a/src/views/dialogs/PreferencesDialog.tsx
+++ b/src/views/dialogs/PreferencesDialog.tsx
@@ -83,7 +83,7 @@ export const usePreferenceMenu = () => {
         },
         {
           value: NotificationType.ReleaseUpdates,
-          label: 'Release Updates',
+          label: stringGetter({ key: STRING_KEYS.RELEASE_UPDATES }),
           slotAfter: (
             <Switch
               name={NotificationType.ReleaseUpdates}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="289" alt="Screenshot 2024-05-01 at 5 49 53 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/09d7c3c2-f2fa-48ce-8306-874daa07466b">
<img width="362" alt="Screenshot 2024-05-01 at 5 51 27 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/cf9ce194-d0d0-40c7-95bd-fcb22a8fdd57">


<!-- Overall purpose of the PR -->

---

## Views

* `PreferencesDialog`
  * Update to localize `Release Updates`

## Components

* `Notification.tsx`
  * Add `white-space: break-spaces` to body to prevent period from falling onto new line after `here`. Checked other notifications and everything looks fine, so I'm inclined to keep it like this 🤔 but lmk if there's something i haven't thought through!

## Constants/Types

* `constants/notifications.ts`
  * added `RevampedConditionalOrders` to `ReleaseUpdateNotificationIds`

## Hooks

* `hooks/useNotificationTypes`
  * synced with product that we want this notification to last for ~1 month
  * added trigger to render conditional orders revamp notification

## Packages

* `localization`
  * updated: v1.1.76 -> v1.1.78


---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
