### PR TITLE
chore: enable traders to cancel "BEST_EFFORT_CANCELED" stateful orders

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12301,7 +12301,6 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
-    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -23,7 +23,7 @@ import { type OrderTableRow } from '@/views/tables/OrdersTable';
 
 import { clearOrder } from '@/state/account';
 import { calculateIsAccountViewOnly } from '@/state/accountCalculators';
-import { getLocalCancelOrders, getOrderById, getOrderDetails } from '@/state/accountSelectors';
+import { getLocalCancelOrders, getOrderDetails } from '@/state/accountSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -40,7 +40,6 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
   const selectedLocale = useSelector(getSelectedLocale);
   const isAccountViewOnly = useSelector(calculateIsAccountViewOnly);
   const localCancelOrders = useSelector(getLocalCancelOrders, shallowEqual);
-  const existingOrder = useSelector(getOrderById(orderId), shallowEqual);
 
   const { cancelOrder } = useSubaccount();
 
@@ -67,6 +66,7 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
     trailingPercent,
     triggerPrice,
     type,
+    orderFlags,
   } = (useSelector(getOrderDetails(orderId)) as OrderTableRow) ?? {};
 
   const renderOrderPrice = ({
@@ -183,10 +183,9 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
     setIsOpen?.(false);
   };
 
-  const isShortTermOrder = existingOrder?.orderFlags === OrderFlags.SHORT_TERM;
+  const isShortTermOrder = orderFlags === OrderFlags.SHORT_TERM;
   const isBestEffortCanceled = status === AbacusOrderStatus.canceling;
-  const isCancelDisabled =
-    !!isOrderCanceling || !existingOrder || (isShortTermOrder && isBestEffortCanceled);
+  const isCancelDisabled = !!isOrderCanceling || (isShortTermOrder && isBestEffortCanceled);
 
   return (
     <DetailsDialog

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -213,8 +213,13 @@ const getOrdersTableColumnDef = ({
         label: stringGetter({ key: STRING_KEYS.ACTION }),
         isActionable: true,
         allowsSorting: false,
-        renderCell: ({ id, status }) => (
-          <OrderActionsCell orderId={id} status={status} isDisabled={isAccountViewOnly} />
+        renderCell: ({ id, status, orderFlags }) => (
+          <OrderActionsCell
+            orderId={id}
+            status={status}
+            orderFlags={orderFlags}
+            isDisabled={isAccountViewOnly}
+          />
         ),
       },
       [OrdersTableColumnKey.StatusFill]: {

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from 'react';
 
+import { type Nullable } from '@dydxprotocol/v4-abacus';
 import { OrderFlags } from '@dydxprotocol/v4-client-js';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { AbacusOrderStatus, type OrderStatus } from '@/constants/abacus';
@@ -14,19 +15,18 @@ import { IconButton } from '@/components/IconButton';
 import { ActionsTableCell } from '@/components/Table';
 
 import { clearOrder } from '@/state/account';
-import { getOrderById } from '@/state/accountSelectors';
 
 import { isOrderStatusClearable } from '@/lib/orders';
 
 type ElementProps = {
   orderId: string;
+  orderFlags: Nullable<number>;
   status: OrderStatus;
   isDisabled?: boolean;
 };
 
-export const OrderActionsCell = ({ orderId, status, isDisabled }: ElementProps) => {
+export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: ElementProps) => {
   const dispatch = useDispatch();
-  const order = useSelector(getOrderById(orderId), shallowEqual);
 
   const [isCanceling, setIsCanceling] = useState(false);
 
@@ -39,10 +39,10 @@ export const OrderActionsCell = ({ orderId, status, isDisabled }: ElementProps) 
 
   // CT831: if order is stateful and is initially best effort canceled, it's a stuck order that
   // traders should be able to submit another cancel
-  const isShortTermOrder = order?.orderFlags === OrderFlags.SHORT_TERM;
+  const isShortTermOrder = orderFlags === OrderFlags.SHORT_TERM;
   const isBestEffortCanceled = status === AbacusOrderStatus.canceling;
   const isCancelDisabled =
-    isCanceling || !!isDisabled || !order || (isShortTermOrder && isBestEffortCanceled);
+    isCanceling || !!isDisabled || (isShortTermOrder && isBestEffortCanceled);
 
   return (
     <ActionsTableCell>


### PR DESCRIPTION
context: some traders are running into unexpected equity tier limit issues and seeing an order count mismatch. their accounts have "stuck" stateful orders that are "best_effort_canceled" but are hidden by indexer/FE

indexer will include best effort canceled orders in the initial v4_subaccounts subscribe ws message, and FE will display those in the orders tab, and enable the Cancel button so traders can attempt submitting another cancel to get rid of them.

cancel ux flow on FE is not impacted, because we keep a local `isCanceling` state which disables subsequent cancel clicks already. 


To test, sub out the v4_subaccounts subscription message and add two example stuck orders, for example the following (you'll have to sub out your subaccount id etc. as well). Observe that the cancel button is only disabled best effort canceled orders that are short term, and not stateful (i.e. not long term / conditional). The cancel button should also disabled when you click cancel on a real order + is loading.
```
...
"orders": [
      {
        "id": "5453372a-f6b3-5bcb-be8b-7323a546785e",
        "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
        "clientId": "281571908",
        "clobPairId": "1",
        "side": "BUY",
        "size": "0.01",
        "totalFilled": "0",
        "price": "2000",
        "type": "LIMIT",
        "status": "BEST_EFFORT_CANCELED",
        "timeInForce": "GTT",
        "reduceOnly": false,
        "orderFlags": "64",
        "goodTilBlockTime": "2024-06-18T17:20:40.000Z",
        "createdAtHeight": "12828984",
        "clientMetadata": "0",
        "updatedAt": "2024-05-21T17:20:40.044Z",
        "updatedAtHeight": "12828984",
        "postOnly": false,
        "ticker": "ETH-USD",
        "subaccountNumber": 0
      },
      {
        "id": "2f6f99e6-8ef0-5a49-ba6a-c0365bd9c747",
        "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
        "clientId": "239572883",
        "clobPairId": "1",
        "side": "BUY",
        "size": "0.02",
        "price": "3922.5",
        "status": "BEST_EFFORT_CANCELED",
        "type": "LIMIT",
        "timeInForce": "IOC",
        "postOnly": false,
        "reduceOnly": false,
        "orderFlags": "0",
        "goodTilBlock": "13830117",
        "ticker": "ETH-USD",
        "clientMetadata": "1"
      },
      {
        "id": "15c5720e-cc73-5ddd-b02c-8764dc632054",
        "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
        "clientId": "9852734",
        "clobPairId": "16",
        "side": "SELL",
        "size": "151",
        "totalFilled": "3",
        "price": "5.611",
        "type": "TAKE_PROFIT",
        "status": "BEST_EFFORT_CANCELED",
        "timeInForce": "IOC",
        "reduceOnly": true,
        "orderFlags": "32",
        "goodTilBlockTime": "2024-08-01T20:03:57.000Z",
        "createdAtHeight": "14739377",
        "clientMetadata": "1",
        "triggerPrice": "7.014",
        "updatedAt": "2024-05-05T07:41:11.545Z",
        "updatedAtHeight": "14855568",
        "postOnly": false,
        "ticker": "NEAR-USD",
        "subaccountNumber": 0
      },
      {
        "id": "064bf2df-e1b9-5d14-9133-97387e2f5e62",
        "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
        "clientId": "1859269100",
        "clobPairId": "1",
        "side": "SELL",
        "size": "0.051",
        "totalFilled": "0.03",
        "price": "2391.2",
        "type": "TAKE_PROFIT",
        "status": "BEST_EFFORT_CANCELED",
        "timeInForce": "IOC",
        "reduceOnly": true,
        "orderFlags": "32",
        "goodTilBlockTime": "2024-05-30T19:24:45.000Z",
        "createdAtHeight": "14655078",
        "clientMetadata": "1",
        "triggerPrice": "2989",
        "updatedAt": "2024-05-02T19:24:52.597Z",
        "updatedAtHeight": "14655085",
        "postOnly": false,
        "ticker": "ETH-USD",
        "subaccountNumber": 0
      }
    ]
```
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/478abc36-7129-487d-a714-f0f76a6f5385)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/d4fc5e1e-1391-4b90-8d9c-71524164b59d)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/9bfa6a86-81be-4bfc-abf7-9499fa841080)


