### PR TITLE
feat: Self-served MFA modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.7.43",
     "@dydxprotocol/v4-client-js": "^1.1.15",
-    "@dydxprotocol/v4-localization": "^1.1.105",
+    "@dydxprotocol/v4-localization": "^1.1.109",
     "@ethersproject/providers": "^5.7.2",
     "@js-joda/core": "^5.5.3",
     "@privy-io/react-auth": "^1.59.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.1.15
     version: 1.1.15
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.105
-    version: 1.1.105
+    specifier: ^1.1.109
+    version: 1.1.109
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1406,8 +1406,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.105:
-    resolution: {integrity: sha512-8HrdmgRMm4t386/lqoHlxPOn7vXo7UGbtjZQP94o0KXUOmdb3D2MDfrupIxqT7YsWZEyG9fmH3TNaq/wATOg5g==}
+  /@dydxprotocol/v4-localization@1.1.109:
+    resolution: {integrity: sha512-ZHcduX7sAWii3wOfD+C3OU1P6cAjQDLLObSEbOchmR8gT4BBhrx3Y3FUdzmNf4F/NobhL8/aABorUx8MpxlaxA==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:
@@ -11833,7 +11833,6 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
-    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -1,6 +1,6 @@
 import { ElementType, memo } from 'react';
 
-import { usePrivy } from '@privy-io/react-auth';
+import { useMfaEnrollment, usePrivy } from '@privy-io/react-auth';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
@@ -68,6 +68,8 @@ export const AccountMenu = () => {
 
   const privy = usePrivy();
   const { google, discord, twitter } = privy?.user ?? {};
+
+  const { showMfaEnrollmentModal } = useMfaEnrollment();
 
   const usdcBalance = freeCollateral?.current ?? 0;
 
@@ -258,6 +260,16 @@ export const AccountMenu = () => {
                 label: <span>{stringGetter({ key: STRING_KEYS.EXPORT_SECRET_PHRASE })}</span>,
                 highlightColor: 'destroy' as const,
                 onSelect: () => dispatch(openDialog({ type: DialogTypes.MnemonicExport })),
+              },
+            ]
+          : []),
+        ...(privy.ready && privy.authenticated
+          ? [
+              {
+                value: 'MFA',
+                icon: <Icon iconName={IconName.Lock} />,
+                label: stringGetter({ key: STRING_KEYS.MULTI_FACTOR_AUTH }),
+                onSelect: () => showMfaEnrollmentModal(),
               },
             ]
           : []),


### PR DESCRIPTION
### Description
- Added a new item in AccountMenu "Multi-Factor Authentication"
- Privy's MFA modal is shown when item is clicked
- There's a PR in v4-localization to add the new localized string https://github.com/dydxprotocol/v4-localization/pull/486

[mfa.webm](https://github.com/dydxprotocol/v4-web/assets/13419428/d2725f17-d584-455f-9cc6-73d99bf7e7d5)

![image](https://github.com/dydxprotocol/v4-web/assets/13419428/b99a1993-5bf7-46b5-a18e-5eccc2ca1efa)
