### PR TITLE
fix: order cancel toast should go from canceling -> canceled / error

### DIFF
--- a/src/views/notifications/OrderCancelNotification.tsx
+++ b/src/views/notifications/OrderCancelNotification.tsx
@@ -1,7 +1,7 @@
 import { shallowEqual, useSelector } from 'react-redux';
 import styled, { AnyStyledComponent } from 'styled-components';
 
-import { AbacusOrderStatus, KotlinIrEnumValues, ORDER_STATUS_STRINGS } from '@/constants/abacus';
+import { AbacusOrderStatus } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 import { CancelOrderStatuses, LocalCancelOrderData, ORDER_TYPE_STRINGS } from '@/constants/trade';
 
@@ -43,16 +43,15 @@ export const OrderCancelNotification = ({
   let orderStatusIcon = <Styled.LoadingSpinner />;
   let customContent = null;
 
-  if (cancelStatus === CancelOrderStatuses.Canceled) {
-    orderStatusStringKey =
-      ORDER_STATUS_STRINGS[
-        indexedOrderStatus as unknown as KotlinIrEnumValues<typeof AbacusOrderStatus>
-      ];
-    orderStatusIcon = <Styled.OrderStatusIcon status={indexedOrderStatus} />;
+  // whichever canceled confirmation happens first (node / indexer)
+  const canceledStatusValue = AbacusOrderStatus.cancelled.rawValue;
+  if (cancelStatus === CancelOrderStatuses.Canceled || indexedOrderStatus === canceledStatusValue) {
+    orderStatusStringKey = STRING_KEYS.CANCELED;
+    orderStatusIcon = <Styled.OrderStatusIcon status={canceledStatusValue} />;
   }
 
   if (localCancel.errorStringKey) {
-    orderStatusStringKey = STRING_KEYS.FAILED;
+    orderStatusStringKey = STRING_KEYS.ERROR;
     orderStatusIcon = <Styled.WarningIcon iconName={IconName.Warning} />;
     customContent = <span>{stringGetter({ key: localCancel.errorStringKey })}</span>;
   }


### PR DESCRIPTION
there's a lag between order confirmed cancel (node response) vs indexer's response, therefore currently the order cancel toast can be canceling -> open -> canceled

fix: optimistically believe in node response that it's canceled and show that (or if indexer says it's confirmed first), so that toast should go from canceling -> canceled, or canceling -> error when fail

test: cancel an open order