### PR TITLE
fix: prefer cctp validation to squid route validation [OTE-291]

### DIFF
--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -347,6 +347,26 @@ export const WithdrawForm = () => {
   const { sanctionedAddresses } = useRestrictions();
 
   const { alertType, errorMessage } = useMemo(() => {
+    if (isCctp) {
+      if (debouncedAmountBN.gte(MAX_CCTP_TRANSFER_AMOUNT)) {
+        return {
+          errorMessage: stringGetter({
+            key: STRING_KEYS.MAX_CCTP_TRANSFER_LIMIT_EXCEEDED,
+            params: {
+              MAX_CCTP_TRANSFER_AMOUNT: MAX_CCTP_TRANSFER_AMOUNT,
+            },
+          }),
+        };
+      }
+      if (
+        !debouncedAmountBN.isZero() &&
+        MustBigNumber(debouncedAmountBN).lte(MIN_CCTP_TRANSFER_AMOUNT)
+      ) {
+        return {
+          errorMessage: 'Amount must be greater than 10 USDC',
+        };
+      }
+    }
     if (error) {
       return {
         errorMessage: error,
@@ -394,27 +414,6 @@ export const WithdrawForm = () => {
       return {
         errorMessage: stringGetter({ key: STRING_KEYS.WITHDRAW_MORE_THAN_FREE }),
       };
-    }
-
-    if (isCctp) {
-      if (debouncedAmountBN.gte(MAX_CCTP_TRANSFER_AMOUNT)) {
-        return {
-          errorMessage: stringGetter({
-            key: STRING_KEYS.MAX_CCTP_TRANSFER_LIMIT_EXCEEDED,
-            params: {
-              MAX_CCTP_TRANSFER_AMOUNT: MAX_CCTP_TRANSFER_AMOUNT,
-            },
-          }),
-        };
-      }
-      if (
-        !debouncedAmountBN.isZero() &&
-        MustBigNumber(debouncedAmountBN).lte(MIN_CCTP_TRANSFER_AMOUNT)
-      ) {
-        return {
-          errorMessage: 'Amount must be greater than 10 USDC',
-        };
-      }
     }
 
     if (isMainnet && MustBigNumber(summary?.aggregatePriceImpact).gte(MAX_PRICE_IMPACT)) {


### PR DESCRIPTION
update `WithdrawForm` errorMessage handling to prefer human-actionable error message before displaying routing messages.

fixes issue [where we see "Unable to resolve quote"](https://linear.app/dydx/issue/OTE-291/fix-squid-error-showing-unable-to-resolve-quote) instead of "amount must be >10"

as a general rule of thumb, we should be prefer user addressable error messages vs backend error messages since they may not be actionable by the end-user