### PR TITLE
fix: fix market dropdown table pagination

### DIFF
--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -347,7 +347,7 @@ Styled.Toolbar = styled(Toolbar)`
 
 Styled.ScrollArea = styled.div`
   ${layoutMixins.scrollArea}
-  height: calc(100% - var(--popover-item-height));
+  height: calc(100% - var(--stickyArea-topHeight));
 `;
 
 Styled.Table = styled(Table)`

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -304,6 +304,8 @@ Styled.Popover = styled(Popover)`
   --popover-backgroundColor: var(--color-layer-2);
   --stickyArea-topHeight: 6.125rem;
 
+  --toolbar-height: var(--stickyArea-topHeight);
+
   height: calc(
     100vh - var(--page-header-height) - var(--market-info-row-height) - var(--page-footer-height)
   );
@@ -340,14 +342,14 @@ Styled.Popover = styled(Popover)`
 
 Styled.Toolbar = styled(Toolbar)`
   ${layoutMixins.stickyHeader}
-  height: var(--stickyArea-topHeight);
+  height: var(--toolbar-height);
   gap: 0.5rem;
   border-bottom: solid var(--border-width) var(--color-border);
 `;
 
 Styled.ScrollArea = styled.div`
   ${layoutMixins.scrollArea}
-  height: calc(100% - var(--stickyArea-topHeight));
+  height: calc(100% - var(--toolbar-height));
 `;
 
 Styled.Table = styled(Table)`


### PR DESCRIPTION
Fix market dropdown pagination button being hidden due to incorrect height calculation. It still looks sorta janky, but will fix in my overall PR to update pagination to be page based ([ticket](https://linear.app/dydx/issue/TRCL-3578/update-pagination-on-tables-to-be-page-based)) (new designs).

<img width="794" alt="Screenshot 2024-05-09 at 8 17 59 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/696d2dd5-1972-4dad-abbc-02918003b9d5">
