### PR TITLE
fix: clear inputs on close position click to avoid subsequent place orders

### DIFF
--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -208,6 +208,19 @@ export const ClosePositionForm = ({
         setUnIndexedClientId(placeOrderPayload?.clientId);
       },
     });
+
+    onClearInputs();
+  };
+
+  const onClearInputs = () => {
+    abacusStateManager.setClosePositionValue({
+      value: null,
+      field: ClosePositionInputField.percent,
+    });
+    abacusStateManager.setClosePositionValue({
+      value: null,
+      field: ClosePositionInputField.size,
+    });
   };
 
   const alertMessage = alertContent && <AlertMessage type={alertType}>{alertContent}</AlertMessage>;
@@ -273,16 +286,7 @@ export const ClosePositionForm = ({
               action={ButtonAction.Reset}
               shape={ButtonShape.Pill}
               size={ButtonSize.XSmall}
-              onClick={() => {
-                abacusStateManager.setClosePositionValue({
-                  value: null,
-                  field: ClosePositionInputField.percent,
-                });
-                abacusStateManager.setClosePositionValue({
-                  value: null,
-                  field: ClosePositionInputField.size,
-                });
-              }}
+              onClick={onClearInputs}
             >
               {stringGetter({ key: STRING_KEYS.CLEAR })}
             </Button>


### PR DESCRIPTION
one of the most frequent place order errors are related to this "Reduce-only orders cannot increase the position size"

trader can submit multiple close position orders if they click it kinda fast

this PR should prevent this behavior


to test, attempt to close an open position by clicking the close position CTA on the form multiple times