### PR TITLE
fix: get transfers state working

### DIFF
--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -260,7 +260,7 @@ const useAccountsContext = () => {
     if (dydxAddress) {
       abacusStateManager.setAccount(localDydxWallet, hdKey);
     } else abacusStateManager.attemptDisconnectAccount();
-  }, [localDydxWallet, hdKey, dydxAddress]);
+  }, [localDydxWallet, hdKey]);
 
   useEffect(() => {
     const setNobleWallet = async () => {

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -257,9 +257,8 @@ const useAccountsContext = () => {
 
   // abacus
   useEffect(() => {
-    if (dydxAddress) {
-      abacusStateManager.setAccount(localDydxWallet, hdKey);
-    } else abacusStateManager.attemptDisconnectAccount();
+    if (dydxAddress) abacusStateManager.setAccount(localDydxWallet, hdKey);
+    else abacusStateManager.attemptDisconnectAccount();
   }, [localDydxWallet, hdKey]);
 
   useEffect(() => {

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -4,7 +4,7 @@ import { OfflineSigner } from '@cosmjs/proto-signing';
 import { LocalWallet, NOBLE_BECH32_PREFIX, type Subaccount } from '@dydxprotocol/v4-client-js';
 import { usePrivy } from '@privy-io/react-auth';
 import { AES, enc } from 'crypto-js';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { OnboardingGuard, OnboardingState, type EvmDerivedAddresses } from '@/constants/account';
 import { LOCAL_STORAGE_VERSIONS, LocalStorageKey } from '@/constants/localStorage';
@@ -18,6 +18,7 @@ import {
 } from '@/constants/wallets';
 
 import { setOnboardingGuard, setOnboardingState } from '@/state/account';
+import { getSubaccount } from '@/state/accountSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { log } from '@/lib/telemetry';
@@ -57,6 +58,7 @@ const useAccountsContext = () => {
 
   // EVM wallet connection
   const [previousEvmAddress, setPreviousEvmAddress] = useState(evmAddress);
+  const hasSubAccount = Boolean(useSelector(getSubaccount));
 
   useEffect(() => {
     // Wallet accounts switched
@@ -73,7 +75,7 @@ const useAccountsContext = () => {
     }
 
     setPreviousEvmAddress(evmAddress);
-  }, [evmAddress]);
+  }, [evmAddress, hasSubAccount]);
 
   const { ready, authenticated } = usePrivy();
 
@@ -255,9 +257,10 @@ const useAccountsContext = () => {
 
   // abacus
   useEffect(() => {
-    if (dydxAddress) abacusStateManager.setAccount(localDydxWallet, hdKey);
-    else abacusStateManager.attemptDisconnectAccount();
-  }, [localDydxWallet, hdKey]);
+    if (dydxAddress) {
+      abacusStateManager.setAccount(localDydxWallet, hdKey);
+    } else abacusStateManager.attemptDisconnectAccount();
+  }, [localDydxWallet, hdKey, dydxAddress]);
 
   useEffect(() => {
     const setNobleWallet = async () => {

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/constants/wallets';
 
 import { setOnboardingGuard, setOnboardingState } from '@/state/account';
-import { getSubaccount } from '@/state/accountSelectors';
+import { getHasSubaccount } from '@/state/accountSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { log } from '@/lib/telemetry';
@@ -58,7 +58,7 @@ const useAccountsContext = () => {
 
   // EVM wallet connection
   const [previousEvmAddress, setPreviousEvmAddress] = useState(evmAddress);
-  const hasSubAccount = Boolean(useSelector(getSubaccount));
+  const hasSubAccount = useSelector(getHasSubaccount);
 
   useEffect(() => {
     // Wallet accounts switched

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -31,6 +31,12 @@ export const getSubaccount = (state: RootState) => state.account.subaccount;
 
 /**
  * @param state
+ * @returns Whether or not Abacus' subaccount object exists
+ */
+export const getHasSubaccount = (state: RootState) => Boolean(state.account.subaccount);
+
+/**
+ * @param state
  * @returns identifier of the current subaccount
  */
 export const getSubaccountId = (state: RootState) => state.account.subaccount?.subaccountNumber;


### PR DESCRIPTION
Abacus was rejecting v4-web state change requests as a result of...
- abacus stateManager.sourceAddress not being set... as a result of
- v4-web not being able to set the sourceAddress... as a result of
- abacus AccountSupervisor not having an account... as a result of
- v4-web attempting to set the sourceAddress before the account was set


we could have done this the *more correct way* which is to functionally ensure that these dependent codepieces cohabit the same function or exist in functions nested in a linearly executed piece of code.

but that would involve figuring out what all the account setting dependencies and requirements are so for now we've took the hacky route of:
- checking for the existence of a subAccount (aka `Account` in abacus) and adding that to the dependencyArray of the useEffect hook that sets the `sourceAddress`


https://www.loom.com/share/958371e647754dca8a3cd0034a660549?sid=e2cbe66c-a9be-4746-9869-a66961753c45