### PR TITLE
fix(sltp): match order size slider value to input value

### DIFF
--- a/src/views/forms/TriggersForm/OrderSizeInput.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeInput.tsx
@@ -64,7 +64,7 @@ export const OrderSizeInput = ({
   const setAbacusSize = (newSize: number | null) => {
     const newSizeString = MustBigNumber(
       newSize && positionSize ? Math.min(positionSize, newSize) : newSize
-    ).toFixed(stepSizeDecimals ?? TOKEN_DECIMALS);
+    ).toString();
 
     abacusStateManager.setTriggerOrdersValue({
       value: newSize != null ? newSizeString : null,
@@ -103,15 +103,16 @@ export const OrderSizeInput = ({
     >
       <$SizeInputRow>
         <$OrderSizeSlider
-          setAbacusSize={setAbacusSize}
-          setOrderSizeInput={setOrderSize}
+          setAbacusSize={(sizeString: string) => setAbacusSize(parseFloat(sizeString))}
+          setOrderSizeInput={(sizeString: string) => setOrderSize(parseFloat(sizeString))}
           size={orderSize}
           positionSize={positionSize ?? undefined}
+          stepSizeDecimals={stepSizeDecimals ?? TOKEN_DECIMALS}
           className={className}
         />
         <FormInput
           type={InputType.Number}
-          value={orderSize?.toFixed(stepSizeDecimals ?? TOKEN_DECIMALS)}
+          value={orderSize?.toString()}
           slotRight={<Tag>{symbol}</Tag>}
           onInput={onSizeInput}
         />

--- a/src/views/forms/TriggersForm/OrderSizeInput.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeInput.tsx
@@ -64,9 +64,10 @@ export const OrderSizeInput = ({
   const setAbacusSize = (newSize: number | null) => {
     const newSizeString = MustBigNumber(
       newSize && positionSize ? Math.min(positionSize, newSize) : newSize
-    ).toString();
+    ).toFixed(stepSizeDecimals ?? TOKEN_DECIMALS);
+
     abacusStateManager.setTriggerOrdersValue({
-      value: newSize != null ? newSizeString.toString() : null,
+      value: newSize != null ? newSizeString : null,
       field: TriggerOrdersInputField.size,
     });
   };

--- a/src/views/forms/TriggersForm/OrderSizeInput.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeInput.tsx
@@ -67,7 +67,7 @@ export const OrderSizeInput = ({
     ).toString();
 
     abacusStateManager.setTriggerOrdersValue({
-      value: newSize != null ? newSizeString : null,
+      value: newSize !== null ? newSizeString : null,
       field: TriggerOrdersInputField.size,
     });
   };

--- a/src/views/forms/TriggersForm/OrderSizeSlider.stories.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeSlider.stories.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 import type { Story } from '@ladle/react';
-import styled, { AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
+
+import { TOKEN_DECIMALS } from '@/constants/numbers';
 
 import { breakpoints } from '@/styles';
 
@@ -16,8 +18,9 @@ export const OrderSizeSliderStory: Story<Parameters<typeof OrderSizeSlider>[0]> 
       <$Container>
         <OrderSizeSlider
           setAbacusSize={() => null}
-          setOrderSizeInput={setSize}
+          setOrderSizeInput={(sizeString: string) => setSize(parseFloat(sizeString))}
           size={size}
+          stepSizeDecimals={TOKEN_DECIMALS}
           positionSize={100}
         />
       </$Container>

--- a/src/views/forms/TriggersForm/OrderSizeSlider.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeSlider.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { Slider } from '@/components/Slider';
 
-import { MustBigNumber, roundToTick } from '@/lib/numbers';
+import { MustBigNumber } from '@/lib/numbers';
 
 type ElementProps = {
   setAbacusSize: (value: string) => void;

--- a/src/views/forms/TriggersForm/OrderSizeSlider.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeSlider.tsx
@@ -1,15 +1,18 @@
 import { useCallback } from 'react';
 
 import _ from 'lodash';
-import styled, { AnyStyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { Slider } from '@/components/Slider';
 
+import { MustBigNumber, roundToTick } from '@/lib/numbers';
+
 type ElementProps = {
-  setAbacusSize: (value: number | null) => void;
-  setOrderSizeInput: (value: number) => void;
+  setAbacusSize: (value: string) => void;
+  setOrderSizeInput: (value: string) => void;
   size: number | null;
   positionSize?: number;
+  stepSizeDecimals: number;
 };
 
 type StyleProps = {
@@ -21,6 +24,7 @@ export const OrderSizeSlider = ({
   setAbacusSize,
   size,
   positionSize,
+  stepSizeDecimals,
   className,
 }: ElementProps & StyleProps) => {
   const step = positionSize ? Math.pow(10, Math.floor(Math.log10(positionSize) - 1)) : 0.1;
@@ -29,22 +33,24 @@ export const OrderSizeSlider = ({
 
   // Debounced slightly to avoid excessive updates to Abacus while still providing a smooth slide
   const debouncedSetAbacusSize = useCallback(
-    _.debounce((newSize: number) => {
+    _.debounce((newSize: string) => {
       setAbacusSize(newSize);
     }, 50),
     []
   );
 
   const onSliderDrag = ([newSize]: number[]) => {
-    setOrderSizeInput(newSize);
-    debouncedSetAbacusSize(newSize);
+    const roundedSize = MustBigNumber(newSize).toFixed(stepSizeDecimals);
+    setOrderSizeInput(roundedSize);
+    debouncedSetAbacusSize(roundedSize);
   };
 
   const onValueCommit = ([newSize]: number[]) => {
-    setOrderSizeInput(newSize);
+    const roundedSize = MustBigNumber(newSize).toFixed(stepSizeDecimals);
+    setOrderSizeInput(roundedSize);
     // Ensure Abacus is updated with the latest, committed value
     debouncedSetAbacusSize.cancel();
-    setAbacusSize(newSize);
+    setAbacusSize(roundedSize);
   };
 
   return (


### PR DESCRIPTION
Previously, bug was that sliding the slider could display a seemingly usable order size - but error out on the button (due to incorrect step size, or below min size). This was because the value we were displaying as the order size (right size input) was being rounded while our abacus input we were sending back wasn't. Updated order slider to always send back rounded value (to make it easier to use) and to not round order size right size input - since that is seemingly what the user wants to input.

https://github.com/dydxprotocol/v4-web/assets/70078372/ded278fc-4d5d-4410-8689-1ed90b685997

