### PR TITLE
refactor(market-revamp): sum staking rewards, update compact tables, reduce sparkline api call

### DIFF
--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -60,6 +60,7 @@ type ElementProps = {
   isLoading?: boolean;
   fractionDigits?: number | null;
   showSign?: ShowSign;
+  slotLeft?: React.ReactNode;
   slotRight?: React.ReactNode;
   useGrouping?: boolean;
   roundingMode?: BigNumber.RoundingMode;
@@ -90,6 +91,7 @@ export const Output = ({
   isLoading,
   fractionDigits,
   showSign = ShowSign.Negative,
+  slotLeft,
   slotRight,
   useGrouping = true,
   withSubscript = false,
@@ -122,6 +124,7 @@ export const Output = ({
           title={`${value ?? ''}${tag ? ` ${tag}` : ''}`}
           className={className}
         >
+          {slotLeft}
           {value?.toString() ?? null}
 
           {tag && <Tag>{tag}</Tag>}
@@ -251,6 +254,7 @@ export const Output = ({
           withParentheses={withParentheses}
           withBaseFont={withBaseFont}
         >
+          {slotLeft}
           {sign && <Styled.Sign>{sign}</Styled.Sign>}
           {hasValue &&
             {

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -53,10 +53,6 @@ export const useMarketsData = (
   const allPerpetualMarkets = useSelector(getPerpetualMarkets, shallowEqual) || {};
   const allAssets = useSelector(getAssets, shallowEqual) || {};
   const sevenDaysSparklineData = usePerpetualMarketSparklines();
-  const oneDaySparklineData = usePerpetualMarketSparklines({
-    period: 'ONE_DAY',
-    refetchInterval: undefined,
-  });
 
   const markets = useMemo(() => {
     return Object.values(allPerpetualMarkets)
@@ -86,13 +82,12 @@ export const useMarketsData = (
           tickSizeDecimals: marketData.configs?.tickSizeDecimals,
           isNew,
           listingDate,
-          oneDaySparkline: oneDaySparklineData?.[marketData.id] ?? [],
           ...marketData,
           ...marketData.perpetual,
           ...marketData.configs,
         };
       }) as MarketData[];
-  }, [allPerpetualMarkets, allAssets, oneDaySparklineData, sevenDaysSparklineData]);
+  }, [allPerpetualMarkets, allAssets, sevenDaysSparklineData]);
 
   const filteredMarkets = useMemo(() => {
     const filtered = markets.filter(filterFunctions[filter]);

--- a/src/hooks/usePerpetualMarketSparklines.ts
+++ b/src/hooks/usePerpetualMarketSparklines.ts
@@ -9,22 +9,19 @@ import { useDydxClient } from './useDydxClient';
 
 const POLLING_MS = timeUnits.hour;
 export const SEVEN_DAY_SPARKLINE_ENTRIES = 42;
-/**
- * Number of elements returned by the service in case the period is one day, specifically the timeframe is one hour
- */
 export const ONE_DAY_SPARKLINE_ENTRIES = 24;
 
-interface UsePerpetualMarketSparklinesProps {
+type UsePerpetualMarketSparklinesProps = {
   period?: 'ONE_DAY' | 'SEVEN_DAYS';
   refetchInterval?: number;
-}
+};
 
 export const usePerpetualMarketSparklines = (props: UsePerpetualMarketSparklinesProps = {}) => {
   const { period = 'SEVEN_DAYS', refetchInterval = POLLING_MS } = props;
   const { getPerpetualMarketSparklines, compositeClient } = useDydxClient();
 
   const { data } = useQuery<PerpetualMarketSparklineResponse | undefined>({
-    enabled: !!compositeClient,
+    enabled: Boolean(compositeClient),
     queryKey: ['perpetualMarketSparklines', period],
     queryFn: () => {
       try {

--- a/src/hooks/usePerpetualMarketsStats.ts
+++ b/src/hooks/usePerpetualMarketsStats.ts
@@ -38,7 +38,11 @@ export const usePerpetualMarketsStats = () => {
     refetchOnWindowFocus: false,
   });
 
-  const feeEarned = useMemo(() => data?.[0].total, [data]);
+  const feesEarned = useMemo(() => {
+    if (!data) return null;
+
+    return data.reduce((acc, { total }) => acc + total, 0);
+  }, [data]);
 
   const stats = useMemo(() => {
     let volume24HUSDC = 0;
@@ -53,11 +57,11 @@ export const usePerpetualMarketsStats = () => {
     return {
       volume24HUSDC,
       openInterestUSDC,
-      feeEarned,
+      feesEarned,
     };
-  }, [markets, feeEarned]);
+  }, [markets, feesEarned]);
 
-  const feeEarnedChart = useMemo(
+  const feesEarnedChart = useMemo(
     () =>
       data?.map((point, x) => ({
         x: x + 1,
@@ -68,6 +72,6 @@ export const usePerpetualMarketsStats = () => {
 
   return {
     stats,
-    feeEarnedChart,
+    feesEarnedChart,
   };
 };

--- a/src/pages/markets/Markets.tsx
+++ b/src/pages/markets/Markets.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import styled, { AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
@@ -57,71 +57,65 @@ const Markets = () => {
   );
 };
 
-const Styled: Record<string, AnyStyledComponent> = {};
-
-Styled.Page = styled.div`
-  ${layoutMixins.contentContainerPage}
-`;
-
-Styled.ContentSectionHeader = styled(ContentSectionHeader)`
-  margin-top: 1rem;
-  margin-bottom: 0.25rem;
-
-  h3 {
-    font: var(--font-extra-medium);
-  }
-
-  @media ${breakpoints.tablet} {
-    margin-top: 0;
-    padding: 1.25rem 1.5rem 0;
+const Styled = {
+  Page: styled.div`
+    ${layoutMixins.contentContainerPage}
+  `,
+  ContentSectionHeader: styled(ContentSectionHeader)`
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
 
     h3 {
       font: var(--font-extra-medium);
     }
-  }
-`;
 
-Styled.HeaderSection = styled.section`
-  ${layoutMixins.contentSectionDetached}
+    @media ${breakpoints.tablet} {
+      margin-top: 0;
+      padding: 1.25rem 1.5rem 0;
 
-  margin-bottom: 2rem;
+      h3 {
+        font: var(--font-extra-medium);
+      }
+    }
+  `,
+  HeaderSection: styled.section`
+    ${layoutMixins.contentSectionDetached}
 
-  @media ${breakpoints.tablet} {
-    ${layoutMixins.flexColumn}
+    margin-bottom: 2rem;
+
+    @media ${breakpoints.tablet} {
+      ${layoutMixins.flexColumn}
+      gap: 1rem;
+
+      margin-bottom: 1rem;
+    }
+  `,
+  MarketsTable: styled(MarketsTable)`
+    ${layoutMixins.contentSectionAttached}
+  `,
+  MarketsStats: styled(MarketsStats)<{
+    showHighlights?: boolean;
+  }>`
+    ${({ showHighlights }) => !showHighlights && 'display: none;'}
+  `,
+  Highlights: styled.label`
+    align-items: center;
     gap: 1rem;
+    margin-bottom: 1.25rem;
+    display: none;
+    cursor: pointer;
 
-    margin-bottom: 1rem;
-  }
-`;
+    @media ${breakpoints.desktopSmall} {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
 
-Styled.MarketsTable = styled(MarketsTable)`
-  ${layoutMixins.contentSectionAttached}
-`;
-
-Styled.MarketsStats = styled(MarketsStats)<{
-  showHighlights?: boolean;
-}>`
-  ${({ showHighlights }) => !showHighlights && 'display: none;'}
-`;
-
-Styled.Highlights = styled.label`
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.25rem;
-  display: none;
-  cursor: pointer;
-
-  @media ${breakpoints.desktopSmall} {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  @media ${breakpoints.tablet} {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-    margin-bottom: 0;
-    display: flex;
-  }
-`;
-
+    @media ${breakpoints.tablet} {
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      margin-bottom: 0;
+      display: flex;
+    }
+  `,
+};
 export default Markets;

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -23,8 +23,8 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
   const { chainTokenLabel } = useTokenConfigs();
 
   const {
-    stats: { volume24HUSDC, openInterestUSDC, feeEarned },
-    feeEarnedChart,
+    stats: { volume24HUSDC, openInterestUSDC, feesEarned },
+    feesEarnedChart,
   } = usePerpetualMarketsStats();
 
   return (
@@ -50,14 +50,26 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
           key: 'fee-earned-stakers',
           labelKey: STRING_KEYS.EARNED_BY_STAKERS,
           tagKey: STRING_KEYS._24H,
-          value: feeEarned,
+          value: feesEarned,
           type: OutputType.CompactFiat,
-          chartData: feeEarnedChart,
+          chartData: feesEarnedChart,
           linkLabelKey: STRING_KEYS.LEARN_MORE_ARROW,
           link: `${chainTokenLabel}/${TokenRoute.StakingRewards}`,
+          slotLeft: '~',
         },
       ].map(
-        ({ key, labelKey, tagKey, value, fractionDigits, type, chartData, link, linkLabelKey }) => (
+        ({
+          key,
+          labelKey,
+          tagKey,
+          value,
+          fractionDigits,
+          type,
+          chartData,
+          link,
+          linkLabelKey,
+          slotLeft,
+        }) => (
           <Styled.BillboardContainer key={key}>
             <Styled.BillboardStat>
               <Styled.BillboardTitle>
@@ -66,10 +78,11 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
               </Styled.BillboardTitle>
               <Styled.Output
                 useGrouping
+                withBaseFont
                 fractionDigits={fractionDigits}
                 type={type}
                 value={value}
-                withBaseFont
+                slotLeft={slotLeft}
               />
               {link && linkLabelKey ? (
                 <Styled.BillboardLink

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -1,4 +1,4 @@
-import styled, { type AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
@@ -101,63 +101,57 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
   );
 };
 
-const Styled: Record<string, AnyStyledComponent> = {};
+const Styled = {
+  MarketBillboardsWrapper: styled.div`
+    ${layoutMixins.column}
 
-Styled.MarketBillboardsWrapper = styled.div`
-  ${layoutMixins.column}
+    gap: 1rem;
+  `,
+  BillboardContainer: styled.div`
+    ${layoutMixins.row}
+    flex: 1;
+    justify-content: space-between;
 
-  gap: 1rem;
-`;
+    background-color: var(--color-layer-3);
+    padding: 1.5rem;
+    border-radius: 0.625rem;
+  `,
+  BillboardChart: styled.div`
+    width: 130px;
+    height: 40px;
+  `,
+  BillboardLink: styled(Button)`
+    --button-textColor: var(--color-accent);
+    --button-height: unset;
+    --button-padding: 0;
+    justify-content: flex-start;
+  `,
+  BillboardTitle: styled.div`
+    ${layoutMixins.row}
 
-Styled.BillboardContainer = styled.div`
-  ${layoutMixins.row}
-  flex: 1;
-  justify-content: space-between;
+    gap: 0.375rem;
+  `,
+  BillboardStat: styled.div`
+    ${layoutMixins.column}
 
-  background-color: var(--color-layer-3);
-  padding: 1.5rem;
-  border-radius: 0.625rem;
-`;
+    gap: 0.5rem;
 
-Styled.BillboardChart = styled.div`
-  width: 130px;
-  height: 40px;
-`;
+    label {
+      color: var(--color-text-0);
+      font: var(--font-base-medium);
+    }
 
-Styled.BillboardLink = styled(Button)`
-  --button-textColor: var(--color-accent);
-  --button-height: unset;
-  --button-padding: 0;
-  justify-content: flex-start;
-`;
+    output {
+      color: var(--color-text-1);
+      font: var(--font-large-medium);
+    }
+  `,
+  Output: styled(Output)`
+    font: var(--font-extra-book);
+    color: var(--color-text-2);
 
-Styled.BillboardTitle = styled.div`
-  ${layoutMixins.row}
-
-  gap: 0.375rem;
-`;
-
-Styled.BillboardStat = styled.div`
-  ${layoutMixins.column}
-
-  gap: 0.5rem;
-
-  label {
-    color: var(--color-text-0);
-    font: var(--font-base-medium);
-  }
-
-  output {
-    color: var(--color-text-1);
-    font: var(--font-large-medium);
-  }
-`;
-
-Styled.Output = styled(Output)`
-  font: var(--font-extra-book);
-  color: var(--color-text-2);
-
-  @media ${breakpoints.tablet} {
-    font: var(--font-base-book);
-  }
-`;
+    @media ${breakpoints.tablet} {
+      font: var(--font-base-book);
+    }
+  `,
+};

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
-import { ButtonAction, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { MarketFilters, MarketSorting } from '@/constants/markets';
 
@@ -12,7 +11,6 @@ import { useStringGetter } from '@/hooks';
 import { breakpoints } from '@/styles';
 import { layoutMixins } from '@/styles/layoutMixins';
 
-import { Button } from '@/components/Button';
 import { Tag } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
@@ -40,16 +38,10 @@ export const MarketsStats = (props: MarketsStatsProps) => {
       <Styled.ExchangeBillboards />
       <Styled.Section>
         <Styled.SectionHeader>
-          <h4>{stringGetter({ key: STRING_KEYS.RECENTLY_LISTED })}</h4>
-          <Styled.NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</Styled.NewTag>
-
-          <Styled.ViewAll
-            type={ButtonType.Link}
-            action={ButtonAction.Navigation}
-            onClick={setNewFilter}
-          >
-            {stringGetter({ key: STRING_KEYS.VIEW })} →
-          </Styled.ViewAll>
+          <Styled.RecentlyListed>
+            {stringGetter({ key: STRING_KEYS.RECENTLY_LISTED })}
+            <Styled.NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</Styled.NewTag>
+          </Styled.RecentlyListed>
         </Styled.SectionHeader>
         <MarketsCompactTable filters={MarketFilters.NEW} />
       </Styled.Section>
@@ -100,9 +92,10 @@ const Styled = {
     background: var(--color-layer-3);
     border-radius: 0.625rem;
   `,
-  ViewAll: styled(Button)`
-    --button-textColor: var(--color-accent);
-    margin-left: auto;
+  RecentlyListed: styled.h4`
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
   `,
   NewTag: styled(Tag)`
     background-color: var(--color-accent-faded);
@@ -128,6 +121,7 @@ const Styled = {
     justify-content: space-between;
     padding: 1.125rem 1.5rem;
     gap: 0.375rem;
+    height: 4rem;
 
     & h4 {
       font: var(--font-base-medium);

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useDispatch } from 'react-redux';
-import styled, { AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { ButtonAction, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
@@ -81,66 +81,60 @@ export const MarketsStats = (props: MarketsStatsProps) => {
   );
 };
 
-const Styled: Record<string, AnyStyledComponent> = {};
+const Styled = {
+  MarketsStats: styled.section`
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
 
-Styled.MarketsStats = styled.section`
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+    @media ${breakpoints.desktopSmall} {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
 
-  @media ${breakpoints.desktopSmall} {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
+    @media ${breakpoints.tablet} {
+      ${layoutMixins.column}
+    }
+  `,
+  Section: styled.div`
+    background: var(--color-layer-3);
+    border-radius: 0.625rem;
+  `,
+  ViewAll: styled(Button)`
+    --button-textColor: var(--color-accent);
+    margin-left: auto;
+  `,
+  NewTag: styled(Tag)`
+    background-color: var(--color-accent-faded);
+    color: var(--color-accent);
+    text-transform: uppercase;
+  `,
+  ToggleGroupContainer: styled.div`
+    ${layoutMixins.row}
+    margin-left: auto;
 
-  @media ${breakpoints.tablet} {
-    ${layoutMixins.column}
-  }
-`;
+    & button {
+      --button-toggle-off-backgroundColor: var(--color-layer-3);
+      --button-toggle-off-textColor: var(--color-text-1);
+      --border-color: var(--color-layer-6);
+      --button-height: 1.75rem;
+      --button-padding: 0 0.75rem;
+      --button-font: var(--font-mini-book);
+    }
+  `,
+  SectionHeader: styled.div`
+    ${layoutMixins.row}
 
-Styled.Section = styled.div`
-  background: var(--color-layer-3);
-  border-radius: 0.625rem;
-`;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    gap: 0.375rem;
 
-Styled.ViewAll = styled(Button)`
-  --button-textColor: var(--color-accent);
-  margin-left: auto;
-`;
-
-Styled.NewTag = styled(Tag)`
-  background-color: var(--color-accent-faded);
-  color: var(--color-accent);
-  text-transform: uppercase;
-`;
-
-Styled.ToggleGroupContainer = styled.div`
-  ${layoutMixins.row}
-  margin-left: auto;
-
-  & button {
-    --button-toggle-off-backgroundColor: var(--color-layer-3);
-    --button-toggle-off-textColor: var(--color-text-1);
-    --border-color: var(--color-layer-6);
-    --button-height: 1.75rem;
-    --button-padding: 0 0.75rem;
-    --button-font: var(--font-mini-book);
-  }
-`;
-
-Styled.SectionHeader = styled.div`
-  ${layoutMixins.row}
-
-  justify-content: space-between;
-  padding: 1.125rem 1.5rem;
-  gap: 0.375rem;
-
-  & h4 {
-    font: var(--font-base-medium);
-    color: var(--color-text-2);
-  }
-`;
-
-Styled.ExchangeBillboards = styled(ExchangeBillboards)`
-  ${layoutMixins.contentSectionDetachedScrollable}
-`;
+    & h4 {
+      font: var(--font-base-medium);
+      color: var(--color-text-2);
+    }
+  `,
+  ExchangeBillboards: styled(ExchangeBillboards)`
+    ${layoutMixins.contentSectionDetachedScrollable}
+  `,
+};

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -20,7 +20,7 @@ import { tradeViewMixins } from '@/styles/tradeViewMixins';
 
 import { Button } from '@/components/Button';
 import { Output, OutputType } from '@/components/Output';
-import { type ColumnDef, AssetTableCell, Table, TableCell } from '@/components/Table';
+import { AssetTableCell, Table, TableCell, type ColumnDef } from '@/components/Table';
 import { Toolbar } from '@/components/Toolbar';
 import { TriangleIndicator } from '@/components/TriangleIndicator';
 import { SparklineChart } from '@/components/visx/SparklineChart';
@@ -111,12 +111,12 @@ export const MarketsTable = ({ className }: { className?: string }) => {
             },
             {
               columnKey: 'priceChange24HChart',
-              getCellValue: (row) => row.oneDaySparkline,
+              getCellValue: (row) => row.priceChange24HPercent,
               label: stringGetter({ key: STRING_KEYS.LAST_24H }),
-              renderCell: ({ oneDaySparkline, priceChange24HPercent }) => (
+              renderCell: ({ line, priceChange24HPercent }) => (
                 <div style={{ width: 50, height: 50 }}>
                   <SparklineChart
-                    data={(oneDaySparkline ?? []).map((datum, index) => ({
+                    data={(line?.toArray() ?? []).map((datum, index) => ({
                       x: index + 1,
                       y: parseFloat(datum.toString()),
                     }))}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1555" alt="Screen Shot 2024-05-02 at 3 52 24 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/5ca7769f-fcf9-406e-a953-b80d704881b5">

<!-- Overall purpose of the PR -->
Additional cleanup.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketsCompactTable>`
  * update styled object
  * fix props
  * add headers
  * fix data accessor
  * remove default sort

* `<Markets>`, `<ExchangeBillboard>`
  * update styled object

* `<MarketStats>`
  * update styled object
  * remove `View` button (it didn't do anything...) 

* `<MarketsTable>`
  * Utilize abacus perpetualMarket `line` data 

## Components

* New: `<ComponentName>`
  * <!-- explain features of new design system component (props, CSS params, style variants, etc.) -->
  * 

* `<Output>`
  * add `slotLeft` prop

## Hooks

* `hooks/useMarketsData`
  * remove 24h sparkline query call. Utilize abacus stored line info

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
