### PR TITLE
fix: remove noisy log

### DIFF
--- a/src/lib/abacus/rest.ts
+++ b/src/lib/abacus/rest.ts
@@ -68,7 +68,7 @@ class AbacusRest implements AbacusRestProtocol {
         try {
           lastSuccessfulRestRequestByOrigin[new URL(url).origin] = Date.now();
         } catch (error) {
-          log('AbacusRest/request', error);
+          log('AbacusRest/request', error, { url });
         }
       })
       .catch(() => callback(null, 0, null)); // Network error or request couldn't be made

--- a/src/lib/isExternalLink.tsx
+++ b/src/lib/isExternalLink.tsx
@@ -1,11 +1,10 @@
-import { log } from './telemetry';
-
 export const isExternalLink = (href: string | undefined) => {
-  if (href)
+  if (href) {
     try {
       return new URL(href).hostname !== globalThis.location.hostname;
     } catch (error) {
-      log('isExternalLink', error);
+      return false;
     }
+  }
   return false;
 };


### PR DESCRIPTION
It is filling the console in dev mode on localhost since all the urls are like "/history" which is an invalid url. 