### PR TITLE
chore: add logging events [OTE-311] [1/n]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -77,6 +77,7 @@ export enum AnalyticsEvent {
   TransferFaucetConfirmed = 'TransferFaucetConfirmed',
   TransferDeposit = 'TransferDeposit',
   TransferWithdraw = 'TransferWithdraw',
+  TransferStep = 'TransferStep',
 
   // Trading
   TradeOrderTypeSelected = 'TradeOrderTypeSelected',
@@ -87,6 +88,9 @@ export enum AnalyticsEvent {
 
   // Notification
   NotificationAction = 'NotificationAction',
+
+  // SquidStatus
+  TransferNotification = 'TransferNotification',
 }
 
 export type AnalyticsEventData<T extends AnalyticsEvent> =
@@ -205,6 +209,16 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
     ? {
         type: string;
         id: string;
+      }
+    : T extends AnalyticsEvent.TransferNotification
+    ? {
+        type: string;
+        complete: boolean;
+      }
+    : T extends AnalyticsEvent.TransferStep
+    ? {
+        step: string;
+        type: string;
       }
     : never;
 

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -76,6 +76,7 @@ export enum AnalyticsEvent {
   TransferFaucet = 'TransferFaucet',
   TransferFaucetConfirmed = 'TransferFaucetConfirmed',
   TransferDeposit = 'TransferDeposit',
+  TransferNotification = 'TransferNotification',
   TransferWithdraw = 'TransferWithdraw',
   TransferStep = 'TransferStep',
 
@@ -90,7 +91,7 @@ export enum AnalyticsEvent {
   NotificationAction = 'NotificationAction',
 
   // SquidStatus
-  TransferNotification = 'TransferNotification',
+  SquidRouteError = 'SquidRouteError',
 }
 
 export type AnalyticsEventData<T extends AnalyticsEvent> =
@@ -219,6 +220,11 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
     ? {
         step: string;
         type: string;
+      }
+    : T extends AnalyticsEvent.SquidRouteError
+    ? {
+        type: DialogTypes;
+        errorMessage: string | undefined;
       }
     : never;
 

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -5,7 +5,8 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { ComplianceStatus } from '@/constants/abacus';
+import { ComplianceStatus, TransferType } from '@/constants/abacus';
+import { AnalyticsEvent } from '@/constants/analytics';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import {
@@ -50,6 +51,7 @@ import { openDialog } from '@/state/dialogs';
 import { getAbacusNotifications } from '@/state/notificationsSelectors';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
+import { track } from '@/lib/analytics';
 import { formatSeconds } from '@/lib/timeUtils';
 
 import { useComplianceState } from './useComplianceState';
@@ -230,6 +232,11 @@ export const notificationTypes: NotificationTypeConfig[] = [
               AMOUNT_USD: `${toAmount} ${DydxChainAsset.USDC.toUpperCase()}`,
               ESTIMATED_DURATION: estimatedDuration,
             },
+          });
+
+          track(AnalyticsEvent.TransferNotification, {
+            type: TransferType.deposit.name,
+            complete: Boolean(isFinished),
           });
 
           trigger(

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -11,6 +11,7 @@ import { TransferInputField, TransferInputTokenResource, TransferType } from '@/
 import { AlertType } from '@/constants/alerts';
 import { AnalyticsEvent, AnalyticsEventData } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
+import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
 import { MAX_CCTP_TRANSFER_AMOUNT, MAX_PRICE_IMPACT, NumberSign } from '@/constants/numbers';
@@ -39,6 +40,7 @@ import { getSelectedDydxChainId } from '@/state/appSelectors';
 import { getTransferInputs } from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { track } from '@/lib/analytics';
 import { MustBigNumber } from '@/lib/numbers';
 import { getNobleChainId, NATIVE_TOKEN_ADDRESS } from '@/lib/squid';
 import { log } from '@/lib/telemetry';
@@ -108,6 +110,10 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
   useEffect(() => {
     if (routeErrors) {
       log('DepositForm/routeErrors', new Error(routeErrors));
+      track(AnalyticsEvent.SquidRouteError, {
+        type: DialogTypes.Deposit,
+        errorMessage,
+      });
     }
   }, [routeErrors]);
 

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -105,6 +105,12 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
   const debouncedAmountBN = MustBigNumber(debouncedAmount);
   const balanceBN = MustBigNumber(balance);
 
+  useEffect(() => {
+    if (routeErrors) {
+      log('DepositForm/routeErrors', new Error(routeErrors));
+    }
+  }, [routeErrors]);
+
   useEffect(() => setSlippage(isCctp ? 0 : 0.01), [isCctp]);
 
   useEffect(() => {

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -10,6 +10,7 @@ import { TransferInputField, TransferInputTokenResource, TransferType } from '@/
 import { AlertType } from '@/constants/alerts';
 import { AnalyticsEvent } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
+import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
 import { TransferNotificationTypes } from '@/constants/notifications';
@@ -112,6 +113,10 @@ export const WithdrawForm = () => {
   useEffect(() => {
     if (routeErrors) {
       log('WithdrawForm/routeErrors', new Error(routeErrors));
+      track(AnalyticsEvent.SquidRouteError, {
+        type: DialogTypes.Withdraw,
+        errorMessage,
+      });
     }
   }, [routeErrors]);
 

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -59,6 +59,7 @@ import { validateCosmosAddress } from '@/lib/addressUtils';
 import { track } from '@/lib/analytics';
 import { MustBigNumber } from '@/lib/numbers';
 import { getNobleChainId } from '@/lib/squid';
+import { log } from '@/lib/telemetry';
 
 import { TokenSelectMenu } from './TokenSelectMenu';
 import { WithdrawButtonAndReceipt } from './WithdrawForm/WithdrawButtonAndReceipt';
@@ -107,6 +108,12 @@ export const WithdrawForm = () => {
     () => MustBigNumber(freeCollateral?.current),
     [freeCollateral?.current]
   );
+
+  useEffect(() => {
+    if (routeErrors) {
+      log('WithdrawForm/routeErrors', new Error(routeErrors));
+    }
+  }, [routeErrors]);
 
   useEffect(() => setSlippage(isCctp ? 0 : 0.01), [isCctp]);
 

--- a/src/views/notifications/TransferStatusNotification/TransferStatusSteps.tsx
+++ b/src/views/notifications/TransferStatusNotification/TransferStatusSteps.tsx
@@ -4,6 +4,7 @@ import { StatusResponse } from '@0xsquid/sdk';
 import { useSelector } from 'react-redux';
 import styled, { css, type AnyStyledComponent } from 'styled-components';
 
+import { AnalyticsEvent } from '@/constants/analytics';
 import { STRING_KEYS } from '@/constants/localization';
 import { TransferNotificationTypes } from '@/constants/notifications';
 
@@ -17,6 +18,8 @@ import { LoadingDots } from '@/components/Loading/LoadingDots';
 import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
 
 import { getSelectedDydxChainId } from '@/state/appSelectors';
+
+import { track } from '@/lib/analytics';
 
 type ElementProps = {
   status?: StatusResponse;
@@ -106,7 +109,10 @@ export const TransferStatusSteps = ({ className, status, type }: ElementProps & 
     if (status?.squidTransactionStatus === 'success') {
       currentStep = TransferStatusStep.Complete;
     }
-
+    track(AnalyticsEvent.TransferStep, {
+      step: TransferStatusStep[currentStep],
+      type,
+    });
     return {
       currentStep,
       steps,

--- a/src/views/notifications/TransferStatusNotification/TransferStatusSteps.tsx
+++ b/src/views/notifications/TransferStatusNotification/TransferStatusSteps.tsx
@@ -4,7 +4,6 @@ import { StatusResponse } from '@0xsquid/sdk';
 import { useSelector } from 'react-redux';
 import styled, { css, type AnyStyledComponent } from 'styled-components';
 
-import { AnalyticsEvent } from '@/constants/analytics';
 import { STRING_KEYS } from '@/constants/localization';
 import { TransferNotificationTypes } from '@/constants/notifications';
 
@@ -18,8 +17,6 @@ import { LoadingDots } from '@/components/Loading/LoadingDots';
 import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
 
 import { getSelectedDydxChainId } from '@/state/appSelectors';
-
-import { track } from '@/lib/analytics';
 
 type ElementProps = {
   status?: StatusResponse;
@@ -109,10 +106,7 @@ export const TransferStatusSteps = ({ className, status, type }: ElementProps & 
     if (status?.squidTransactionStatus === 'success') {
       currentStep = TransferStatusStep.Complete;
     }
-    track(AnalyticsEvent.TransferStep, {
-      step: TransferStatusStep[currentStep],
-      type,
-    });
+
     return {
       currentStep,
       steps,


### PR DESCRIPTION
adds a TELEMETRY log for squid route errors.

may swap this to amplitude like [the spec](https://www.notion.so/dydx/Error-tracking-deposits-withdrawals-077b53ea3b554c2a9dca986542596944?pvs=4#72aef7cb1a7a4af18a71c6b9217e7321) suggests... but just going with existing pattern of using telemetry log to gather analytics on errors

adds transfer notification tracking events (https://www.notion.so/dydx/Error-tracking-deposits-withdrawals-077b53ea3b554c2a9dca986542596944?pvs=4#1f46ce43633b42779e2c440bb108443e)

telemetry log events
- DepositForm/routeErrors
- WithdrawForm/routeErrors
  - both of these events log squid routing error data to telemetry

amplitude events
- TransferNotification: This event tracks the [appearance and completion of the transfer notification toast](https://www.notion.so/dydx/Error-tracking-deposits-withdrawals-077b53ea3b554c2a9dca986542596944?pvs=4#048ddbd75af2455ea0e373d3bc1389f4)
- SquidRouteError: This event tracks the occurrence of a [squid routing error](https://www.notion.so/dydx/Error-tracking-deposits-withdrawals-077b53ea3b554c2a9dca986542596944?pvs=4#72aef7cb1a7a4af18a71c6b9217e7321)

part2: https://github.com/dydxprotocol/v4-web/pull/526
part3: https://github.com/dydxprotocol/v4-web/pull/527