### PR TITLE
fix(perf): add default pagination to all tables

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -42,10 +42,15 @@ import { Icon, IconName } from './Icon';
 import { Tag } from './Tag';
 
 export { ActionsTableCell } from './Table/ActionsTableCell';
-export { MarketTableCell } from './Table/MarketTableCell';
 export { AssetTableCell } from './Table/AssetTableCell';
+export { MarketTableCell } from './Table/MarketTableCell';
 export { TableCell } from './Table/TableCell';
 export { TableColumnHeader } from './Table/TableColumnHeader';
+
+export type ViewMoreConfig = {
+  initialNumRowsToShow: number;
+  numRowsPerPage?: number;
+};
 
 export type CustomRowConfig = {
   key: string;
@@ -90,10 +95,7 @@ export type ElementProps<TableRowData extends object | CustomRowConfig, TableRow
   selectionBehavior?: 'replace' | 'toggle';
   onRowAction?: (key: TableRowKey, row: TableRowData) => void;
   slotEmpty?: React.ReactNode;
-  viewMoreConfig?: {
-    initialNumRowsToShow: number;
-    numRowsPerPage?: number;
-  };
+  viewMoreConfig?: ViewMoreConfig;
   // collection: TableCollection<string>;
   // children: React.ReactNode;
 };
@@ -123,7 +125,10 @@ export const Table = <TableRowData extends object, TableRowKey extends Key>({
   selectionMode = 'single',
   selectionBehavior = 'toggle',
   slotEmpty,
-  viewMoreConfig,
+  viewMoreConfig = {
+    initialNumRowsToShow: 25,
+    numRowsPerPage: 10,
+  },
   // shouldRowRender,
 
   // collection,

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -12,6 +12,7 @@ import { useBreakpoints, useStringGetter } from '@/hooks';
 import { AssetIcon } from '@/components/AssetIcon';
 import { CollapsibleTabs } from '@/components/CollapsibleTabs';
 import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
+import { ViewMoreConfig } from '@/components/Table';
 import { MobileTabs } from '@/components/Tabs';
 import { Tag, TagType } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -95,6 +95,11 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
     showCurrentMarket ? numOpenOrders : numTotalOpenOrders
   );
 
+  const viewMoreConfig: ViewMoreConfig = {
+    initialNumRowsToShow: 10,
+    numRowsPerPage: 10,
+  };
+
   const onViewOrders = useCallback((market: string) => {
     navigate(`${AppRoute.Trade}/${market}`, {
       state: {
@@ -143,6 +148,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                   ].filter(isTruthy)
             }
             showClosePositionAction={showClosePositionAction}
+            viewMoreConfig={viewMoreConfig}
             onNavigate={() => setView(PanelView.CurrentMarket)}
             navigateToOrders={onViewOrders}
           />
@@ -180,6 +186,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                     !isAccountViewOnly && OrdersTableColumnKey.Actions,
                   ].filter(isTruthy)
             }
+            viewMoreConfig={viewMoreConfig}
           />
         ),
       },
@@ -218,6 +225,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
             columnWidths={{
               [FillsTableColumnKey.TypeAmount]: '100%',
             }}
+            viewMoreConfig={viewMoreConfig}
           />
         ),
       },

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -19,7 +19,7 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Icon, IconName } from '@/components/Icon';
 import { OrderSideTag } from '@/components/OrderSideTag';
 import { Output, OutputType } from '@/components/Output';
-import { Table, TableCell, TableColumnHeader, type ColumnDef } from '@/components/Table';
+import { Table, TableCell, TableColumnHeader, ViewMoreConfig, type ColumnDef } from '@/components/Table';
 import { MarketTableCell } from '@/components/Table/MarketTableCell';
 import { TagSize } from '@/components/Tag';
 
