### PR TITLE
chore: add logging for status tracking [1/n]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -215,6 +215,7 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
         timeSpent: Record<string, number> | number | undefined;
         txHash: string;
         status: string;
+        triggeredAt: number | undefined;
       }
     : never;
 

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -3,6 +3,7 @@ import type { OnboardingState, OnboardingSteps } from './account';
 import type { DialogTypes } from './dialogs';
 import type { SupportedLocales } from './localization';
 import type { DydxNetwork } from './networks';
+import { TransferNotificationTypes } from './notifications';
 import type { TradeTypes } from './trade';
 import type { DydxAddress, EvmAddress, WalletConnectionType, WalletType } from './wallets';
 
@@ -77,6 +78,7 @@ export enum AnalyticsEvent {
   TransferFaucetConfirmed = 'TransferFaucetConfirmed',
   TransferDeposit = 'TransferDeposit',
   TransferWithdraw = 'TransferWithdraw',
+  TransferNotification = 'TransferNotification',
 
   // Trading
   TradeOrderTypeSelected = 'TradeOrderTypeSelected',
@@ -205,6 +207,14 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
     ? {
         type: string;
         id: string;
+      }
+    : T extends AnalyticsEvent.TransferNotification
+    ? {
+        type: TransferNotificationTypes | undefined;
+        toAmount: number | undefined;
+        timeSpent: Record<string, number> | number | undefined;
+        txHash: string;
+        status: string;
       }
     : never;
 

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -214,7 +214,7 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
         toAmount: number | undefined;
         timeSpent: Record<string, number> | number | undefined;
         txHash: string;
-        status: string;
+        status: 'new' | 'success' | 'error';
         triggeredAt: number | undefined;
       }
     : never;

--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -78,6 +78,7 @@ const useLocalNotificationsContext = () => {
       setTransferNotifications([...transferNotifications, notification]);
       // track initialized new transfer notification
       track(AnalyticsEvent.TransferNotification, {
+        triggeredAt,
         timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
         txHash,
         toAmount,
@@ -133,9 +134,10 @@ const useLocalNotificationsContext = () => {
                   transferNotification.status = status;
                   if (status.squidTransactionStatus === 'success') {
                     track(AnalyticsEvent.TransferNotification, {
+                      triggeredAt,
                       timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
                       toAmount: transferNotification.toAmount,
-                      status: 'complete',
+                      status: 'success',
                       type: transferNotification.type,
                       txHash,
                     });
@@ -146,6 +148,7 @@ const useLocalNotificationsContext = () => {
                   if (errorCount && errorCount > ERROR_COUNT_THRESHOLD) {
                     transferNotification.status = error;
                     track(AnalyticsEvent.TransferNotification, {
+                      triggeredAt,
                       timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
                       toAmount: transferNotification.toAmount,
                       status: 'error',

--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -2,11 +2,13 @@ import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { useQuery } from 'react-query';
 
+import { AnalyticsEvent } from '@/constants/analytics';
 import { LOCAL_STORAGE_VERSIONS, LocalStorageKey } from '@/constants/localStorage';
 import type { TransferNotifcation } from '@/constants/notifications';
 
 import { useAccounts } from '@/hooks/useAccounts';
 
+import { track } from '@/lib/analytics';
 import { fetchSquidStatus, STATUS_ERROR_GRACE_PERIOD } from '@/lib/squid';
 
 import { useLocalStorage } from './useLocalStorage';
@@ -71,8 +73,18 @@ const useLocalNotificationsContext = () => {
   );
 
   const addTransferNotification = useCallback(
-    (notification: TransferNotifcation) =>
-      setTransferNotifications([...transferNotifications, notification]),
+    (notification: TransferNotifcation) => {
+      const { txHash, triggeredAt, toAmount, type } = notification;
+      setTransferNotifications([...transferNotifications, notification]);
+      // track initialized new transfer notification
+      track(AnalyticsEvent.TransferNotification, {
+        timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
+        txHash,
+        toAmount,
+        type,
+        status: 'new',
+      });
+    },
     [transferNotifications]
   );
 
@@ -117,14 +129,29 @@ const useLocalNotificationsContext = () => {
                   undefined,
                   requestId
                 );
-
                 if (status) {
                   transferNotification.status = status;
+                  if (status.squidTransactionStatus === 'success') {
+                    track(AnalyticsEvent.TransferNotification, {
+                      timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
+                      toAmount: transferNotification.toAmount,
+                      status: 'complete',
+                      type: transferNotification.type,
+                      txHash,
+                    });
+                  }
                 }
               } catch (error) {
                 if (!triggeredAt || Date.now() - triggeredAt > STATUS_ERROR_GRACE_PERIOD) {
                   if (errorCount && errorCount > ERROR_COUNT_THRESHOLD) {
                     transferNotification.status = error;
+                    track(AnalyticsEvent.TransferNotification, {
+                      timeSpent: triggeredAt ? Date.now() - triggeredAt : undefined,
+                      toAmount: transferNotification.toAmount,
+                      status: 'error',
+                      type: transferNotification.type,
+                      txHash: txHash,
+                    });
                   } else {
                     transferNotification.errorCount = errorCount ? errorCount + 1 : 1;
                   }
@@ -143,7 +170,6 @@ const useLocalNotificationsContext = () => {
     },
     refetchInterval: TRANSFER_STATUS_FETCH_INTERVAL,
   });
-
   return {
     // Transfer notifications
     transferNotifications,

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -13,6 +13,7 @@ import { AnalyticsEvent, AnalyticsEventData } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
+import { TransferNotificationTypes } from '@/constants/notifications';
 import {
   MAX_CCTP_TRANSFER_AMOUNT,
   MAX_PRICE_IMPACT,
@@ -285,6 +286,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
             triggeredAt: Date.now(),
             isCctp,
             requestId: requestPayload.requestId ?? undefined,
+            type: TransferNotificationTypes.Deposit,
           });
           abacusStateManager.clearTransferInputValues();
           setFromAmount('');


### PR DESCRIPTION
adds success/fail/new transfer notification tracking.

creates new event `AnalyticsEvent.TransferNotification` with metadata:
- txHash (uses this as the id)
- toAmount (amount to withdraw/deposit)
- timeSpent (time since tx start)
- triggeredAt (time the tx began)
- status (success, error, new)
- type (withdraw/deposit)