### PR TITLE
feat: ui updates for eimf [OTE-299]

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -76,7 +76,7 @@
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/rewards/trading_rewards",
          "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
-         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
+         "initialMarginFractionLearnMore": "https://docs.dydx.exchange/governance/functionalities#liquidity-tiers"
       },
       "dydx-testnet-4": {
          "tos": "https://dydx.exchange/v4-terms",
@@ -102,7 +102,7 @@
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/rewards/trading_rewards",
          "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
-         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
+         "initialMarginFractionLearnMore": "https://docs.dydx.exchange/governance/functionalities#liquidity-tiers"
       },
       "[mainnet chain id]": {
          "tos": "[HTTP link to TOS]",
@@ -128,7 +128,7 @@
          "launchIncentive": "[HTTP link to launch incentive host, can be null]",
          "tradingRewardsLearnMore": "[HTTP link to trading rewards learn more, can be null]",
          "exchangeStats": "[HTTP link to exchange stats, can be null]",
-         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
+         "initialMarginFractionLearnMore": "[HTTP link to governance functionalities liquidity tiers, can be null]"
       }
    },
    "wallets": {

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -75,7 +75,8 @@
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/rewards/trading_rewards",
-         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c"
+         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
+         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
       },
       "dydx-testnet-4": {
          "tos": "https://dydx.exchange/v4-terms",
@@ -100,7 +101,8 @@
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/rewards/trading_rewards",
-         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c"
+         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
+         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
       },
       "[mainnet chain id]": {
          "tos": "[HTTP link to TOS]",
@@ -125,7 +127,8 @@
          "withdrawalGateLearnMore": "[HTTP link to withdrawal gate learn more, can be null]",
          "launchIncentive": "[HTTP link to launch incentive host, can be null]",
          "tradingRewardsLearnMore": "[HTTP link to trading rewards learn more, can be null]",
-         "exchangeStats": "[HTTP link to exchange stats, can be null]"
+         "exchangeStats": "[HTTP link to exchange stats, can be null]",
+         "initialMarginFractionLearnMore": "https://help.dydx.trade/en/articles/8587513-default-margin-calculations-on-dydx-chain"
       }
    },
    "wallets": {

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -7,6 +7,8 @@ import styled, {
   type FlattenInterpolation,
 } from 'styled-components';
 
+import { Nullable } from '@/constants/abacus';
+
 import { LoadingContext } from '@/contexts/LoadingContext';
 
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -19,7 +21,7 @@ export type DetailsItem = {
   tooltip?: string;
   tooltipParams?: Record<string, string>;
   label: string | JSX.Element;
-  value?: string | JSX.Element | undefined;
+  value?: Nullable<string> | JSX.Element | undefined;
   subitems?: DetailsItem[];
   withTooltipIcon?: boolean;
 };

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -85,39 +85,6 @@ type StyleProps = {
 
 export type OutputProps = ElementProps & StyleProps;
 
-type DynamicOutputProps = {
-  staticValue: BigNumber;
-  dynamicValue: BigNumber;
-  type: OutputType;
-};
-
-/***
- * TODO: think about making this more abstract to support various types of dynamic outputs
- *
- * This component allows for a static and dynamic value.
- * The optional output will render if a dynamic value exists and is not equal to the static value.
- * If optional output is rendered, the static output will be a rendered w/ gray text instead of white.
- */
-export const DynamicOutput = ({ staticValue, dynamicValue, type }: DynamicOutputProps) => {
-  const renderOptionalOutput = Boolean(dynamicValue && !dynamicValue.isEqualTo(staticValue));
-  return (
-    <Styled.Row>
-      <Styled.StaticOutput
-        useGrouping
-        value={staticValue}
-        type={type}
-        $renderOptionalOutput={renderOptionalOutput}
-      />
-      {renderOptionalOutput && (
-        <>
-          <Styled.Gap>&#8594;</Styled.Gap>
-          <Output useGrouping value={dynamicValue} type={type} />
-        </>
-      )}
-    </Styled.Row>
-  );
-};
-
 export const Output = ({
   type,
   value,
@@ -438,19 +405,7 @@ const _OUTPUT_STYLES = styled.output<{ withParentheses?: boolean }>`
 `;
 
 const Styled = {
-  StaticOutput: styled(Output)<{ $renderOptionalOutput?: boolean }>`
-    color: ${(props) =>
-      props.$renderOptionalOutput ? 'var(--color-text-0)' : 'var(--color-text-1)'};
-  `,
-  Gap: styled.div`
-    margin-left: 0.15rem;
-    margin-right: 0.15rem;
-  `,
   Output: _OUTPUT_STYLES,
-  Row: styled.div`
-    display: flex;
-    flex-direction: row;
-  `,
   Tag: styled(Tag)`
     margin-left: 0.5ch;
   `,

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import BigNumber from 'bignumber.js';
 import { DateTime } from 'luxon';
 import { useSelector } from 'react-redux';
-import styled, { css, type AnyStyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import {
   LEVERAGE_DECIMALS,
@@ -84,6 +84,39 @@ type StyleProps = {
 };
 
 export type OutputProps = ElementProps & StyleProps;
+
+type DynamicOutputProps = {
+  staticValue: BigNumber;
+  dynamicValue: BigNumber;
+  type: OutputType;
+};
+
+/***
+ * TODO: think about making this more abstract to support various types of dynamic outputs
+ *
+ * This component allows for a static and dynamic value.
+ * The optional output will render if a dynamic value exists and is not equal to the static value.
+ * If optional output is rendered, the static output will be a rendered w/ gray text instead of white.
+ */
+export const DynamicOutput = ({ staticValue, dynamicValue, type }: DynamicOutputProps) => {
+  const renderOptionalOutput = Boolean(dynamicValue && !dynamicValue.isEqualTo(staticValue));
+  return (
+    <Styled.Row>
+      <Styled.StaticOutput
+        useGrouping
+        value={staticValue}
+        type={type}
+        $renderOptionalOutput={renderOptionalOutput}
+      />
+      {renderOptionalOutput && (
+        <>
+          <Styled.Gap>&#8594;</Styled.Gap>
+          <Output useGrouping value={dynamicValue} type={type} />
+        </>
+      )}
+    </Styled.Row>
+  );
+};
 
 export const Output = ({
   type,
@@ -371,9 +404,7 @@ export const Output = ({
   }
 };
 
-const Styled: Record<string, AnyStyledComponent> = {};
-
-Styled.Output = styled.output<{ withParentheses?: boolean }>`
+const _OUTPUT_STYLES = styled.output<{ withParentheses?: boolean }>`
   --output-beforeString: '';
   --output-afterString: '';
   --output-sign-color: currentColor;
@@ -406,20 +437,33 @@ Styled.Output = styled.output<{ withParentheses?: boolean }>`
     `}
 `;
 
-Styled.Tag = styled(Tag)`
-  margin-left: 0.5ch;
-`;
+const Styled = {
+  StaticOutput: styled(Output)<{ $renderOptionalOutput?: boolean }>`
+    color: ${(props) =>
+      props.$renderOptionalOutput ? 'var(--color-text-0)' : 'var(--color-text-1)'};
+  `,
+  Gap: styled.div`
+    margin-left: 0.15rem;
+    margin-right: 0.15rem;
+  `,
+  Output: _OUTPUT_STYLES,
+  Row: styled.div`
+    display: flex;
+    flex-direction: row;
+  `,
+  Tag: styled(Tag)`
+    margin-left: 0.5ch;
+  `,
 
-Styled.Sign = styled.span`
-  color: var(--output-sign-color);
-`;
-
-Styled.Text = styled(Styled.Output)``;
-
-Styled.Number = styled(Styled.Output)<{ withBaseFont?: boolean }>`
-  ${({ withBaseFont }) =>
-    !withBaseFont &&
-    css`
-      font-feature-settings: var(--fontFeature-monoNumbers);
-    `}
-`;
+  Sign: styled.span`
+    color: var(--output-sign-color);
+  `,
+  Text: styled(_OUTPUT_STYLES)``,
+  Number: styled(_OUTPUT_STYLES)<{ withBaseFont?: boolean }>`
+    ${({ withBaseFont }) =>
+      !withBaseFont &&
+      css`
+        font-feature-settings: var(--fontFeature-monoNumbers);
+      `}
+  `,
+};

--- a/src/components/ToggleGroup.tsx
+++ b/src/components/ToggleGroup.tsx
@@ -63,6 +63,7 @@ export const ToggleGroup = forwardRef(
             <ToggleButton
               size={size ? size : isTablet ? ButtonSize.Small : ButtonSize.XSmall}
               shape={shape}
+              disabled={item.disabled}
               {...buttonProps}
             >
               {item.slotBefore}

--- a/src/constants/tooltips/trade.ts
+++ b/src/constants/tooltips/trade.ts
@@ -57,9 +57,10 @@ export const tradeTooltips: TooltipStrings = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.INDEX_PRICE_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.INDEX_PRICE_BODY }),
   }),
-  'initial-margin-fraction': ({ stringGetter }) => ({
+  'initial-margin-fraction': ({ stringGetter, urlConfigs }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.INITIAL_MARGIN_FRACTION_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.INITIAL_MARGIN_FRACTION_BODY }),
+    learnMoreLink: urlConfigs?.initialMarginFractionLearnMore,
   }),
   'initial-stop': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.INITIAL_STOP_TITLE }),

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -10,7 +10,8 @@ export const BIG_NUMBERS = {
   ONE: new BigNumber(1),
 };
 
-export const MustBigNumber = (amount?: BigNumberish | null) => new BigNumber(amount || 0);
+export const MustBigNumber = (amount?: BigNumberish | null): BigNumber =>
+  new BigNumber(amount || 0);
 
 /**
  * @description Rounds the input to the nearest multiple of `factor`, which must be non-zero.

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -157,6 +157,8 @@ const getWalletconnect2ConnectorOptions = (
     qrModalOptions: {
       themeMode: 'dark' as const,
       themeVariables: {
+        // TODO: figure out why --wcm-accent-color isn't considered a known property
+        // @ts-ignore
         '--wcm-accent-color': '#5973fe',
         '--wcm-font-family': 'var(--fontFamily-base)',
       },

--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -13,8 +13,9 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Details } from '@/components/Details';
+import { DiffOutput } from '@/components/DiffOutput';
 import { Icon, IconName } from '@/components/Icon';
-import { DynamicOutput, Output, OutputType } from '@/components/Output';
+import { Output, OutputType } from '@/components/Output';
 
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getCurrentMarketData } from '@/state/perpetualsSelectors';
@@ -49,6 +50,10 @@ export const MarketDetails: React.FC = () => {
     websiteLink,
     whitepaperLink,
   } = resources || {};
+
+  const preferIEMF = Boolean(
+    effectiveInitialMarginFraction && initialMarginFraction != effectiveInitialMarginFraction
+  );
 
   const items = [
     {
@@ -101,11 +106,14 @@ export const MarketDetails: React.FC = () => {
       label: stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE }),
       tooltip: 'maximum-leverage',
       value: (
-        <DynamicOutput
-          // it's okay if we default to 0. it doesn't cause runtime errors
-          // and both values should always exist. their types aren't accurate yet.
-          staticValue={BIG_NUMBERS.ONE.div(initialMarginFraction || 0)}
-          dynamicValue={BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction || 0)}
+        <DiffOutput
+          value={initialMarginFraction ? BIG_NUMBERS.ONE.div(initialMarginFraction) : null}
+          newValue={
+            effectiveInitialMarginFraction
+              ? BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction)
+              : null
+          }
+          withDiff={preferIEMF}
           type={OutputType.Multiple}
         />
       ),
@@ -123,11 +131,12 @@ export const MarketDetails: React.FC = () => {
       label: stringGetter({ key: STRING_KEYS.INITIAL_MARGIN_FRACTION }),
       tooltip: 'initial-margin-fraction',
       value: (
-        // it's okay if we default to 0. it doesn't cause runtime errors
-        // and both values should always exist. their types aren't accurate yet.
-        <DynamicOutput
-          staticValue={BigNumber(initialMarginFraction || 0)}
-          dynamicValue={BigNumber(effectiveInitialMarginFraction || 0)}
+        <DiffOutput
+          value={initialMarginFraction ? BigNumber(initialMarginFraction) : null}
+          newValue={
+            effectiveInitialMarginFraction ? BigNumber(effectiveInitialMarginFraction) : null
+          }
+          withDiff={preferIEMF}
           type={OutputType.SmallPercent}
         />
       ),

--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -51,7 +51,7 @@ export const MarketDetails: React.FC = () => {
     whitepaperLink,
   } = resources || {};
 
-  const preferIEMF = Boolean(
+  const preferEIMF = Boolean(
     effectiveInitialMarginFraction && initialMarginFraction != effectiveInitialMarginFraction
   );
 
@@ -113,7 +113,7 @@ export const MarketDetails: React.FC = () => {
               ? BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction)
               : null
           }
-          withDiff={preferIEMF}
+          withDiff={preferEIMF}
           type={OutputType.Multiple}
         />
       ),
@@ -136,7 +136,7 @@ export const MarketDetails: React.FC = () => {
           newValue={
             effectiveInitialMarginFraction ? BigNumber(effectiveInitialMarginFraction) : null
           }
-          withDiff={preferIEMF}
+          withDiff={preferEIMF}
           type={OutputType.SmallPercent}
         />
       ),

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -12,7 +12,8 @@ import { breakpoints } from '@/styles';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Details } from '@/components/Details';
-import { DynamicOutput, Output, OutputType } from '@/components/Output';
+import { DiffOutput } from '@/components/DiffOutput';
+import { Output, OutputType } from '@/components/Output';
 import { VerticalSeparator } from '@/components/Separator';
 import { TriangleIndicator } from '@/components/TriangleIndicator';
 import { WithTooltip } from '@/components/WithTooltip';
@@ -173,9 +174,16 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
               }
               case MarketStats.MaxLeverage: {
                 return (
-                  <DynamicOutput
-                    staticValue={BIG_NUMBERS.ONE.div(initialMarginFraction || 0)}
-                    dynamicValue={BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction || 0)}
+                  <DiffOutput
+                    value={
+                      initialMarginFraction ? BIG_NUMBERS.ONE.div(initialMarginFraction) : null
+                    }
+                    newValue={
+                      effectiveInitialMarginFraction
+                        ? BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction)
+                        : null
+                    }
+                    withDiff={initialMarginFraction != effectiveInitialMarginFraction}
                     type={OutputType.Multiple}
                   />
                 );

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -12,9 +12,10 @@ import { breakpoints } from '@/styles';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Details } from '@/components/Details';
-import { Output, OutputType } from '@/components/Output';
+import { DynamicOutput, Output, OutputType } from '@/components/Output';
 import { VerticalSeparator } from '@/components/Separator';
 import { TriangleIndicator } from '@/components/TriangleIndicator';
+import { WithTooltip } from '@/components/WithTooltip';
 import { NextFundingTimer } from '@/views/NextFundingTimer';
 
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
@@ -24,7 +25,7 @@ import {
   getCurrentMarketMidMarketPrice,
 } from '@/state/perpetualsSelectors';
 
-import { MustBigNumber } from '@/lib/numbers';
+import { BIG_NUMBERS, MustBigNumber } from '@/lib/numbers';
 
 import { MidMarketPrice } from './MidMarketPrice';
 
@@ -40,6 +41,7 @@ enum MarketStats {
   Volume24H = 'Volume24H',
   Trades24H = 'Trades24H',
   NextFunding = 'NextFunding',
+  MaxLeverage = 'MaxLeverage',
 }
 
 const defaultMarketStatistics = Object.values(MarketStats);
@@ -48,7 +50,8 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
   const { id = '' } = useSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
-  const { tickSizeDecimals } = useSelector(getCurrentMarketConfig, shallowEqual) ?? {};
+  const { tickSizeDecimals, initialMarginFraction, effectiveInitialMarginFraction } =
+    useSelector(getCurrentMarketConfig, shallowEqual) ?? {};
   const midMarketPrice = useSelector(getCurrentMarketMidMarketPrice);
   const lastMidMarketPrice = useRef(midMarketPrice);
   const currentMarketData = useSelector(getCurrentMarketData, shallowEqual);
@@ -70,6 +73,7 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
     [MarketStats.PriceChange24H]: priceChange24H,
     [MarketStats.Trades24H]: trades24H,
     [MarketStats.Volume24H]: volume24H,
+    [MarketStats.MaxLeverage]: undefined, // needs more complex logic
   };
 
   const labelMap = {
@@ -80,6 +84,11 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
     [MarketStats.PriceChange24H]: stringGetter({ key: STRING_KEYS.CHANGE_24H }),
     [MarketStats.Trades24H]: stringGetter({ key: STRING_KEYS.TRADES_24H }),
     [MarketStats.Volume24H]: stringGetter({ key: STRING_KEYS.VOLUME_24H }),
+    [MarketStats.MaxLeverage]: (
+      <WithTooltip tooltip="maximum-leverage">
+        {stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE })}
+      </WithTooltip>
+    ),
   };
 
   return (
@@ -161,6 +170,15 @@ export const MarketStatsDetails = ({ showMidMarketPrice = true }: ElementProps) 
               case MarketStats.Volume24H: {
                 // $ with no decimals
                 return <Styled.Output type={OutputType.Fiat} value={value} fractionDigits={0} />;
+              }
+              case MarketStats.MaxLeverage: {
+                return (
+                  <DynamicOutput
+                    staticValue={BIG_NUMBERS.ONE.div(initialMarginFraction || 0)}
+                    dynamicValue={BIG_NUMBERS.ONE.div(effectiveInitialMarginFraction || 0)}
+                    type={OutputType.Multiple}
+                  />
+                );
               }
               default: {
                 // Default renderer

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -165,6 +165,7 @@ export const MarketLeverageInput = ({
         items={leverageOptions.map((leverageAmount: number) => ({
           label: `${leverageAmount}×`,
           value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
+          disabled: maxLeverage.lt(leverageAmount),
         }))}
         value={MustBigNumber(formattedLeverageValue).abs().toFixed(LEVERAGE_DECIMALS)} // sign agnostic
         onValueChange={updateLeverage}

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -47,7 +47,7 @@ export const MarketLeverageInput = ({
   const { leverage, size: currentPositionSize } = currentPositionData || {};
   const { current: currentSize, postOrder: postOrderSize } = currentPositionSize || {};
   const { current: currentLeverage, postOrder: postOrderLeverage } = leverage || {};
-  const { initialMarginFraction } = currentMarketConfig || {};
+  const { initialMarginFraction, effectiveInitialMarginFraction } = currentMarketConfig || {};
   const { side } = inputTradeData || {};
   const orderSide = getSelectedOrderSide(side);
 
@@ -56,9 +56,9 @@ export const MarketLeverageInput = ({
     postOrderSize,
   });
 
-  const maxLeverage = initialMarginFraction
-    ? BIG_NUMBERS.ONE.div(initialMarginFraction)
-    : MustBigNumber(10);
+  const preferredIMF = effectiveInitialMarginFraction ?? initialMarginFraction;
+
+  const maxLeverage = preferredIMF ? BIG_NUMBERS.ONE.div(preferredIMF) : MustBigNumber(10);
 
   const leverageOptions = maxLeverage.lt(10) ? [1, 2, 3, 4, 5] : [1, 2, 3, 5, 10];
 

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -66,11 +66,14 @@ export const MarketLeverageInput = ({
 
   const getSignedLeverage = (newLeverage: string | number) => {
     const newLeverageBN = MustBigNumber(newLeverage);
+    const newLeverageBNCapped = newLeverageBN.isGreaterThan(maxLeverage)
+      ? maxLeverage
+      : newLeverageBN;
     const newLeverageSignedBN =
       leveragePosition === PositionSide.Short ||
       (leveragePosition === PositionSide.None && orderSide === OrderSide.SELL)
-        ? newLeverageBN.abs().negated()
-        : newLeverageBN.abs();
+        ? newLeverageBNCapped.abs().negated()
+        : newLeverageBNCapped.abs();
 
     return newLeverageSignedBN.toFixed(LEVERAGE_DECIMALS);
   };


### PR DESCRIPTION
<!-- Overall purpose of the PR -->
UI updates for effective IMF changes. going according to [figma spec](https://www.figma.com/file/fMQodZKzn9B5aZTN5G0fLJ/dYdX-%E2%80%BA-Desktop?type=design&node-id=27458-41684&mode=design&t=pkj8dD829Aa7Idt7-0).
---



## Views


* `src/views/MarketDetails.tsx` + `src/views/MarketStatsDetails.tsx`
  * update to use `DynamicOutput` component

## Components

* New: `DynamicOutput`
  * extension of existing `Output` component.
  * allows for static and dynamic value props so we can conditionally render old leverage/imf vs new one side by side

## General
* continuing to update `Styled` objs as we go, migrating styles to live inside the `Styled` obj declaration and removing the existing `Any` typing for styles

IMF = EIMF:
UI looks the same as before
<img width="1179" alt="Screenshot 2024-05-06 at 3 19 02 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/bf83f6c8-41fa-4578-b79b-fd93182b7f8c">


IMF != EIMF:
Slider, marketdetails, and marketStatsDetails all updated with new IMF and leverage
<img width="970" alt="Screenshot 2024-05-06 at 2 54 47 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/6352c0cb-91be-4978-8a4a-33bf5e8585a8">

tooltip
<img width="970" alt="Screenshot 2024-05-06 at 2 54 47 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/d7af792d-e73b-4323-9af4-4cd9a888a74d">


togglegroup buttons
https://www.loom.com/share/77868f80ea944fd4ad7bd428c5542bcf?sid=02216de2-3223-41b7-96dc-a32d09335fdf


overall view on staging
<img width="1095" alt="Screenshot 2024-05-07 at 4 05 24 PM" src="https://github.com/dydxprotocol/v4-web/assets/37092291/d2c9396c-d8bf-4bd2-afc6-6aa12fde159e">
