### PR TITLE
chore: padding / real estate

### DIFF
--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -131,7 +131,7 @@ const ButtonStyle = css<StyleProps>`
 
   --button-width: auto;
   --button-height: 2.75rem;
-  --button-padding: 0 0.625em;
+  --button-padding: 0 0.625rem;
 
   --button-textColor: var(--color-text-0);
   --button-backgroundColor: transparent;

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -176,8 +176,8 @@ const itemLayoutVariants = {
 
     ${layoutMixins.spacedRow}
     gap: 0.5rem;
-    align-items: start;
-    padding: 0.5rem 0;
+    align-items: center;
+    padding: var(--details-item-vertical-padding, 0.5rem) 0;
 
     min-height: var(--details-item-height);
 
@@ -196,7 +196,7 @@ const itemLayoutVariants = {
 
   stackColumn: css`
     ${layoutMixins.column}
-    padding: 0.75rem 0;
+    padding: var(--details-item-vertical-padding, 0.75rem) 0;
     > :first-child {
       margin-bottom: 0.5rem;
     }
@@ -229,10 +229,11 @@ const $Details = styled.dl<{
   layout: 'column' | 'row' | 'rowColumns' | 'grid' | 'stackColumn';
   withSeparators: boolean;
 }>`
-  --details-item-height: 2rem;
+  --details-item-height: 1rem;
   --details-item-backgroundColor: transparent;
   --details-subitem-borderWidth: 2px;
   --details-grid-numColumns: 2;
+  --details-item-vertical-padding: ;
 
   ${({ layout }) => layout && detailsLayoutVariants[layout]}
 `;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -302,6 +302,7 @@ const $DropdownTabTrigger = styled(Trigger)`
 
 const $DropdownSelectMenu = styled(DropdownSelectMenu)<{ $isActive?: boolean }>`
   --trigger-radius: 0;
+  --dropdownSelectMenu-item-font-size: var(--fontSize-base);
 
   ${({ $isActive }) =>
     $isActive &&

--- a/src/components/WithDetailsReceipt.tsx
+++ b/src/components/WithDetailsReceipt.tsx
@@ -34,6 +34,7 @@ export const WithDetailsReceipt = ({
 );
 const $Details = styled(Details)`
   --details-item-backgroundColor: var(--withReceipt-backgroundColor);
+  --details-item-vertical-padding: 0.33rem;
 
   padding: 0.375rem 0.75rem 0.25rem;
 

--- a/src/views/charts/DepthChart/Tooltip.tsx
+++ b/src/views/charts/DepthChart/Tooltip.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { OrderSide } from '@dydxprotocol/v4-client-js';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
 import { shallowEqual } from 'react-redux';
+import styled from 'styled-components';
 
 import type { Nullable } from '@/constants/abacus';
 import {
@@ -85,7 +86,7 @@ export const DepthChartTooltipContent = ({
             }[nearestDatum.key]}
       </h4>
 
-      <Details
+      <$Details
         layout="column"
         items={
           isEditingOrder
@@ -221,3 +222,7 @@ export const DepthChartTooltipContent = ({
     </TooltipContent>
   );
 };
+
+const $Details = styled(Details)`
+  --details-item-vertical-padding: 0.2rem;
+`;

--- a/src/views/charts/FundingChart/Tooltip.tsx
+++ b/src/views/charts/FundingChart/Tooltip.tsx
@@ -1,4 +1,5 @@
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import styled from 'styled-components';
 
 import { FundingRateResolution, type FundingChartDatum } from '@/constants/charts';
 import { STRING_KEYS } from '@/constants/localization';
@@ -42,7 +43,7 @@ export const FundingChartTooltipContent = ({
           : stringGetter({ key: STRING_KEYS.HISTORICAL_FUNDING_RATE })}
       </h4>
 
-      <Details
+      <$Details
         layout="column"
         items={
           [
@@ -106,3 +107,7 @@ export const FundingChartTooltipContent = ({
     </TooltipContent>
   );
 };
+
+const $Details = styled(Details)`
+  --details-item-vertical-padding: 0.2rem;
+`;

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -279,6 +279,7 @@ const $WithReceipt = styled(WithReceipt)`
 `;
 
 const $Details = styled(Details)`
+  --details-item-vertical-padding: 0.33rem;
   padding: var(--form-input-paddingY) var(--form-input-paddingX);
   font-size: 0.8125em;
 `;

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -206,6 +206,7 @@ const $WithReceipt = styled(WithReceipt)`
 `;
 
 const $Details = styled(Details)`
+  --details-item-vertical-padding: 0.33rem;
   padding: var(--form-input-paddingY) var(--form-input-paddingX);
   font-size: 0.8125em;
 `;

--- a/src/views/notifications/BlockRewardNotification/index.tsx
+++ b/src/views/notifications/BlockRewardNotification/index.tsx
@@ -52,7 +52,7 @@ export const BlockRewardNotification = ({
   );
 };
 const $Details = styled(Details)`
-  --details-item-height: 1.5rem;
+  --details-item-vertical-padding: 0;
 
   dd {
     color: var(--color-text-2);

--- a/src/views/notifications/IncentiveSeasonDistributionNotification.tsx
+++ b/src/views/notifications/IncentiveSeasonDistributionNotification.tsx
@@ -43,7 +43,7 @@ export const IncentiveSeasonDistributionNotification = ({
   );
 };
 const $Details = styled(Details)`
-  --details-item-height: 1.5rem;
+  --details-item-vertical-padding: 0;
 
   dd {
     color: var(--color-text-2);


### PR DESCRIPTION
- decrease padding in receipts, especially in tooltip content (longstanding feedback) and with receipt button (more likely someone on a short screen will see the CTA .v.)
- changing horizontal padding of button back to rem -- this matches the design system more actually

test:
- Details are used across the app, mainly details dialog, market details, receipt areas, notifications, tooltip contents
- compare before/after side by side


<img width="344" alt="Screenshot 2024-06-04 at 12 59 30 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/9c5d215c-3bbd-4ad4-8eec-2034bcaa09cb">
<img width="471" alt="Screenshot 2024-06-04 at 12 59 41 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/f3cb4975-014c-4371-b134-89d8dda30ae9">
<img width="297" alt="Screenshot 2024-06-04 at 12 59 48 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/eb6e81ae-e9f1-4b94-90ae-f5f7626eab73">
<img width="796" alt="Screenshot 2024-06-04 at 12 59 56 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/3e187a55-a703-4edb-90bc-6b0c7ce115b0">
<img width="398" alt="Screenshot 2024-06-04 at 1 00 02 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/7db527a2-2ad4-4c9b-9234-5e1eb4649d27">
<img width="368" alt="Screenshot 2024-06-04 at 1 00 35 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/0e67f516-68f3-4702-b467-9147789f8b9c">
<img width="545" alt="Screenshot 2024-06-04 at 1 00 47 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/70ec162a-5e82-4846-b336-25d51894982e">
<img width="562" alt="Screenshot 2024-06-04 at 1 00 54 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/f061c1ba-fa81-4086-9db8-b0906d792186">