@@ -289,6 +289,7 @@ type ElementProps = {
   columnKeys: FillsTableColumnKey[];
   columnWidths?: Partial<Record<FillsTableColumnKey, ColumnSize>>;
   currentMarket?: string;
+  viewMoreConfig?: ViewMoreConfig;
 };
 
 type StyleProps = {
@@ -301,6 +302,7 @@ export const FillsTable = ({
   columnKeys,
   columnWidths,
   currentMarket,
+  viewMoreConfig,
   withGradientCardRows,
   withOuterBorder,
   withInnerBorders = true,
@@ -363,6 +365,7 @@ export const FillsTable = ({
           <h4>{stringGetter({ key: STRING_KEYS.TRADES_EMPTY_STATE })}</h4>
         </>
       }
+      viewMoreConfig={viewMoreConfig}
       withOuterBorder={withOuterBorder}
       withInnerBorders={withInnerBorders}
       withScrollSnapColumns

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -27,6 +27,7 @@ import {
   Table,
   TableCell,
   TableColumnHeader,
+  ViewMoreConfig,
   type ColumnDef,
 } from '@/components/Table';
 import { TagSize } from '@/components/Tag';
@@ -293,6 +294,7 @@ type ElementProps = {
   columnKeys: OrdersTableColumnKey[];
   columnWidths?: Partial<Record<OrdersTableColumnKey, ColumnSize>>;
   currentMarket?: string;
+  viewMoreConfig?: ViewMoreConfig;
 };
 
 type StyleProps = {
@@ -303,6 +305,7 @@ export const OrdersTable = ({
   columnKeys = [],
   columnWidths,
   currentMarket,
+  viewMoreConfig,
   withOuterBorder,
 }: ElementProps & StyleProps) => {
   const stringGetter = useStringGetter();
@@ -371,6 +374,7 @@ export const OrdersTable = ({
           <h4>{stringGetter({ key: STRING_KEYS.ORDERS_EMPTY_STATE })}</h4>
         </>
       }
+      viewMoreConfig={viewMoreConfig}
       withOuterBorder={withOuterBorder}
       withInnerBorders
       withScrollSnapColumns

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -27,7 +27,7 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType, ShowSign } from '@/components/Output';
 import { PositionSideTag } from '@/components/PositionSideTag';
-import { Table, TableColumnHeader, type ColumnDef } from '@/components/Table';
+import { Table, TableColumnHeader, ViewMoreConfig, type ColumnDef } from '@/components/Table';
 import { MarketTableCell } from '@/components/Table/MarketTableCell';
 import { TableCell } from '@/components/Table/TableCell';
 import { TagSize } from '@/components/Tag';
@@ -367,6 +367,7 @@ type ElementProps = {
   currentRoute?: string;
   currentMarket?: string;
   showClosePositionAction: boolean;
+  viewMoreConfig?: ViewMoreConfig;
   onNavigate?: () => void;
   navigateToOrders: (market: string) => void;
 };
@@ -382,6 +383,7 @@ export const PositionsTable = ({
   currentRoute,
   currentMarket,
   showClosePositionAction,
+  viewMoreConfig,
   onNavigate,
   navigateToOrders,
   withGradientCardRows,
@@ -472,6 +474,7 @@ export const PositionsTable = ({
           <h4>{stringGetter({ key: STRING_KEYS.POSITIONS_EMPTY_STATE })}</h4>
         </>
       }
+      viewMoreConfig={viewMoreConfig}
       withGradientCardRows={withGradientCardRows}
       withOuterBorder={withOuterBorder}
       withInnerBorders


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Add default pagination to tables; reduce pagination vals for horizontal panel since it's shorter. Helps improve perf for heavy traders. I want to also follow up to maybe not load alllll the data from abacus (i.e. like a couple thousand orders), but that'll be a separate PR.

*Chose 25 as a default to-load number that works for my large desktop screen (without scrolling). Can adjust in the future.

<!-- Overall purpose of the PR -->

see perf on heavy trader simulation:


https://github.com/dydxprotocol/v4-web/assets/70078372/2e741747-0aef-4eab-97ba-a4e30d4c6a1b



---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `HorizontalPanel.tsx`
  * Have all tables in this view pass in `VIewMoreConfig` of just 10 to initial load since it's a "shorter" view

## Components

* `Table.tsx`
  * Add default to `ViewMoreConfig`
* `FillsTable.tsx`, `PositionsTable.tsx`, `OrdersTable.tsx`
  * Pass through `viewMoreConfig`

