### PR TITLE
chore: show all markets w/o pagination on market page

### DIFF
--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -223,6 +223,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
           direction: 'descending',
         }}
         columns={columns}
+        paginationBehavior="showAll"
         className={className}
         slotEmpty={
           <$MarketNotFound>


### PR DESCRIPTION
tested by building locally and looking at markets page

<img width="1309" alt="Screenshot 2024-05-21 at 1 55 49 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/a7c4e632-5124-4342-9c8d-759b4a81a42c">
