### PR TITLE
style(trade-form): update trade form with tooltips and marginMode selection (2/N)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.7.39",
     "@dydxprotocol/v4-client-js": "^1.1.13",
-    "@dydxprotocol/v4-localization": "^1.1.92",
+    "@dydxprotocol/v4-localization": "^1.1.97",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@privy-io/react-auth": "^1.59.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.1.13
     version: 1.1.13
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.92
-    version: 1.1.92
+    specifier: ^1.1.97
+    version: 1.1.97
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1411,8 +1411,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.92:
-    resolution: {integrity: sha512-h5BiqPzzUsBAOEyrr5Jxa0q6VdGsjrMCH6IVtTbQlX9DqDPDRNbwzLDSrJvadyZE0iuQFnlmoQqDhZH/WXUjdA==}
+  /@dydxprotocol/v4-localization@1.1.97:
+    resolution: {integrity: sha512-9gSKrwwiaEfS2M+8hzPW5mzl1vndXEB+BdLJAjkGf757W0RQLZ2O0N7enaPSavRgs210BSVcnQcCl8K9sfhcIQ==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:

--- a/src/constants/tooltips/trade.ts
+++ b/src/constants/tooltips/trade.ts
@@ -203,6 +203,10 @@ export const tradeTooltips: TooltipStrings = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.TAKER_FEE_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.TAKER_FEE_BODY }),
   }),
+  'target-leverage': ({ stringGetter, stringParams }) => ({
+    title: stringGetter({ key: TOOLTIP_STRING_KEYS.TARGET_LEVERAGE_TITLE }),
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.TARGET_LEVERAGE_BODY, params: stringParams }),
+  }),
   'tick-size': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.TICK_SIZE_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.TICK_SIZE_BODY }),

--- a/src/state/inputsSelectors.ts
+++ b/src/state/inputsSelectors.ts
@@ -113,6 +113,7 @@ export const useTradeFormData = () => {
 
         const {
           needsLimitPrice,
+          needsMarginMode,
           needsTargetLeverage,
           needsTrailingPercent,
           needsTriggerPrice,
@@ -133,6 +134,7 @@ export const useTradeFormData = () => {
           summary,
 
           needsLimitPrice,
+          needsMarginMode,
           needsTargetLeverage,
           needsTrailingPercent,
           needsTriggerPrice,

--- a/src/views/dialogs/TradeDialog.tsx
+++ b/src/views/dialogs/TradeDialog.tsx
@@ -6,6 +6,7 @@ import styled, { css } from 'styled-components';
 import { MARGIN_MODE_STRINGS } from '@/constants/abacus';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
+import { LEVERAGE_DECIMALS } from '@/constants/numbers';
 import { MobilePlaceOrderSteps } from '@/constants/trade';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
@@ -19,10 +20,12 @@ import { GreenCheckCircle } from '@/components/GreenCheckCircle';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 import { Ring } from '@/components/Ring';
+import { WithTooltip } from '@/components/WithTooltip';
 import { TradeForm } from '@/views/forms/TradeForm';
 
 import { openDialog } from '@/state/dialogs';
 import { getInputTradeData, useTradeFormData } from '@/state/inputsSelectors';
+import { getCurrentMarketAssetId } from '@/state/perpetualsSelectors';
 
 import { orEmptyObj } from '@/lib/typeUtils';
 
@@ -38,10 +41,11 @@ export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) =>
   const { isMobile } = useBreakpoints();
   const dispatch = useDispatch();
   const stringGetter = useStringGetter();
+  const currentAssetId = useSelector(getCurrentMarketAssetId);
   const currentTradeData = orEmptyObj(useSelector(getInputTradeData, shallowEqual));
   const { marginMode, targetLeverage } = currentTradeData;
 
-  const { needsTargetLeverage } = useTradeFormData();
+  const { needsMarginMode, needsTargetLeverage } = useTradeFormData();
   const [currentStep, setCurrentStep] = useState<MobilePlaceOrderSteps>(
     MobilePlaceOrderSteps.EditOrder
   );
@@ -50,6 +54,45 @@ export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) =>
     setCurrentStep(MobilePlaceOrderSteps.EditOrder);
     setIsOpen?.(false);
   };
