### PR TITLE
fix: the transfer type ternary is not correct

### DIFF
--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -214,9 +214,10 @@ export const notificationTypes: NotificationTypeConfig[] = [
           const icon = <Icon iconName={isFinished ? IconName.Transfer : IconName.Clock} />;
 
           const transferType =
-            type ?? fromChainId === selectedDydxChainId
+            type ??
+            (fromChainId === selectedDydxChainId
               ? TransferNotificationTypes.Withdrawal
-              : TransferNotificationTypes.Deposit;
+              : TransferNotificationTypes.Deposit);
 
           const title = stringGetter({
             key: {


### PR DESCRIPTION
The addition of the notification type here:
https://github.com/dydxprotocol/v4-web/blob/fix-deposit-notif/src/views/forms/AccountManagementForms/DepositForm.tsx#L289

Uncovered a bug where the notification transferType is not calculated correctly.