### PR TITLE
chore: cleaner handling of higher order function type inference (styled and forwardRef)

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { Fragment, forwardRef, type Ref } from 'react';
+import { Fragment, type Ref } from 'react';
 
 import { Content, Item, Portal, Root, Separator, Trigger } from '@radix-ui/react-dropdown-menu';
 import styled from 'styled-components';
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { popoverMixins } from '@/styles/popoverMixins';
 
 import { Icon, IconName } from '@/components/Icon';
+
+import { forwardRefFn } from '@/lib/genericFunctionalComponentUtils';
 
 export type DropdownMenuItem<T> = {
   value: T;
@@ -31,7 +33,7 @@ type ElementProps<T> = {
 
 type DropdownMenuProps<T> = StyleProps & ElementProps<T>;
 
-export const DropdownMenu = forwardRef(
+export const DropdownMenu = forwardRefFn(
   <T extends string>(
     {
       align = 'center',

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Ref } from 'react';
+import { Ref } from 'react';
 
 import {
   Content,
@@ -10,7 +10,7 @@ import {
   Trigger,
   Viewport,
 } from '@radix-ui/react-navigation-menu';
-import { matchPath, NavLink, useLocation } from 'react-router-dom';
+import { NavLink, matchPath, useLocation } from 'react-router-dom';
 import styled, { css, keyframes } from 'styled-components';
 
 import { MenuConfig, MenuItem } from '@/constants/menus';
@@ -18,6 +18,7 @@ import { MenuConfig, MenuItem } from '@/constants/menus';
 import { layoutMixins } from '@/styles/layoutMixins';
 import { popoverMixins } from '@/styles/popoverMixins';
 
+import { forwardRefFn, getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { isExternalLink } from '@/lib/isExternalLink';
 
 import { Icon, IconName } from './Icon';
@@ -46,8 +47,9 @@ function NavItemWithRef<MenuItemValue extends string>(
     slotAfter = isExternalLink(href) ? <Icon iconName={IconName.LinkOut} /> : undefined,
     onSelect,
     subitems,
+    type,
     ...props
-  }: MenuItem<MenuItemValue>,
+  }: MenuItem<MenuItemValue, string | number>,
   ref: Ref<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>
 ) {
   const location = useLocation();
@@ -76,7 +78,7 @@ function NavItemWithRef<MenuItemValue extends string>(
       asChild
       target={isExternalLink(href) ? '_blank' : undefined}
     >
-      <NavLink to={href} ref={ref as Ref<HTMLAnchorElement>} {...props}>
+      <NavLink to={href} ref={ref as Ref<HTMLAnchorElement>} type={'' + type} {...props}>
         {children}
       </NavLink>
     </Link>
@@ -93,10 +95,7 @@ function NavItemWithRef<MenuItemValue extends string>(
   );
 }
 
-const NavItem = forwardRef(NavItemWithRef);
-
-type AllNavItemProps<MenuItemValue extends string> = MenuItem<MenuItemValue, string | number> &
-  React.RefAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>;
+const NavItem = forwardRefFn(NavItemWithRef);
 
 export const NavigationMenu = <MenuItemValue extends string, MenuGroupValue extends string>({
   onSelectItem,
@@ -390,8 +389,10 @@ const $SubMenuTrigger = styled(Trigger)`
   }
 `;
 
-type NavItemStyleProps = { orientation: 'horizontal' | 'vertical' };
-const $NavItem = styled(NavItem)<NavItemStyleProps>`
+type navItemStyleProps = { orientation: 'horizontal' | 'vertical' };
+const NavItemTypeTemp = getSimpleStyledOutputType(NavItem, {} as navItemStyleProps);
+
+const $NavItem = styled(NavItem)<navItemStyleProps>`
   ${({ subitems }) =>
     subitems?.length
       ? css`
@@ -463,9 +464,7 @@ const $NavItem = styled(NavItem)<NavItemStyleProps>`
   ${$List}[data-orientation="menu"] ${$List}[data-orientation="menu"] > ${$ListItem}:first-child > & {
     border-top-left-radius: 0;
   }
-` as <MenuItemValue extends string>(
-  props: AllNavItemProps<MenuItemValue> & NavItemStyleProps
-) => React.ReactNode;
+` as typeof NavItemTypeTemp;
 
 const $Icon = styled(Icon)`
   font-size: 0.375em;

--- a/src/components/SearchSelectMenu.tsx
+++ b/src/components/SearchSelectMenu.tsx
@@ -17,6 +17,8 @@ import { Popover, TriggerType } from '@/components/Popover';
 import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
 import { WithLabel } from '@/components/WithLabel';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
+
 type ElementProps = {
   asChild?: boolean;
   children: ReactNode;
@@ -126,9 +128,10 @@ const $Popover = styled(Popover)`
   box-shadow: none;
 `;
 
-type ComboboxMenuStyleProps = { $withSearch?: boolean };
+type comboboxMenuStyleProps = { $withSearch?: boolean };
+const ComboboxMenuStyleType = getSimpleStyledOutputType(ComboboxMenu, {} as comboboxMenuStyleProps);
 
-const $ComboboxMenu = styled(ComboboxMenu)<ComboboxMenuStyleProps>`
+const $ComboboxMenu = styled(ComboboxMenu)<comboboxMenuStyleProps>`
   ${layoutMixins.withInnerHorizontalBorders}
 
   --comboboxMenu-backgroundColor: var(--color-layer-4);
@@ -151,10 +154,7 @@ const $ComboboxMenu = styled(ComboboxMenu)<ComboboxMenuStyleProps>`
   border-radius: 0.5rem;
   max-height: 30vh;
   overflow: auto;
-` as <MenuItemValue extends string | number, MenuGroupValue extends string | number>(
-  props: React.ComponentProps<typeof ComboboxMenu<MenuItemValue, MenuGroupValue>> &
-    ComboboxMenuStyleProps
-) => JSX.Element;
+` as typeof ComboboxMenuStyleType;
 
 const $TriggerIcon = styled(Icon)<{ open?: boolean }>`
   width: 0.625rem;

--- a/src/components/ToggleGroup.tsx
+++ b/src/components/ToggleGroup.tsx
@@ -1,7 +1,7 @@
-import { forwardRef, type Ref } from 'react';
+import { type Ref } from 'react';
 
 import { Item, Root } from '@radix-ui/react-toggle-group';
-import styled, { type AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { type MenuItem } from '@/constants/menus';
@@ -13,10 +13,12 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { type BaseButtonProps } from '@/components/BaseButton';
 import { ToggleButton } from '@/components/ToggleButton';
 
+import { forwardRefFn } from '@/lib/genericFunctionalComponentUtils';
+
 type ElementProps<MenuItemValue extends string> = {
   items: MenuItem<MenuItemValue>[];
   value: MenuItemValue;
-  onValueChange: (value: any) => void;
+  onValueChange: (value: MenuItemValue) => void;
   onInteraction?: () => void;
   ensureSelected?: boolean;
 };
@@ -25,7 +27,7 @@ type StyleProps = {
   className?: string;
 };
 
-export const ToggleGroup = forwardRef(
+export const ToggleGroup = forwardRefFn(
   <MenuItemValue extends string>(
     {
       items,

--- a/src/lib/genericFunctionalComponentUtils.ts
+++ b/src/lib/genericFunctionalComponentUtils.ts
@@ -21,7 +21,7 @@ const $NavItem = styled(NavItem)<NavItemStyleProps>`
 */
 
 // Note the output is a total lie, never use it at runtime, just for type inference
-export const getSimpleStyledOutputType: <C, P = {}>(
+export const getSimpleStyledOutputType: <C = {}, P = {}>(
   render: (props: P) => React.ReactNode,
-  style: C
+  style?: C
 ) => (props: P & C) => React.ReactNode = () => undefined as any;

--- a/src/lib/genericFunctionalComponentUtils.ts
+++ b/src/lib/genericFunctionalComponentUtils.ts
@@ -1,0 +1,27 @@
+import { ForwardedRef, PropsWithoutRef, ReactNode, RefAttributes, forwardRef } from 'react';
+
+// a functional-only version of forwardRef. This only accepts and returns a functional component essentially and thus
+// Typescript can fully apply higher order function type inference
+// this is only necessary when render function props has generic type arguments
+export const forwardRefFn: <T, P = {}>(
+  render: (props: P, ref: ForwardedRef<T>) => ReactNode
+) => (props: PropsWithoutRef<P> & RefAttributes<T>) => ReactNode = forwardRef;
+
+// if your input and output components are fully functional, use this to type the styled result
+// only necessary when render function props has generic type arguments
+/*
+Usage:
+
+type NavItemStyleProps = { orientation: 'horizontal' | 'vertical' };
+const navItemTypeTemp = getSimpleStyledOutputType(NavItem, {} as NavItemStyleProps);
+
+const $NavItem = styled(NavItem)<NavItemStyleProps>`
+  ...styles here
+` as typeof navItemTypeTemp;
+*/
+
+// Note the output is a total lie, never use it at runtime, just for type inference
+export const getSimpleStyledOutputType: <C, P = {}>(
+  render: (props: P) => React.ReactNode,
+  style: C
+) => (props: P & C) => React.ReactNode = () => undefined as any;

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -36,6 +36,7 @@ import {
 import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configsSelectors';
 import { getCurrentMarketAssetId, getCurrentMarketId } from '@/state/perpetualsSelectors';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { shortenNumberForDisplay } from '@/lib/numbers';
 import { testFlags } from '@/lib/testFlags';
@@ -308,13 +309,16 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
 const $AssetIcon = styled(AssetIcon)`
   font-size: 1.5em;
 `;
+const collapsibleTabsType = getSimpleStyledOutputType(CollapsibleTabs, {} as {});
+
 const $CollapsibleTabs = styled(CollapsibleTabs)`
   --tableHeader-backgroundColor: var(--color-layer-3);
 
   header {
     background-color: var(--color-layer-2);
   }
-` as typeof CollapsibleTabs<InfoSection>;
+` as typeof collapsibleTabsType;
+
 const $LoadingSpinner = styled(LoadingSpinner)`
   --spinner-width: 1rem;
 `;

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -309,7 +309,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
 const $AssetIcon = styled(AssetIcon)`
   font-size: 1.5em;
 `;
-const collapsibleTabsType = getSimpleStyledOutputType(CollapsibleTabs, {} as {});
+const collapsibleTabsType = getSimpleStyledOutputType(CollapsibleTabs);
 
 const $CollapsibleTabs = styled(CollapsibleTabs)`
   --tableHeader-backgroundColor: var(--color-layer-3);

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -55,11 +55,11 @@ export const MarketsStats = (props: MarketsStatsProps) => {
               items={[
                 {
                   label: stringGetter({ key: STRING_KEYS.GAINERS }),
-                  value: 'gainers',
+                  value: MarketSorting.GAINERS,
                 },
                 {
                   label: stringGetter({ key: STRING_KEYS.LOSERS }),
-                  value: 'losers',
+                  value: MarketSorting.LOSERS,
                 },
               ]}
               value={sorting}

--- a/src/views/dialogs/NewMarketMessageDetailsDialog.tsx
+++ b/src/views/dialogs/NewMarketMessageDetailsDialog.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react';
 
 import { utils } from '@dydxprotocol/v4-client-js';
-import styled, { AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
+import { MenuItem } from '@/constants/menus';
 import { isMainnet } from '@/constants/networks';
 import { NewMarketProposal } from '@/constants/potentialMarkets';
 
@@ -64,7 +65,7 @@ export const NewMarketMessageDetailsDialog = ({
     return baseAsset ? exchangeConfigJson : undefined;
   }, [baseAsset]);
 
-  const toggleGroupItems: Parameters<typeof ToggleGroup>[0]['items'] = useMemo(() => {
+  const toggleGroupItems: MenuItem<CodeToggleGroup>[] = useMemo(() => {
     return [
       {
         value: CodeToggleGroup.CREATE_ORACLE,
@@ -355,7 +356,7 @@ const $ProposedMessageDetails = styled.div`
 
 const $Tabs = styled(ToggleGroup)`
   overflow-x: auto;
-`;
+` as typeof ToggleGroup;
 
 const $Details = styled(Details)`
   --details-item-height: 1.5rem;

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -144,7 +144,7 @@ export const TradeForm = ({
   const { typeOptions } = useSelector(getInputTradeOptions, shallowEqual) ?? {};
 
   const allTradeTypeItems = (typeOptions?.toArray() ?? []).map(({ type, stringKey }) => ({
-    value: type,
+    value: type as TradeTypes,
     label: stringGetter({
       key: stringKey as StringKey,
     }),
@@ -594,7 +594,7 @@ const $ToggleGroup = styled(ToggleGroup)`
       height: 0;
     }
   }
-`;
+` as typeof ToggleGroup;
 const $InputsColumn = styled.div`
   ${formMixins.inputsColumn}
 `;

--- a/src/views/forms/TradeForm/TradeSideToggle.tsx
+++ b/src/views/forms/TradeForm/TradeSideToggle.tsx
@@ -15,6 +15,7 @@ import { ToggleGroup } from '@/components/ToggleGroup';
 import { getTradeSide } from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { getSelectedOrderSide } from '@/lib/tradeData';
 
 export const TradeSideToggle = memo(() => {
@@ -23,7 +24,7 @@ export const TradeSideToggle = memo(() => {
   const selectedOrderSide = getSelectedOrderSide(side);
 
   return (
-    <ToggleContainer
+    <$ToggleContainer
       items={[
         { value: OrderSide.BUY, label: stringGetter({ key: STRING_KEYS.BUY }) },
         { value: OrderSide.SELL, label: stringGetter({ key: STRING_KEYS.SELL }) },
@@ -42,7 +43,9 @@ export const TradeSideToggle = memo(() => {
   );
 });
 
-const ToggleContainer = styled(ToggleGroup)<{ value: OrderSide }>`
+type ToggleContainerStyleProps = { value: OrderSide };
+const toggleContainerType = getSimpleStyledOutputType(ToggleGroup, {} as ToggleContainerStyleProps);
+const $ToggleContainer = styled(ToggleGroup)<ToggleContainerStyleProps>`
   --toggle-radius: 0.5em;
   --toggle-color: var(--color-negative);
   --toggle-background: ${({ theme }) => theme.toggleBackground};
@@ -87,4 +90,4 @@ const ToggleContainer = styled(ToggleGroup)<{ value: OrderSide }>`
         transform: translateX(100%);
       `}
   }
-`;
+` as typeof toggleContainerType;

--- a/src/views/tables/LiveTrades.tsx
+++ b/src/views/tables/LiveTrades.tsx
@@ -13,11 +13,11 @@ import { breakpoints } from '@/styles';
 
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Output, OutputType } from '@/components/Output';
-import { BaseTableRowData, CustomRowConfig, Table } from '@/components/Table';
 
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getCurrentMarketConfig, getCurrentMarketLiveTrades } from '@/state/perpetualsSelectors';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { getSelectedOrderSide } from '@/lib/tradeData';
 
@@ -161,6 +161,7 @@ const $SizeOutput = styled(Output)<StyleProps>`
   }
 `;
 
+const liveTradesTableType = getSimpleStyledOutputType(OrderbookTradesTable, {} as StyleProps);
 const $LiveTradesTable = styled(OrderbookTradesTable)<StyleProps>`
   tr {
     --histogram-bucket-size: 1;
@@ -229,8 +230,4 @@ const $LiveTradesTable = styled(OrderbookTradesTable)<StyleProps>`
 
     font-size: 0.875em;
   }
-` as <TableRowData extends BaseTableRowData | CustomRowConfig>(
-  props: React.ComponentProps<typeof Table<TableRowData>> & {
-    histogramSide?: 'left' | 'right';
-  } & StyleProps
-) => React.ReactNode;
+` as typeof liveTradesTableType;

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -16,13 +16,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { Details } from '@/components/Details';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Output, OutputType } from '@/components/Output';
-import {
-  BaseTableRowData,
-  ColumnDef,
-  Table,
-  TableRow,
-  type CustomRowConfig,
-} from '@/components/Table';
+import { ColumnDef, TableRow, type CustomRowConfig } from '@/components/Table';
 import { WithTooltip } from '@/components/WithTooltip';
 
 import { calculateCanViewAccount } from '@/state/accountCalculators';
@@ -32,6 +26,7 @@ import { setTradeFormInputs } from '@/state/inputs';
 import { getCurrentInput } from '@/state/inputsSelectors';
 import { getCurrentMarketConfig, getCurrentMarketOrderbook } from '@/state/perpetualsSelectors';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { MustBigNumber } from '@/lib/numbers';
 
 import { OrderbookTradesOutput, OrderbookTradesTable } from './OrderbookTradesTable';
@@ -513,6 +508,7 @@ const $HistogramOutput = styled(OrderbookTradesOutput)<StyleProps>`
       : ''}
 `;
 
+const orderbookTableType = getSimpleStyledOutputType(OrderbookTradesTable, {} as StyleProps);
 const $OrderbookTable = styled(OrderbookTradesTable)<StyleProps>`
   /* Params */
   --orderbook-spreadRowHeight: 2rem;
@@ -559,11 +555,7 @@ const $OrderbookTable = styled(OrderbookTradesTable)<StyleProps>`
   ${$HorizontalLayout} & {
     --tableCell-padding: 0.25rem 1rem;
   }
-` as <TableRowData extends BaseTableRowData | CustomRowConfig>(
-  props: React.ComponentProps<typeof Table<TableRowData>> & {
-    histogramSide?: 'left' | 'right';
-  } & StyleProps
-) => React.ReactNode;
+` as typeof orderbookTableType;
 
 const $SpreadTableRow = styled(TableRow)`
   ${layoutMixins.sticky}

--- a/src/views/tables/OrderbookTradesTable.tsx
+++ b/src/views/tables/OrderbookTradesTable.tsx
@@ -5,7 +5,15 @@ import { breakpoints } from '@/styles';
 import { Output } from '@/components/Output';
 import { Table } from '@/components/Table';
 
-export const OrderbookTradesTable = styled(Table)<{ histogramSide: 'left' | 'right' }>`
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
+
+type OrderbookTradesTableStyleProps = { histogramSide?: 'left' | 'right' };
+const orderbookTradesTableType = getSimpleStyledOutputType(
+  Table,
+  {} as OrderbookTradesTableStyleProps
+);
+
+export const OrderbookTradesTable = styled(Table)<OrderbookTradesTableStyleProps>`
   // Params
   --histogram-width: 100%;
 
@@ -91,7 +99,7 @@ export const OrderbookTradesTable = styled(Table)<{ histogramSide: 'left' | 'rig
       --histogram-width: calc(100% / var(--approximate-column-width));
     }
   }
-`;
+` as typeof orderbookTradesTableType;
 
 const colorAnimation = keyframes`
 20% {


### PR DESCRIPTION
I created two utilities for turning react higher order functions into normal higher order functions so the typescript compiler can do higher order type inference correctly. 