### PR TITLE
fix: change script to use relative pathing

### DIFF
--- a/scripts/install-local-abacus.js
+++ b/scripts/install-local-abacus.js
@@ -5,23 +5,25 @@ const clean = process.argv.includes('--clean');
 if (clean) {
   infoMessage('Running deep clean.');
   nonFatalExec('pnpm remove @dydxprotocol/v4-abacus'); // remove abacus from node_modules
-  nonFatalExec('cd ~/v4-abacus && ./gradlew clean'); // cleanup gradle build outputs
-  nonFatalExec('cd ~/v4-abacus && ./gradlew --stop'); // stop any running gradle daemons
+  nonFatalExec('cd ../v4-abacus && ./gradlew clean'); // cleanup gradle build outputs
+  nonFatalExec('cd ../v4-abacus && ./gradlew --stop'); // stop any running gradle daemons
   nonFatalExec('rm -rf ~/.gradle/caches'); // nuke the gradle cache
 }
 
 infoMessage('Cleaning up any previously built abacus packages...');
-nonFatalExec('rm ~/v4-abacus/build/packages/*.tgz');
+nonFatalExec('rm ../v4-abacus/build/packages/*.tgz');
 
 infoMessage('Building abacus...');
-fatalExec('cd ~/v4-abacus && ./gradlew packJsPackage');
+fatalExec('cd ../v4-abacus && ./gradlew packJsPackage');
 
 infoMessage('Installing local abacus package...');
-fatalExec("find ~/v4-abacus/build/packages -name '*.tgz' | head -n 1 | xargs pnpm install");
+fatalExec("find ../v4-abacus/build/packages -name '*.tgz' | head -n 1 | xargs pnpm install");
 infoMessage('Successfully installed local abacus package.');
 
 infoMessage('Generating local-abacus-hash...');
-fatalExec("find ~/v4-abacus/build/packages -name '*.tgz' | head -n 1 | shasum > local-abacus-hash");
+fatalExec(
+  "find ../v4-abacus/build/packages -name '*.tgz' | head -n 1 | shasum > local-abacus-hash"
+);
 
 infoMessage('Vite dev server should have restarted automatically.');
 


### PR DESCRIPTION
the readme states that 
"Our tooling assumes that the [v4-abacus repo](https://github.com/dydxprotocol/v4-abacus) is checked out alongside v4-web
```
--- parent folder
 |___ v4-web
 |___ v4-abacus
```
"

however, the script currently seeks for `~/v4-abacus` which requires that v4-abacus be put in a specific directory, rather than just being in the same repo as v4-web. this fixes some UX issues by:
1. making the readme accurate - now abacus just need to be in the same dir as v4-web
2. giving the dev more flexibility on where they put their code (mine is in ~/dydx)