### PR TITLE
fix: remove log when bad url to prevent spam

### DIFF
--- a/src/lib/abacus/rest.ts
+++ b/src/lib/abacus/rest.ts
@@ -3,8 +3,6 @@ import type { Nullable, kollections } from '@dydxprotocol/v4-abacus';
 import type { AbacusRestProtocol } from '@/constants/abacus';
 import { lastSuccessfulRestRequestByOrigin } from '@/constants/analytics';
 
-import { log } from '../telemetry';
-
 type Headers = Nullable<kollections.Map<string, string>>;
 type FetchResponseCallback = (p0: Nullable<string>, p1: number, p2: Nullable<string>) => void;
 
@@ -68,7 +66,7 @@ class AbacusRest implements AbacusRestProtocol {
         try {
           lastSuccessfulRestRequestByOrigin[new URL(url).origin] = Date.now();
         } catch (error) {
-          log('AbacusRest/request', error, { url });
+          // expected error when bad url
         }
       })
       .catch(() => callback(null, 0, null)); // Network error or request couldn't be made


### PR DESCRIPTION
Remove abacus rest log since it's kinda expected