### PR TITLE
chore: re-enable e2e

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -7,16 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'deployment_status' &&
-      github.event.deployment_status.state == 'success' &&
-      github.event.deployment.sha == github.event.pull_request.head.sha
+      github.event.deployment_status.state == 'success'
     steps:
-      - name: sha from context
-        run: echo ${{ github.event.pull_request.head.sha }}
-
       - name: Check environment URL
         id: check_env
         run: |
-          if [[ "${{ github.event.deployment_status.environment_url }}" == *"v4-testnet"* ]]; then
+          if [[ "${{ github.event.deployment_status.environment_url }}" == *"v4-staging"* ]]; then
             echo "::set-output name=should_run_tests::true"
           else
             echo "::set-output name=should_run_tests::false"

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -8,8 +8,11 @@ jobs:
     if: >
       github.event_name == 'deployment_status' &&
       github.event.deployment_status.state == 'success' &&
-      false
+      github.event.deployment.sha == github.event.pull_request.head.sha
     steps:
+      - name: sha from context
+        run: echo ${{ github.event.pull_request.head.sha }}
+
       - name: Check environment URL
         id: check_env
         run: |


### PR DESCRIPTION
Re-enable e2e tests CI, now that the browserstack plan is activated. 
Also test on staging instead of testnet for now, since testnet deployment does not always have the password gating. To improve the e2e test, we could detect vercel password gating and conditionally proceed.