### PR TITLE
chore: type custom events

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -13,7 +13,7 @@ type AnalyticsEventDataWithReferrer<T extends AnalyticsEvent> = AnalyticsEventDa
 export type AnalyticsEventTrackMeta<T extends AnalyticsEvent> = {
   detail: {
     eventType: AnalyticsEvent;
-    eventData?: AnalyticsEventDataWithReferrer<T>;
+    eventData: AnalyticsEventDataWithReferrer<T>;
   };
 };
 export type AnalyticsEventIdentifyMeta<T extends AnalyticsUserProperty> = {

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -23,12 +23,16 @@ export type AnalyticsEventIdentifyMeta<T extends AnalyticsUserProperty> = {
   };
 };
 
+// Do not update. this is used specifically to type how we create custom identify events.
+// If you want to update how identify events work, go to src/lib/analytics.ts
 export const customIdentifyEvent = <T extends AnalyticsUserProperty>(
   meta: AnalyticsEventIdentifyMeta<T>
 ) => {
   return new CustomEvent('dydx:identify', meta);
 };
 
+// Do not update. this is used specifically to type how we create custom track events.
+// If you want to update how track events work, go to src/lib/analytics.ts
 export const customTrackEvent = <T extends AnalyticsEvent>(meta: AnalyticsEventTrackMeta<T>) => {
   return new CustomEvent('dydx:track', meta);
 };

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -7,6 +7,32 @@ import { TransferNotificationTypes } from './notifications';
 import type { TradeTypes } from './trade';
 import type { DydxAddress, EvmAddress, WalletConnectionType, WalletType } from './wallets';
 
+type AnalyticsEventDataWithReferrer<T extends AnalyticsEvent> = AnalyticsEventData<T> & {
+  referrer: string;
+};
+export type AnalyticsEventTrackMeta<T extends AnalyticsEvent> = {
+  detail: {
+    eventType: AnalyticsEvent;
+    eventData?: AnalyticsEventDataWithReferrer<T>;
+  };
+};
+export type AnalyticsEventIdentifyMeta<T extends AnalyticsUserProperty> = {
+  detail: {
+    property: AnalyticsUserProperty;
+    propertyValue: AnalyticsUserPropertyValue<T>;
+  };
+};
+
+export const customIdentifyEvent = <T extends AnalyticsUserProperty>(
+  meta: AnalyticsEventIdentifyMeta<T>
+) => {
+  return new CustomEvent('dydx:identify', meta);
+};
+
+export const customTrackEvent = <T extends AnalyticsEvent>(meta: AnalyticsEventTrackMeta<T>) => {
+  return new CustomEvent('dydx:track', meta);
+};
+
 // User properties
 export enum AnalyticsUserProperty {
   // Environment

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,8 +1,10 @@
-import type {
-  AnalyticsEvent,
-  AnalyticsEventData,
-  AnalyticsUserProperty,
-  AnalyticsUserPropertyValue,
+import {
+  customIdentifyEvent,
+  customTrackEvent,
+  type AnalyticsEvent,
+  type AnalyticsEventData,
+  type AnalyticsUserProperty,
+  type AnalyticsUserPropertyValue,
 } from '@/constants/analytics';
 
 import { testFlags } from './testFlags';
@@ -17,7 +19,8 @@ export const identify = <T extends AnalyticsUserProperty>(
     // eslint-disable-next-line no-console
     console.log(`[Analytics:Identify] ${property}`, propertyValue);
   }
-  const customEvent = new CustomEvent('dydx:identify', {
+
+  const customEvent = customIdentifyEvent({
     detail: { property, propertyValue },
   });
 
@@ -33,7 +36,7 @@ export const track = <T extends AnalyticsEvent>(
     // eslint-disable-next-line no-console
     console.log(`[Analytics] ${eventType}`, eventDataWithReferrer);
   }
-  const customEvent = new CustomEvent('dydx:track', {
+  const customEvent = customTrackEvent({
     detail: { eventType, eventData: eventDataWithReferrer },
   });
 


### PR DESCRIPTION
result of discussion: https://dydx-team.slack.com/archives/C042V24U87Q/p1715894605604209 

this PR https://github.com/dydxprotocol/v4-web/pull/504/files broke our analytics events since we were no longer sending `eventData` as a param in our `details` object.

added typing around the `CustomEvent` function that prevents this from happening again.

TODO: add a test for this as well
