### PR TITLE
fix(perf): memoize fills table

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.7.4",
+    "@dydxprotocol/v4-abacus": "1.7.5",
     "@dydxprotocol/v4-client-js": "^1.1.8",
     "@dydxprotocol/v4-localization": "^1.1.81",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.7.5",
+    "@dydxprotocol/v4-abacus": "1.7.6",
     "@dydxprotocol/v4-client-js": "^1.1.8",
     "@dydxprotocol/v4-localization": "^1.1.81",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.7.5
-    version: 1.7.5
+    specifier: 1.7.6
+    version: 1.7.6
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.8
     version: 1.1.8
@@ -1590,8 +1590,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.7.5:
-    resolution: {integrity: sha512-MmiLXRWFTziZq7MW/XxjN+yvJ97uBKhaUveYwTUjVUXThIg1yXZH/FUeqg3/XrGKq/VWyTBuNTBr7wMrhqz2Sg==}
+  /@dydxprotocol/v4-abacus@1.7.6:
+    resolution: {integrity: sha512-/d9fTWBLB9IvsaVF+PPGrdWud1Ek+YP0ZqWevL+gFXWkUSV8h5TQ1znCPQpBUohQ1ml+mDd1POUoQkCcG2fGWA==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.7.4
-    version: 1.7.4
+    specifier: 1.7.5
+    version: 1.7.5
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.8
     version: 1.1.8
@@ -1590,8 +1590,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.7.4:
-    resolution: {integrity: sha512-vd4ygnYZWK0vOz1O3ojifqhGKkrftbZo58pb70nHc1icYqP1v9rGoPjBbtx/cz1gTbFJNnw35iILwquk1vo3Qg==}
+  /@dydxprotocol/v4-abacus@1.7.5:
+    resolution: {integrity: sha512-MmiLXRWFTziZq7MW/XxjN+yvJ97uBKhaUveYwTUjVUXThIg1yXZH/FUeqg3/XrGKq/VWyTBuNTBr7wMrhqz2Sg==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { Nullable } from '@dydxprotocol/v4-abacus';
 import { OrderSide } from '@dydxprotocol/v4-client-js';
@@ -19,7 +19,13 @@ import { AssetIcon } from '@/components/AssetIcon';
 import { Icon, IconName } from '@/components/Icon';
 import { OrderSideTag } from '@/components/OrderSideTag';
 import { Output, OutputType } from '@/components/Output';
-import { Table, TableCell, TableColumnHeader, ViewMoreConfig, type ColumnDef } from '@/components/Table';
+import {
+  Table,
+  TableCell,
+  TableColumnHeader,
+  ViewMoreConfig,
+  type ColumnDef,
+} from '@/components/Table';
 import { MarketTableCell } from '@/components/Table/MarketTableCell';
 import { TagSize } from '@/components/Tag';
 
@@ -326,13 +332,17 @@ export const FillsTable = ({
 
   const symbol = currentMarket ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.id : null;
 
-  const fillsData = fills.map((fill: SubaccountFill) =>
-    getHydratedTradingData({
-      data: fill,
-      assets: allAssets,
-      perpetualMarkets: allPerpetualMarkets,
-    })
-  ) as FillTableRow[];
+  const fillsData = useMemo(
+    () =>
+      fills.map((fill: SubaccountFill) =>
+        getHydratedTradingData({
+          data: fill,
+          assets: allAssets,
+          perpetualMarkets: allPerpetualMarkets,
+        })
+      ) as FillTableRow[],
+    [fills, allPerpetualMarkets, allAssets]
+  );
 
   return (
     <Styled.Table


### PR DESCRIPTION
small change, noticed we were missing it when auditing some tables.

Also pulled in most recent abacus such that assets + chains are now alphebetized (lowest fees are still pulled to the top because we do that sorting in web in `TokenSelectMenu`).

<img width="589" alt="Screenshot 2024-05-09 at 1 48 15 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/ad6b45df-a8a4-4f40-b028-6c258cb8e9cc">