+
+  const marginModeSelector = needsMarginMode ? (
+    <Button
+      onClick={() => {
+        dispatch(
+          openDialog({
+            type: DialogTypes.SelectMarginMode,
+          })
+        );
+      }}
+    >
+      {marginMode &&
+        stringGetter({
+          key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+        })}
+      <$TriangleIcon iconName={IconName.Triangle} />
+    </Button>
+  ) : (
+    <$WarningTooltip
+      slotTooltip={
+        <$WarningTooltipContent>
+          <$WarningIcon iconName={IconName.Warning} />
+          {stringGetter({
+            key: STRING_KEYS.UNABLE_TO_CHANGE_MARGIN_MODE,
+            params: {
+              MARKET: currentAssetId,
+            },
+          })}
+        </$WarningTooltipContent>
+      }
+    >
+      <Button disabled>
+        {marginMode &&
+          stringGetter({
+            key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+          })}
+      </Button>
+    </$WarningTooltip>
+  );
 
   return (
     <$Dialog
@@ -63,29 +106,21 @@ export const TradeDialog = ({ isOpen, setIsOpen, slotTrigger }: ElementProps) =>
         [MobilePlaceOrderSteps.EditOrder]: {
           title: (
             <$EditTradeHeader>
-              <Button
-                onClick={() => {
-                  dispatch(
-                    openDialog({
-                      type: DialogTypes.SelectMarginMode,
-                    })
-                  );
-                }}
-              >
-                {marginMode &&
-                  stringGetter({
-                    key: MARGIN_MODE_STRINGS[marginMode.rawValue],
-                  })}
-              </Button>
+              {marginModeSelector}
 
               {needsTargetLeverage && (
-                <Button
-                  onClick={() => {
-                    dispatch(openDialog({ type: DialogTypes.AdjustTargetLeverage }));
-                  }}
+                <WithTooltip
+                  tooltip="target-leverage"
+                  stringParams={{ TARGET_LEVERAGE: targetLeverage?.toFixed(LEVERAGE_DECIMALS) }}
                 >
-                  <Output type={OutputType.Multiple} value={targetLeverage} />
-                </Button>
+                  <Button
+                    onClick={() => {
+                      dispatch(openDialog({ type: DialogTypes.AdjustTargetLeverage }));
+                    }}
+                  >
+                    <Output type={OutputType.Multiple} value={targetLeverage} />
+                  </Button>
+                </WithTooltip>
               )}
 
               <TradeSideToggle />
@@ -151,6 +186,23 @@ const $TradeForm = styled(TradeForm)`
   --tradeBox-content-paddingRight: 1.5rem;
   --tradeBox-content-paddingBottom: 1.5rem;
   --tradeBox-content-paddingLeft: 1.5rem;
+`;
+
+const $TriangleIcon = styled(Icon)`
+  font-size: 0.4375rem;
+  transform: rotate(0.75turn);
+  margin-left: 0.5ch;
+`;
+
+const $WarningTooltip = styled(WithTooltip)`
+  --tooltip-backgroundColor: var(--color-gradient-warning);
+  border: 1px solid ${({ theme }) => theme.warning}30;
+`;
+
+const $WarningTooltipContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: start;
 `;
 
 const $Ring = styled(Ring)`

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -20,7 +20,7 @@ import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/b
 import { DialogTypes, TradeBoxDialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { NotificationType } from '@/constants/notifications';
-import { USD_DECIMALS } from '@/constants/numbers';
+import { LEVERAGE_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import {
   InputErrorData,
   MobilePlaceOrderSteps,
@@ -116,6 +116,7 @@ export const TradeForm = ({
     size,
     summary,
     needsLimitPrice,
+    needsMarginMode,
     needsTargetLeverage,
     needsTrailingPercent,
     needsTriggerPrice,
@@ -332,6 +333,46 @@ export const TradeForm = ({
     });
   }
 
+  const marginModeSelector = needsMarginMode ? (
+    <Button
+      onClick={() => {
+        dispatch(openDialogInTradeBox({ type: TradeBoxDialogTypes.SelectMarginMode }));
+      }}
+    >
+      {marginMode &&
+        stringGetter({
+          key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+        })}
+      <$TriangleIcon iconName={IconName.Triangle} />
+    </Button>
+  ) : (
+    <$WarningTooltip
+      slotTooltip={
+        <$WarningTooltipContent>
+          <$CautionIcon iconName={IconName.Warning} />
+          {stringGetter({
+            key: STRING_KEYS.UNABLE_TO_CHANGE_MARGIN_MODE,
+            params: {
+              MARKET: currentAssetId,
+            },
+          })}
+        </$WarningTooltipContent>
+      }
+    >
+      <Button
+        disabled
+        onClick={() => {
+          dispatch(openDialogInTradeBox({ type: TradeBoxDialogTypes.SelectMarginMode }));
+        }}
+      >
+        {marginMode &&
+          stringGetter({
+            key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+          })}
+      </Button>
+    </$WarningTooltip>
+  );
+
   return (
     <$TradeForm onSubmit={onSubmit} className={className}>
       {currentStep && currentStep !== MobilePlaceOrderSteps.EditOrder ? (
@@ -366,27 +407,21 @@ export const TradeForm = ({
             {!isTablet && (
               <>
                 <$MarginAndLeverageButtons>
-                  <Button
-                    onClick={() => {
-                      dispatch(
-                        openDialogInTradeBox({ type: TradeBoxDialogTypes.SelectMarginMode })
-                      );
-                    }}
-                  >
-                    {marginMode &&
-                      stringGetter({
-                        key: MARGIN_MODE_STRINGS[marginMode.rawValue],
-                      })}
-                  </Button>
+                  {marginModeSelector}
 
                   {needsTargetLeverage && (
-                    <Button
-                      onClick={() => {
-                        dispatch(openDialog({ type: DialogTypes.AdjustTargetLeverage }));
-                      }}
+                    <WithTooltip
+                      tooltip="target-leverage"
+                      stringParams={{ TARGET_LEVERAGE: targetLeverage?.toFixed(LEVERAGE_DECIMALS) }}
                     >
-                      <Output type={OutputType.Multiple} value={targetLeverage} />
-                    </Button>
+                      <Button
+                        onClick={() => {
+                          dispatch(openDialog({ type: DialogTypes.AdjustTargetLeverage }));
+                        }}
+                      >
+                        <Output type={OutputType.Multiple} value={targetLeverage} />
+                      </Button>
+                    </WithTooltip>
                   )}
                 </$MarginAndLeverageButtons>
 
@@ -524,10 +559,34 @@ const $MarginAndLeverageButtons = styled.div`
   gap: 0.5rem;
   margin-right: 0.5rem;
 
+  abbr,
   button {
     width: 100%;
   }
 `;
+
+const $TriangleIcon = styled(Icon)`
+  font-size: 0.4375rem;
+  transform: rotate(0.75turn);
+  margin-left: 0.5ch;
+`;
+
+const $WarningTooltip = styled(WithTooltip)`
+  --tooltip-backgroundColor: var(--color-gradient-warning);
+  border: 1px solid ${({ theme }) => theme.warning}30;
+`;
+
+const $WarningTooltipContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+`;
+
+const $CautionIcon = styled(Icon)`
+  font-size: 1.5rem;
+  color: var(--color-warning);
+`;
+
 const $TopActionsRow = styled.div`
   display: grid;
   grid-auto-flow: column;
@@ -617,13 +676,16 @@ const $ToggleGroup = styled(ToggleGroup)`
     }
   }
 ` as typeof ToggleGroup;
+
 const $InputsColumn = styled.div`
   ${formMixins.inputsColumn}
 `;
+
 const $Message = styled.div`
   ${layoutMixins.row}
   gap: 0.75rem;
 `;
+
 const $IconButton = styled(IconButton)`
   --button-backgroundColor: var(--color-white-faded);
   flex-shrink: 0;
@@ -633,11 +695,13 @@ const $IconButton = styled(IconButton)`
     height: 1.25em;
   }
 `;
+
 const $ButtonRow = styled.div`
   ${layoutMixins.row}
   justify-self: end;
   padding: 0.5rem 0 0.5rem 0;
 `;
+
 const $Footer = styled.footer`
   ${formMixins.footer}
   --stickyFooterBackdrop-outsetY: var(--tradeBox-content-paddingBottom);

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -359,12 +359,7 @@ export const TradeForm = ({
         </$WarningTooltipContent>
       }
     >
-      <Button
-        disabled
-        onClick={() => {
-          dispatch(openDialogInTradeBox({ type: TradeBoxDialogTypes.SelectMarginMode }));
-        }}
-      >
+      <Button disabled>
         {marginMode &&
           stringGetter({
             key: MARGIN_MODE_STRINGS[marginMode.rawValue],


### PR DESCRIPTION
…rginModeSelection if existing position

<!-- Featured screenshots/recordings -->

<img width="422" alt="Screen Shot 2024-05-29 at 4 13 00 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/94bc53ce-e397-4f6a-b642-3c8ad7f3976b">
<img width="375" alt="Screen Shot 2024-05-29 at 4 13 04 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/3d752053-7875-409f-9115-3e96ed9a56de">

<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

* `<TradeForm>`, `<TradeDialog>`
  * Update marginMode selector
  * Add tooltips

## Constants/Types

* `constants/tooltips`
  * Add targetLeverage tooltip

## Packages

* `v4-localization`
  * updated: v1.1.92 -> v1.1.97

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
