### PR TITLE
MOB-523 : iOS: Add Isolated Positions missing message for v1.4.0

### DIFF
--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -132,8 +132,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-2": {
@@ -222,8 +221,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-4": {
@@ -313,8 +311,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-5": {
@@ -403,8 +400,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging": {
@@ -495,8 +491,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -585,8 +580,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging-west": {
@@ -677,8 +671,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet": {
@@ -773,8 +766,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -866,8 +858,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -959,8 +950,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -1052,8 +1042,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -1145,8 +1134,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -1229,8 +1217,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -1322,8 +1309,7 @@
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
             "CCTPWithdrawalOnly": true,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-mainnet": {
@@ -1414,8 +1400,7 @@
          "featureFlags": {
             "reduceOnlySupported": false,
             "withdrawalSafetyEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": false,
-            "shouldEnabledIsolatedMarketsOnAndroid": false
+            "shouldEnableIsolatedMarketsOnMobile": false
          }
       }
    }

--- a/public/configs/env.json
+++ b/public/configs/env.json
@@ -131,7 +131,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-2": {
@@ -219,7 +221,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-4": {
@@ -308,7 +312,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-5": {
@@ -396,7 +402,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging": {
@@ -486,7 +494,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -574,7 +584,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging-west": {
@@ -664,7 +676,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet": {
@@ -758,7 +772,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -849,7 +865,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -940,7 +958,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -1031,7 +1051,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -1122,7 +1144,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -1204,7 +1228,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -1295,7 +1321,9 @@
          "featureFlags": {
             "reduceOnlySupported": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true
+            "CCTPWithdrawalOnly": true,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-mainnet": {
@@ -1385,7 +1413,9 @@
          },
          "featureFlags": {
             "reduceOnlySupported": false,
-            "withdrawalSafetyEnabled": false
+            "withdrawalSafetyEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": false,
+            "shouldEnabledIsolatedMarketsOnAndroid": false
          }
       }
    }

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -286,7 +286,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-2": {
@@ -320,7 +322,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-3": {
@@ -355,7 +359,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-4": {
@@ -390,7 +396,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-dev-5": {
@@ -424,7 +432,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging": {
@@ -459,7 +469,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -501,7 +513,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-staging-west": {
@@ -536,7 +550,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet": {
@@ -575,7 +591,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -609,7 +627,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -644,7 +664,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -678,7 +700,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -713,7 +737,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -748,7 +774,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -783,7 +811,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": true,
+            "shouldEnabledIsolatedMarketsOnAndroid": true
          }
       },
       "dydxprotocol-mainnet": {
@@ -818,7 +848,9 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false
+            "isSlTpLimitOrdersEnabled": false,
+            "shouldEnabledIsolatedMarketsOniOS": false,
+            "shouldEnabledIsolatedMarketsOnAndroid": false
          }
       }
    }

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -287,8 +287,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-2": {
@@ -323,8 +322,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-3": {
@@ -360,8 +358,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-4": {
@@ -397,8 +394,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-dev-5": {
@@ -433,8 +429,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging": {
@@ -470,8 +465,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -514,8 +508,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-staging-west": {
@@ -551,8 +544,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet": {
@@ -592,8 +584,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -628,8 +619,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -665,8 +655,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -701,8 +690,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -738,8 +726,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -775,8 +762,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -812,8 +798,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": true,
-            "shouldEnabledIsolatedMarketsOnAndroid": true
+            "shouldEnableIsolatedMarketsOnMobile": true
          }
       },
       "dydxprotocol-mainnet": {
@@ -849,8 +834,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "shouldEnabledIsolatedMarketsOniOS": false,
-            "shouldEnabledIsolatedMarketsOnAndroid": false
+            "shouldEnableIsolatedMarketsOnMobile": false
          }
       }
    }


### PR DESCRIPTION
[MOB-523 : iOS: Add Isolated Positions missing message for v1.4.0](https://linear.app/dydx/issue/MOB-523/ios-add-isolated-positions-missing-message-for-v140)

mobile and web might not support isolate margins at the same time. There is messaging intended to be displayed on older versions of the mobile app when isolated margins is supported in a corresponding web deployment.

see [slack thread](https://dydx-team.slack.com/archives/C06FR0QLWFJ/p1716473986784749) for details