### PR TITLE
fix(selected-gas-denom): preserve gasDenom and set in chainTransactionProtocol

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -209,3 +209,5 @@ export type AnalyticsEventData<T extends AnalyticsEvent> =
     : never;
 
 export const DEFAULT_TRANSACTION_MEMO = 'dYdX Frontend (web)';
+export const lastSuccessfulRestRequestByOrigin: Record<URL['origin'], number> = {};
+export const lastSuccessfulWebsocketRequestByOrigin: Record<URL['origin'], number> = {};

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
-import { AnalyticsEvent, AnalyticsUserProperty } from '@/constants/analytics';
+import {
+  AnalyticsEvent,
+  AnalyticsUserProperty,
+  lastSuccessfulWebsocketRequestByOrigin,
+} from '@/constants/analytics';
 import type { DialogTypes } from '@/constants/dialogs';
 
 import { calculateOnboardingStep } from '@/state/accountCalculators';
@@ -219,6 +223,3 @@ export const useAnalytics = () => {
     }
   }, [selectedOrderType]);
 };
-
-export const lastSuccessfulRestRequestByOrigin: Record<URL['origin'], number> = {};
-export const lastSuccessfulWebsocketRequestByOrigin: Record<URL['origin'], number> = {};

--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -123,12 +123,6 @@ const useDydxClientContext = () => {
     defaultValue: SelectedGasDenom.USDC,
   });
 
-  useEffect(() => {
-    if (compositeClient) {
-      setSelectedGasDenom(gasDenom);
-    }
-  }, [compositeClient]);
-
   const setSelectedGasDenom = useCallback(
     (selectedGasDenom: SelectedGasDenom) => {
       if (compositeClient) {
@@ -137,8 +131,15 @@ const useDydxClientContext = () => {
         setGasDenom(selectedGasDenom);
       }
     },
-    [compositeClient]
+    [compositeClient, setGasDenom]
   );
+
+  useEffect(() => {
+    if (compositeClient) {
+      setSelectedGasDenom(gasDenom);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [compositeClient, setSelectedGasDenom]);
 
   // ------ Wallet Methods ------ //
   const getWalletFromEvmSignature = async ({ signature }: { signature: string }) => {

--- a/src/hooks/useDydxClient.tsx
+++ b/src/hooks/useDydxClient.tsx
@@ -23,6 +23,7 @@ import { LocalStorageKey } from '@/constants/localStorage';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
 
+import abacusStateManager from '@/lib/abacus';
 import { log } from '@/lib/telemetry';
 
 import { useEndpointsConfig } from './useEndpointsConfig';
@@ -122,10 +123,17 @@ const useDydxClientContext = () => {
     defaultValue: SelectedGasDenom.USDC,
   });
 
+  useEffect(() => {
+    if (compositeClient) {
+      setSelectedGasDenom(gasDenom);
+    }
+  }, [compositeClient]);
+
   const setSelectedGasDenom = useCallback(
     (selectedGasDenom: SelectedGasDenom) => {
       if (compositeClient) {
         compositeClient.validatorClient.setSelectedGasDenom(selectedGasDenom);
+        abacusStateManager.setSelectedGasDenom(selectedGasDenom);
         setGasDenom(selectedGasDenom);
       }
     },

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -16,6 +16,7 @@ import {
   ValidatorConfig,
   encodeJson,
   type LocalWallet,
+  type SelectedGasDenom,
 } from '@dydxprotocol/v4-client-js';
 import Long from 'long';
 
@@ -153,6 +154,10 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       this.store?.dispatch(setInitializationError(error?.message ?? 'Unknown error'));
       log('DydxChainTransactions/connectNetwork', error);
     }
+  }
+
+  setSelectedGasDenom(denom: SelectedGasDenom) {
+    this.compositeClient?.setSelectedGasDenom(denom);
   }
 
   parseToPrimitives<T>(x: T): T {

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -1,4 +1,4 @@
-import type { LocalWallet } from '@dydxprotocol/v4-client-js';
+import type { LocalWallet, SelectedGasDenom } from '@dydxprotocol/v4-client-js';
 
 import type {
   ClosePositionInputFields,
@@ -247,6 +247,10 @@ class AbacusStateManager {
     this.currentMarket = marketId;
     this.clearTradeInputValues({ shouldResetSize: true });
     this.stateManager.market = marketId;
+  };
+
+  setSelectedGasDenom = (denom: SelectedGasDenom) => {
+    this.chainTransactions.setSelectedGasDenom(denom);
   };
 
   setTradeValue = ({ value, field }: { value: any; field: TradeInputFields }) => {

--- a/src/lib/abacus/rest.ts
+++ b/src/lib/abacus/rest.ts
@@ -1,8 +1,7 @@
 import type { Nullable, kollections } from '@dydxprotocol/v4-abacus';
 
 import type { AbacusRestProtocol } from '@/constants/abacus';
-
-import { lastSuccessfulRestRequestByOrigin } from '@/hooks/useAnalytics';
+import { lastSuccessfulRestRequestByOrigin } from '@/constants/analytics';
 
 type Headers = Nullable<kollections.Map<string, string>>;
 type FetchResponseCallback = (p0: Nullable<string>, p1: number, p2: Nullable<string>) => void;

--- a/src/lib/abacus/websocket.ts
+++ b/src/lib/abacus/websocket.ts
@@ -1,8 +1,7 @@
 import type { AbacusWebsocketProtocol } from '@/constants/abacus';
+import { lastSuccessfulWebsocketRequestByOrigin } from '@/constants/analytics';
 import type { TradingViewBar } from '@/constants/candles';
 import { isDev } from '@/constants/networks';
-
-import { lastSuccessfulWebsocketRequestByOrigin } from '@/hooks/useAnalytics';
 
 import { testFlags } from '@/lib/testFlags';
 import { subscriptionsByChannelId } from '@/lib/tradingView/dydxfeed/cache';


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Current implementation of selecting gas denom is only applicable when using a method from `useDydxClient`. Add capability to set gas denom for transactions in Abacus' chain transaction protocol.

---

## Functions

* `lib/abacus`, lib/abacus/dydxChainTransactions`
  * expose setter method for gas denom

## Hooks

* `hooks/useDydxClient`
  * Preserve selected gas denom by setting within useEffect

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
