### PR TITLE
feat: update wording and remove old trade page account boxes

### DIFF
--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -27,7 +27,7 @@
   --tableHeader-height: 2.5rem;
   --tableHeader-height-mobile: 3.25rem;
 
-  --account-info-section-height: 11.25rem;
+  --account-info-section-height: 7rem;
   --position-details-width: 23rem;
 
   /* Auto grid constants */

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -21,8 +21,7 @@ import { Details } from '@/components/Details';
 import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { MarginUsageRing } from '@/components/MarginUsageRing';
-import { Output, OutputType } from '@/components/Output';
-import { UsageBars } from '@/components/UsageBars';
+import { OutputType } from '@/components/Output';
 import { WithTooltip } from '@/components/WithTooltip';
 
 import { calculateIsAccountLoading } from '@/state/accountCalculators';
@@ -37,9 +36,7 @@ import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
 
 enum AccountInfoItem {
   BuyingPower = 'buying-power',
-  Equity = 'equity',
   MarginUsage = 'margin-usage',
-  Leverage = 'leverage',
 }
 
 const getUsageValue = (value: Nullable<TradeState<number>>) => {
@@ -65,7 +62,7 @@ export const AccountInfoConnectedState = () => {
 
   const listOfErrors = inputErrors?.map(({ code }: { code: string }) => code);
 
-  const { buyingPower, equity, marginUsage, leverage } = subAccount ?? {};
+  const { buyingPower, marginUsage } = subAccount ?? {};
 
   const hasDiff =
     (marginUsage?.postOrder !== null &&
@@ -132,34 +129,13 @@ export const AccountInfoConnectedState = () => {
         <$Details
           items={[
             {
-              key: AccountInfoItem.Leverage,
-              // hasError:
-              //   listOfErrors?.includes('INVALID_LARGE_POSITION_LEVERAGE') ||
-              //   listOfErrors?.includes('INVALID_NEW_POSITION_LEVERAGE'),
-              tooltip: 'leverage',
-              isPositive: !MustBigNumber(leverage?.postOrder).gt(MustBigNumber(leverage?.current)),
-              label: stringGetter({ key: STRING_KEYS.LEVERAGE }),
-              type: OutputType.Multiple,
-              value: leverage,
-              slotRight: <$UsageBars value={getUsageValue(leverage)} />,
-            },
-            {
-              key: AccountInfoItem.Equity,
-              // hasError: isNumber(equity?.postOrder) && MustBigNumber(equity?.postOrder).lt(0),
-              tooltip: 'equity',
-              isPositive: MustBigNumber(equity?.postOrder).gt(MustBigNumber(equity?.current)),
-              label: stringGetter({ key: STRING_KEYS.EQUITY }),
-              type: OutputType.Fiat,
-              value: equity,
-            },
-            {
               key: AccountInfoItem.MarginUsage,
               hasError: listOfErrors?.includes('INVALID_NEW_ACCOUNT_MARGIN_USAGE'),
               tooltip: 'margin-usage',
               isPositive: !MustBigNumber(marginUsage?.postOrder).gt(
                 MustBigNumber(marginUsage?.current)
               ),
-              label: stringGetter({ key: STRING_KEYS.MARGIN_USAGE }),
+              label: stringGetter({ key: STRING_KEYS.CROSS_MARGIN_USAGE }),
               type: OutputType.Percent,
               value: marginUsage,
               slotRight: <MarginUsageRing value={getUsageValue(marginUsage)} />,
@@ -173,7 +149,7 @@ export const AccountInfoConnectedState = () => {
               isPositive: MustBigNumber(buyingPower?.postOrder).gt(
                 MustBigNumber(buyingPower?.current)
               ),
-              label: stringGetter({ key: STRING_KEYS.BUYING_POWER }),
+              label: stringGetter({ key: STRING_KEYS.CROSS_FREE_COLLATERAL }),
               type: OutputType.Fiat,
               value:
                 MustBigNumber(buyingPower?.current).lt(0) && buyingPower?.postOrder === null
@@ -201,9 +177,7 @@ export const AccountInfoConnectedState = () => {
                   </$WithUsage>
                 </WithTooltip>
               ),
-              value: [AccountInfoItem.Leverage, AccountInfoItem.Equity].includes(key) ? (
-                <$Output type={type} value={value?.current} />
-              ) : (
+              value: (
                 <AccountInfoDiffOutput
                   hasError={hasError}
                   isPositive={isPositive}
@@ -276,8 +250,8 @@ const $Details = styled(Details)<{ showHeader?: boolean }>`
   > * {
     height: ${({ showHeader }) =>
       !showHeader
-        ? `calc(var(--account-info-section-height) / 2)`
-        : `calc((var(--account-info-section-height) - var(--tabs-height)) / 2)`};
+        ? `calc(var(--account-info-section-height))`
+        : `calc((var(--account-info-section-height) - var(--tabs-height)))`};
 
     padding: 0.625rem 1rem;
   }
@@ -289,15 +263,6 @@ const $Details = styled(Details)<{ showHeader?: boolean }>`
       padding: 1.25rem 1.875rem;
     }
   }
-`;
-
-const $UsageBars = styled(UsageBars)`
-  margin-top: -0.125rem;
-`;
-
-const $Output = styled(Output)<{ isNegative?: boolean }>`
-  color: var(--color-text-1);
-  font: var(--font-base-book);
 `;
 
 const $Header = styled.header`

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -212,7 +212,6 @@ const getOrdersTableColumnDef = ({
         label: stringGetter({ key: STRING_KEYS.ACTION }),
         isActionable: true,
         allowsSorting: false,
-        getCellValue: () => '',
         renderCell: ({ id, status, orderFlags }) => (
           <OrderActionsCell
             orderId={id}


### PR DESCRIPTION
I didn't change calculation at all, just modified the number of boxes and titles. 

![image](https://github.com/dydxprotocol/v4-web/assets/169097417/dc4b4783-0d32-4705-a026-653e5ece9002)
![image](https://github.com/dydxprotocol/v4-web/assets/169097417/ad6f5fd2-4714-45f3-8142-91bb6adc2375)

Tooltips need update:

![image](https://github.com/dydxprotocol/v4-web/assets/169097417/42dba874-776e-497f-afdb-18cca8c6ddf1)
![image](https://github.com/dydxprotocol/v4-web/assets/169097417/dd99cde7-67fd-49e0-b802-5847eb877a67)


