### PR TITLE
chore: add logging events [3/n]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -60,6 +60,7 @@ export enum AnalyticsEvent {
   // Navigation
   NavigatePage = 'NavigatePage',
   NavigateDialog = 'NavigateDialog',
+  NavigateDialogLoaded = 'NavigateDialogLoaded',
   NavigateDialogClose = 'NavigateDialogClose',
   NavigateExternal = 'NavigateExternal',
   NavigateClickTransferTradePanel = 'NavigateClickTransferTradePanel',
@@ -117,6 +118,10 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
         path: string;
       }
     : T extends AnalyticsEvent.NavigateDialog
+    ? {
+        type: DialogTypes;
+      }
+    : T extends AnalyticsEvent.NavigateDialogLoaded
     ? {
         type: DialogTypes;
       }

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -231,6 +231,14 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
         type: DialogTypes;
         errorMessage: string | undefined;
       }
+    : T extends AnalyticsEvent.NavigateClickTransferAccountMenu
+    ? {
+        type: string;
+      }
+    : T extends AnalyticsEvent.NavigateClickTransferTradePanel
+    ? {
+        type: string;
+      }
     : never;
 
 export const DEFAULT_TRANSACTION_MEMO = 'dYdX Frontend (web)';

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -62,6 +62,8 @@ export enum AnalyticsEvent {
   NavigateDialog = 'NavigateDialog',
   NavigateDialogClose = 'NavigateDialogClose',
   NavigateExternal = 'NavigateExternal',
+  NavigateClickTransferTradePanel = 'NavigateClickTransferTradePanel',
+  NavigateClickTransferAccountMenu = 'NavigateClickTransferAccountMenu',
 
   // Wallet
   ConnectWallet = 'ConnectWallet',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -7,7 +7,7 @@ import type {
 
 import { testFlags } from './testFlags';
 
-const DEBUG_ANALYTICS = false;
+const DEBUG_ANALYTICS = true;
 
 export const identify = <T extends AnalyticsUserProperty>(
   property: T,

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -2,6 +2,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import styled, { css, type AnyStyledComponent } from 'styled-components';
 
 import type { Nullable, TradeState } from '@/constants/abacus';
+import { AnalyticsEvent } from '@/constants/analytics';
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
@@ -29,6 +30,7 @@ import { openDialog } from '@/state/dialogs';
 import { getInputErrors } from '@/state/inputsSelectors';
 import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 
+import { track } from '@/lib/analytics';
 import { isNumber, MustBigNumber } from '@/lib/numbers';
 
 import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
@@ -72,7 +74,10 @@ export const AccountInfoConnectedState = () => {
       !MustBigNumber(buyingPower?.postOrder).eq(MustBigNumber(buyingPower?.current)));
 
   const showHeader = !hasDiff && !isTablet;
-
+  const onClick = (type: DialogTypes) => {
+    dispatch(openDialog({ type }));
+    track(AnalyticsEvent.NavigateClickDepositButton);
+  };
   return (
     <Styled.ConnectedAccountInfoContainer $showHeader={showHeader}>
       {!showHeader ? null : (
@@ -81,7 +86,7 @@ export const AccountInfoConnectedState = () => {
           <Styled.TransferButtons>
             <Styled.Button
               state={{ isDisabled: !dydxAccounts }}
-              onClick={() => dispatch(openDialog({ type: DialogTypes.Withdraw }))}
+              onClick={() => onClick(DialogTypes.Withdraw)}
               shape={ButtonShape.Rectangle}
               size={ButtonSize.XSmall}
             >
@@ -91,7 +96,7 @@ export const AccountInfoConnectedState = () => {
               <>
                 <Styled.Button
                   state={{ isDisabled: !dydxAccounts }}
-                  onClick={() => dispatch(openDialog({ type: DialogTypes.Deposit }))}
+                  onClick={() => onClick(DialogTypes.Deposit)}
                   shape={ButtonShape.Rectangle}
                   size={ButtonSize.XSmall}
                 >

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -76,7 +76,7 @@ export const AccountInfoConnectedState = () => {
   const showHeader = !hasDiff && !isTablet;
   const onClick = (type: DialogTypes) => {
     dispatch(openDialog({ type }));
-    track(AnalyticsEvent.NavigateClickDepositButton);
+    track(AnalyticsEvent.NavigateClickTransferTradePanel, { type });
   };
   return (
     <Styled.ConnectedAccountInfoContainer $showHeader={showHeader}>

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -409,6 +409,9 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
   if (!resources) {
     return <LoadingSpace id="DepositForm" />;
   }
+  track(AnalyticsEvent.NavigateDialogLoaded, {
+    type: DialogTypes.Deposit,
+  });
   return (
     <Styled.Form onSubmit={onSubmit}>
       <Styled.Subheader>

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -481,6 +481,7 @@ export const WithdrawForm = () => {
     isLoading ||
     isInvalidNobleAddress;
 
+  track(AnalyticsEvent.NavigateDialogLoaded, { type: DialogTypes.Withdraw });
   return (
     <Styled.Form onSubmit={onSubmit}>
       <Styled.Subheader>

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -6,6 +6,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import styled, { AnyStyledComponent, css } from 'styled-components';
 
 import { OnboardingState } from '@/constants/account';
+import { AnalyticsEvent } from '@/constants/analytics';
 import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
@@ -45,6 +46,7 @@ import { AppTheme } from '@/state/configs';
 import { getAppTheme } from '@/state/configsSelectors';
 import { openDialog } from '@/state/dialogs';
 
+import { track } from '@/lib/analytics';
 import { isTruthy } from '@/lib/isTruthy';
 import { MustBigNumber } from '@/lib/numbers';
 import { truncateAddress } from '@/lib/wallet';
@@ -334,7 +336,10 @@ const AssetActions = memo(
               action={ButtonAction.Base}
               shape={ButtonShape.Square}
               iconName={iconName}
-              onClick={() => dispatch(openDialog({ type: dialogType, dialogProps }))}
+              onClick={() => {
+                track(AnalyticsEvent.NavigateClickTransferAccountMenu);
+                dispatch(openDialog({ type: dialogType, dialogProps }));
+              }}
             />
           </Styled.WithTooltip>
         ))}

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -337,7 +337,7 @@ const AssetActions = memo(
               shape={ButtonShape.Square}
               iconName={iconName}
               onClick={() => {
-                track(AnalyticsEvent.NavigateClickTransferAccountMenu);
+                track(AnalyticsEvent.NavigateClickTransferAccountMenu, { type: dialogType });
                 dispatch(openDialog({ type: dialogType, dialogProps }));
               }}
             />


### PR DESCRIPTION
adds withdraw/deposit button click tracks

we already have a tracking event for dialogs appearing so we can use that to check if a dialog has appeared

adds deposit/withdraw form loading. complete tracking events

part1: https://github.com/dydxprotocol/v4-web/pull/525
part2: https://github.com/dydxprotocol/v4-web/pull/526