### PR TITLE
feat: update fills tab number logic to count unseen fills only

### DIFF
--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -74,10 +74,10 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
   const currentMarketId = useSelector(getCurrentMarketId);
   const currentMarketAssetId = useSelector(getCurrentMarketAssetId);
 
-  const { numTotalPositions, numTotalOpenOrders, numTotalFills } =
+  const { numTotalPositions, numTotalOpenOrders, numTotalUnseenFills } =
     useSelector(getTradeInfoNumbers, shallowEqual) || {};
 
-  const { numOpenOrders, numFills } =
+  const { numOpenOrders, numUnseenFills } =
     useSelector(getCurrentMarketTradeInfoNumbers, shallowEqual) || {};
 
   const showClosePositionAction = true;
@@ -92,7 +92,9 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
   const isWaitingForOrderToIndex = useSelector(calculateHasUncommittedOrders);
   const showCurrentMarket = isTablet || view === PanelView.CurrentMarket;
 
-  const fillsTagNumber = shortenNumberForDisplay(showCurrentMarket ? numFills : numTotalFills);
+  const fillsTagNumber = shortenNumberForDisplay(
+    showCurrentMarket ? numUnseenFills : numTotalUnseenFills
+  );
   const ordersTagNumber = shortenNumberForDisplay(
     showCurrentMarket ? numOpenOrders : numTotalOpenOrders
   );

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -47,7 +47,7 @@ export type AccountState = {
   onboardingState: OnboardingState;
 
   clearedOrderIds?: string[];
-  hasUnseenFillUpdates: boolean;
+  unseenFillsCountPerMarket: Record<string, number>;
   hasUnseenOrderUpdates: boolean;
   latestOrder?: Nullable<SubaccountOrder>;
   historicalPnlPeriod?: HistoricalPnlPeriods;
@@ -88,7 +88,7 @@ const initialState: AccountState = {
 
   // UI
   clearedOrderIds: undefined,
-  hasUnseenFillUpdates: false,
+  unseenFillsCountPerMarket: {},
   hasUnseenOrderUpdates: false,
   latestOrder: undefined,
   uncommittedOrderClientIds: [],
@@ -113,12 +113,22 @@ export const accountSlice = createSlice({
         state.fills != null &&
         (action.payload ?? []).some((fill: SubaccountFill) => !existingFillIds.includes(fill.id));
 
+      const newUnseenFillsCountPerMarket = { ...state.unseenFillsCountPerMarket };
+      if (hasNewFillUpdates) {
+        (action.payload ?? [])
+          .filter((fill: SubaccountFill) => !existingFillIds.includes(fill.id))
+          .forEach((fill: SubaccountFill) => {
+            newUnseenFillsCountPerMarket[fill.marketId] =
+              (newUnseenFillsCountPerMarket[fill.marketId] ?? 0) + 1;
+          });
+      }
+
       const filledOrderIds = (action.payload ?? []).map((fill: SubaccountFill) => fill.orderId);
 
       return {
         ...state,
         fills: action.payload,
-        hasUnseenFillUpdates: state.hasUnseenFillUpdates || hasNewFillUpdates,
+        unseenFillsCountPerMarket: newUnseenFillsCountPerMarket,
         localPlaceOrders: hasNewFillUpdates
           ? state.localPlaceOrders.map((order) =>
               order.submissionStatus < PlaceOrderStatuses.Filled &&
@@ -212,8 +222,14 @@ export const accountSlice = createSlice({
       ...state,
       wallet: action.payload,
     }),
-    viewedFills: (state) => {
-      state.hasUnseenFillUpdates = false;
+    viewedFills: (state, action: PayloadAction<string | undefined>) => {
+      if (!action.payload) {
+        // viewed fills for all markets
+        state.unseenFillsCountPerMarket = {};
+      } else {
+        const { [action.payload]: unseenCount, ...remaining } = state.unseenFillsCountPerMarket;
+        state.unseenFillsCountPerMarket = remaining;
+      }
     },
     viewedOrders: (state) => {
       state.hasUnseenOrderUpdates = false;

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -29,11 +29,7 @@ import { PageSize } from '@/components/Table/TablePaginationRow';
 import { TagSize } from '@/components/Tag';
 
 import { viewedFills } from '@/state/account';
-import {
-  getCurrentMarketFills,
-  getHasUnseenFillUpdates,
-  getSubaccountFills,
-} from '@/state/accountSelectors';
+import { getCurrentMarketFills, getSubaccountFills } from '@/state/accountSelectors';
 import { getAssets } from '@/state/assetsSelectors';
 import { openDialog } from '@/state/dialogs';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
@@ -316,11 +312,13 @@ export const FillsTable = ({
   const allPerpetualMarkets = orEmptyObj(useSelector(getPerpetualMarkets, shallowEqual));
   const allAssets = orEmptyObj(useSelector(getAssets, shallowEqual));
 
-  const hasUnseenFillUpdates = useSelector(getHasUnseenFillUpdates);
-
   useEffect(() => {
-    if (hasUnseenFillUpdates) dispatch(viewedFills());
-  }, [hasUnseenFillUpdates]);
+    // marked fills as seen both on mount and dismount (i.e. new fill came in while fills table is being shown)
+    dispatch(viewedFills(currentMarket));
+    return () => {
+      dispatch(viewedFills(currentMarket));
+    };
+  }, [currentMarket]);
 
   const symbol = currentMarket ? allAssets[allPerpetualMarkets[currentMarket]?.assetId]?.id : null;
 


### PR DESCRIPTION
context: for traders who've traded a bit, fills tab number will just consistently be 99+ which is not that useful. instead, we want to just show number of unseen fills, either for current market, or total.

logic:
- we treat all existing fills (i.e. first fills from abacus) as "seen"
- when trader selects fills tab on Trade or sees the Fills table in portfolio, all fills (for the current market if filter, or all) will be marked as seen. no fun logic to determine what's rendered :p
- that also applies to fills that come in when fills table is being rendered; those fills will be marked as seen once they switch market / navigate away from table

to test:
- create some market orders in different markets
- navigate to and away from Fills tab on Trade page and observe number different
- navigate to portfolio / trade history and observe fills marked as seen


https://github.com/dydxprotocol/v4-web/assets/9400120/22d22acc-cc39-4e70-881a-4f793ae911e3

