### PR TITLE
chore: make trade form footer not sticky depending on screen height + table column header nits

### DIFF
--- a/src/styles/formMixins.ts
+++ b/src/styles/formMixins.ts
@@ -136,11 +136,17 @@ export const formMixins: Record<
     }
   `,
 
-  footer: css`
-    ${layoutMixins.stickyFooter}
-    ${layoutMixins.withStickyFooterBackdrop}
+  withStickyFooter: css`
+    footer {
+      ${layoutMixins.stickyFooter}
+      ${layoutMixins.withStickyFooterBackdrop}
+    }
+  `,
 
+  footer: css`
     margin-top: auto;
+    backdrop-filter: none;
+    ${layoutMixins.noPointerEvents}
   `,
 
   transfersForm: css`

--- a/src/views/dialogs/DepositDialog/DepositDialogContent.tsx
+++ b/src/views/dialogs/DepositDialog/DepositDialogContent.tsx
@@ -70,13 +70,10 @@ const $Content = styled.div`
 `;
 
 const $TextToggle = styled.div`
-  ${layoutMixins.stickyFooter}
   --stickyArea-bottomHeight: 0;
 
   color: var(--color-accent);
   cursor: pointer;
-
-  margin-top: auto;
 
   &:hover {
     text-decoration: underline;

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -29,14 +29,12 @@ import { useLocalNotifications } from '@/hooks/useLocalNotifications';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { formMixins } from '@/styles/formMixins';
-import { layoutMixins } from '@/styles/layoutMixins';
 
 import { AlertMessage } from '@/components/AlertMessage';
 import { Button } from '@/components/Button';
 import { DiffOutput } from '@/components/DiffOutput';
 import { FormInput } from '@/components/FormInput';
 import { InputType } from '@/components/Input';
-import { Link } from '@/components/Link';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { OutputType } from '@/components/Output';
 import { Tag } from '@/components/Tag';
@@ -490,18 +488,6 @@ const $Footer = styled.footer`
 
 const $WithDetailsReceipt = styled(WithDetailsReceipt)`
   --withReceipt-backgroundColor: var(--color-layer-2);
-`;
-
-const $Link = styled(Link)`
-  color: var(--color-accent);
-
-  &:visited {
-    color: var(--color-accent);
-  }
-`;
-
-const $TransactionInfo = styled.span`
-  ${layoutMixins.row}
 `;
 
 const $FormInputButton = styled(Button)`

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -308,22 +308,30 @@ export const ClosePositionForm = ({
 const $ClosePositionForm = styled.form`
   --form-rowGap: 1.25rem;
 
-  ${layoutMixins.expandingColumnWithFooter}
+  min-height: 100%;
+  isolation: isolate;
+
+  ${layoutMixins.flexColumn}
   gap: var(--form-rowGap);
-  align-items: start;
 
   ${layoutMixins.stickyArea1}
   --stickyArea1-background: var(--color-layer-2);
   --stickyArea1-paddingBottom: var(--dialog-content-paddingBottom);
 
-  @media ${breakpoints.tablet} {
-    ${layoutMixins.expandingColumnWithFooter}
+  @media (min-height: 48rem) {
+    ${formMixins.withStickyFooter}
+  }
 
+  @media ${breakpoints.tablet} {
     --orderbox-column-width: 140px;
     --orderbook-width: calc(var(--orderbox-column-width) + var(--dialog-content-paddingLeft));
 
     && * {
       outline: none !important;
+    }
+
+    @media (min-height: 35rem) {
+      ${formMixins.withStickyFooter}
     }
   }
 `;
@@ -403,12 +411,11 @@ const $ToggleGroup = styled(ToggleGroup)`
 `;
 
 const $Footer = styled.footer`
-  ${layoutMixins.stickyFooter}
-  backdrop-filter: none;
+  ${formMixins.footer}
+  padding-bottom: var(--dialog-content-paddingBottom);
+  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 
   ${layoutMixins.column}
-  ${layoutMixins.noPointerEvents}
-  margin-top: auto;
 `;
 
 const $ButtonRow = styled.div`

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -488,6 +488,10 @@ const $TradeForm = styled.form`
   padding: var(--tradeBox-content-paddingTop) var(--tradeBox-content-paddingRight)
     var(--tradeBox-content-paddingBottom) var(--tradeBox-content-paddingLeft);
 
+  @media (min-height: 48rem) {
+    ${formMixins.withStickyFooter}
+  }
+
   @media ${breakpoints.tablet} {
     padding-left: 0;
     padding-right: 0;
@@ -496,6 +500,9 @@ const $TradeForm = styled.form`
 
     && * {
       outline: none !important;
+    }
+    @media (min-height: 35rem) {
+      ${formMixins.withStickyFooter}
     }
   }
 `;
@@ -621,8 +628,6 @@ const $ButtonRow = styled.div`
 const $Footer = styled.footer`
   ${formMixins.footer}
   --stickyFooterBackdrop-outsetY: var(--tradeBox-content-paddingBottom);
-  backdrop-filter: none;
 
   ${layoutMixins.column}
-  ${layoutMixins.noPointerEvents}
 `;

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -87,9 +87,12 @@ const getFillsTableColumnDef = ({
       [FillsTableColumnKey.TypeAmount]: {
         columnKey: 'typeAmount',
         getCellValue: (row) => row.size,
-        label: `${stringGetter({ key: STRING_KEYS.TYPE })} / ${stringGetter({
-          key: STRING_KEYS.AMOUNT,
-        })}`,
+        label: (
+          <TableColumnHeader>
+            <span>{stringGetter({ key: STRING_KEYS.TYPE })}</span>
+            <span>{stringGetter({ key: STRING_KEYS.AMOUNT })}</span>
+          </TableColumnHeader>
+        ),
         renderCell: ({ resources, size, stepSizeDecimals, asset: { id } }) => (
           <TableCell stacked slotLeft={<$AssetIcon symbol={id} />}>
             <span>
@@ -107,9 +110,12 @@ const getFillsTableColumnDef = ({
       [FillsTableColumnKey.PriceFee]: {
         columnKey: 'priceFee',
         getCellValue: (row) => row.price,
-        label: `${stringGetter({ key: STRING_KEYS.PRICE })} / ${stringGetter({
-          key: STRING_KEYS.FEE,
-        })}`,
+        label: (
+          <TableColumnHeader>
+            <span>{stringGetter({ key: STRING_KEYS.PRICE })}</span>
+            <span>{stringGetter({ key: STRING_KEYS.FEE })}</span>
+          </TableColumnHeader>
+        ),
         renderCell: ({ fee, orderSide, price, resources, tickSizeDecimals }) => (
           <TableCell stacked>
             <$InlineRow>
@@ -176,15 +182,11 @@ const getFillsTableColumnDef = ({
       [FillsTableColumnKey.TotalFee]: {
         columnKey: 'totalFee',
         getCellValue: (row) => MustBigNumber(row.price).times(row.size).toNumber(),
-        label: isTablet ? (
+        label: (
           <TableColumnHeader>
             <span>{stringGetter({ key: STRING_KEYS.TOTAL })}</span>
             <span>{stringGetter({ key: STRING_KEYS.FEE })}</span>
           </TableColumnHeader>
-        ) : (
-          `${stringGetter({ key: STRING_KEYS.TOTAL })} / ${stringGetter({
-            key: STRING_KEYS.FEE,
-          })}`
         ),
         renderCell: ({ size, fee, price }) => (
           <TableCell stacked>
@@ -242,15 +244,11 @@ const getFillsTableColumnDef = ({
       [FillsTableColumnKey.AmountPrice]: {
         columnKey: 'sizePrice',
         getCellValue: (row) => row.size,
-        label: isTablet ? (
+        label: (
           <TableColumnHeader>
             <span>{stringGetter({ key: STRING_KEYS.AMOUNT })}</span>
             <span>{stringGetter({ key: STRING_KEYS.PRICE })}</span>
           </TableColumnHeader>
-        ) : (
-          `${stringGetter({ key: STRING_KEYS.AMOUNT })} / ${stringGetter({
-            key: STRING_KEYS.PRICE,
-          })}`
         ),
         renderCell: ({ size, stepSizeDecimals, price, tickSizeDecimals }) => (
           <TableCell stacked>
@@ -262,15 +260,11 @@ const getFillsTableColumnDef = ({
       [FillsTableColumnKey.TypeLiquidity]: {
         columnKey: 'typeLiquidity',
         getCellValue: (row) => row.type.rawValue,
-        label: isTablet ? (
+        label: (
           <TableColumnHeader>
             <span>{stringGetter({ key: STRING_KEYS.TYPE })}</span>
             <span>{stringGetter({ key: STRING_KEYS.LIQUIDITY })}</span>
           </TableColumnHeader>
-        ) : (
-          `${stringGetter({ key: STRING_KEYS.TYPE })} / ${stringGetter({
-            key: STRING_KEYS.LIQUIDITY,
-          })}`
         ),
         renderCell: ({ resources }) => (
           <TableCell stacked>

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -220,9 +220,16 @@ const getOrdersTableColumnDef = ({
       [OrdersTableColumnKey.StatusFill]: {
         columnKey: 'statusFill',
         getCellValue: (row) => row.status.name,
-        label: `${stringGetter({ key: STRING_KEYS.STATUS })} / ${stringGetter({
-          key: STRING_KEYS.FILL,
-        })}`,
+        label: (
+          <TableColumnHeader>
+            <span>{stringGetter({ key: STRING_KEYS.STATUS })}</span>
+            <span>
+              {stringGetter({
+                key: STRING_KEYS.FILL,
+              })}
+            </span>
+          </TableColumnHeader>
+        ),
         renderCell: ({ asset, createdAtMilliseconds, size, status, totalFilled, resources }) => {
           const { statusIconColor } = getOrderStatusInfo({ status: status.rawValue });
 

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -125,9 +125,16 @@ const getPositionsTableColumnDef = ({
       [PositionsTableColumnKey.IndexEntry]: {
         columnKey: 'oracleEntry',
         getCellValue: (row) => row.entryPrice?.current,
-        label: `${stringGetter({ key: STRING_KEYS.ORACLE_PRICE_ABBREVIATED })} / ${stringGetter({
-          key: STRING_KEYS.ENTRY_PRICE_SHORT,
-        })}`,
+        label: (
+          <TableColumnHeader>
+            <span>{stringGetter({ key: STRING_KEYS.ORACLE_PRICE_ABBREVIATED })}</span>
+            <span>
+              {stringGetter({
+                key: STRING_KEYS.ENTRY_PRICE_SHORT,
+              })}
+            </span>
+          </TableColumnHeader>
+        ),
         hideOnBreakpoint: MediaQueryKeys.isNotTablet,
         renderCell: ({ entryPrice, oraclePrice, tickSizeDecimals }) => (
           <TableCell stacked>


### PR DESCRIPTION
context: some traders use a much smaller screenheight and trade form's footer cover most of the inputs

fix: make footer not sticky when screen is too short

![image](https://github.com/dydxprotocol/v4-web/assets/9400120/edc89437-5414-4250-bf8f-08df6ee6bd73)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/2f8cd413-1848-407c-a3dd-266e74b51f9a)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/d1fcc9b7-e95c-43bc-8b74-e453332abe45)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/55252f2d-a227-4100-aa7f-73b77444ee56)
![image](https://github.com/dydxprotocol/v4-web/assets/9400120/06e0ce01-b8c3-4630-8dd4-9710ac5dd2ce)


also opt to use ' | ' for the table column header