### PR TITLE
fix: remove scrollArea style to fix safari mobile

### DIFF
--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -117,7 +117,7 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
 const Styled = {
   MarketBillboardsWrapper: styled.div`
     ${layoutMixins.column}
-
+    height: unset!important;
     gap: 1rem;
   `,
   BillboardContainer: styled.div`

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -18,7 +18,7 @@ type ExchangeBillboardsProps = {
   className?: string;
 };
 
-export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ className }) => {
+export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
   const stringGetter = useStringGetter();
   const { chainTokenLabel } = useTokenConfigs();
 
@@ -26,9 +26,8 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
     stats: { volume24HUSDC, openInterestUSDC, feesEarned },
     feesEarnedChart,
   } = usePerpetualMarketsStats();
-
   return (
-    <Styled.MarketBillboardsWrapper className={className}>
+    <Styled.MarketBillboardsWrapper>
       {[
         {
           key: 'volume',
@@ -117,7 +116,6 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = ({ classNam
 const Styled = {
   MarketBillboardsWrapper: styled.div`
     ${layoutMixins.column}
-    height: unset!important;
     gap: 1rem;
   `,
   BillboardContainer: styled.div`

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -35,7 +35,7 @@ export const MarketsStats = (props: MarketsStatsProps) => {
 
   return (
     <Styled.MarketsStats className={className}>
-      <Styled.ExchangeBillboards />
+      <ExchangeBillboards />
       <Styled.Section>
         <Styled.SectionHeader>
           <Styled.RecentlyListed>
@@ -127,8 +127,5 @@ const Styled = {
       font: var(--font-base-medium);
       color: var(--color-text-2);
     }
-  `,
-  ExchangeBillboards: styled(ExchangeBillboards)`
-    ${layoutMixins.contentSectionDetachedScrollable}
   `,
 };


### PR DESCRIPTION
adding `contentSectionDetachedScrollable` layout mixin created strange interactions with safari mobile view. after removing the style i can't see any regressions.

context: 
- https://dydx-team.slack.com/archives/C03GKH23YAZ/p1715339847403409
- https://dydx-team.slack.com/archives/C04CQCRGELV/p1715355311206209