### PR TITLE
chore(market-type): display perpetual market type in Details

### DIFF
--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -85,6 +85,7 @@ export type MarketTrade = Abacus.exchange.dydx.abacus.output.MarketTrade;
 export type OrderbookLine = Abacus.exchange.dydx.abacus.output.OrderbookLine;
 export type PerpetualMarket = Abacus.exchange.dydx.abacus.output.PerpetualMarket;
 export type MarketHistoricalFunding = Abacus.exchange.dydx.abacus.output.MarketHistoricalFunding;
+export const PerpetualMarketType = Abacus.exchange.dydx.abacus.output.PerpetualMarketType;
 
 // ------ Configs ------ //
 export type Configs = Abacus.exchange.dydx.abacus.output.Configs;

--- a/src/views/MarketDetails.tsx
+++ b/src/views/MarketDetails.tsx
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js';
 import { shallowEqual, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
+import { PerpetualMarketType } from '@/constants/abacus';
 import { ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 
@@ -40,6 +41,7 @@ export const MarketDetails: React.FC = () => {
     effectiveInitialMarginFraction,
     maintenanceMarginFraction,
     minOrderSize,
+    perpetualMarketType,
     stepSizeDecimals,
     tickSizeDecimals,
   } = configs;
@@ -61,6 +63,14 @@ export const MarketDetails: React.FC = () => {
       key: 'market-name',
       label: stringGetter({ key: STRING_KEYS.MARKET_NAME }),
       value: market,
+    },
+    {
+      key: 'market-type',
+      label: stringGetter({ key: STRING_KEYS.TYPE }),
+      value:
+        perpetualMarketType === PerpetualMarketType.CROSS
+          ? stringGetter({ key: STRING_KEYS.CROSS })
+          : stringGetter({ key: STRING_KEYS.ISOLATED }),
     },
     {
       key: 'tick-size',


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="885" alt="Screen Shot 2024-05-30 at 1 53 26 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/481fb522-0846-418a-b7e5-3ff840e08617">

<!-- Overall purpose of the PR -->

Display perpetual market type in Details

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketDetails>`
  * Add new detail item for perpetualMarketType

## Constants/Types

* `constants/abacus`
  * PerpetualMarketType

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
