### PR TITLE
chore: audit all typecasts, make safer where possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
     "no-underscore-dangle": "off",
     "no-use-before-define": "off",
     "prefer-destructuring": "off",
+    "prefer-object-spread": "off",
     "prettier/prettier": "error",
     "react/display-name": "off",
     "react/forbid-prop-types": "off",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -55,7 +55,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
   ) => {
     const state: Record<string, boolean | undefined> =
       typeof stateConfig === 'string'
-        ? { [stateConfig as ButtonState]: true }
+        ? { [stateConfig]: true }
         : {
             [ButtonState.Loading]: stateConfig.isLoading,
             [ButtonState.Disabled]: stateConfig.isDisabled,

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -49,7 +49,7 @@ export const Toast = ({
   lastUpdated,
 }: ToastProps) => {
   // Timeout
-  const timeout = useRef<number>();
+  const timeout = useRef<NodeJS.Timeout>();
   const [isPaused, setIsPaused] = useState(false);
 
   useEffect(() => {
@@ -59,7 +59,7 @@ export const Toast = ({
     if (isOpen && !isPaused && duration !== Infinity)
       timeout.current = globalThis.setTimeout(() => {
         setIsOpen?.(false, true);
-      }, duration) as unknown as number;
+      }, duration);
   }, [isOpen, isPaused, duration, lastUpdated]);
 
   return (

--- a/src/components/visx/TimeSeriesChart.tsx
+++ b/src/components/visx/TimeSeriesChart.tsx
@@ -29,7 +29,7 @@ import Tooltip from '@/components/visx/XYChartTooltipWithBounds';
 
 import { formatAbsoluteTime } from '@/lib/dateTime';
 import { clamp, lerp, map } from '@/lib/math';
-import { objectEntries } from '@/lib/objectEntries';
+import { objectEntries } from '@/lib/objectHelpers';
 
 import { XYChartThreshold, type Threshold } from './XYChartThreshold';
 
@@ -196,8 +196,8 @@ export const TimeSeriesChart = <Datum extends {}>({
     if (!zoomDomain)
       return {
         zoom: 1,
-        domain: [0, 1] as [number, number],
-        range: [0, 1] as [number, number],
+        domain: [0, 1] as const,
+        range: [0, 1] as const,
         visibleData: data,
       };
 

--- a/src/components/visx/getScaleBandwidth.ts
+++ b/src/components/visx/getScaleBandwidth.ts
@@ -1,8 +1,6 @@
 // https://github.com/airbnb/visx/blob/master/packages/visx-xychart/src/typeguards/isValidNumber.ts
 import { AxisScale } from '@visx/axis';
 
-export function getScaleBandwidth<Scale extends AxisScale>(scale?: Scale) {
-  // Broaden type before using 'xxx' in s as typeguard.
-  const s = scale as AxisScale;
+export function getScaleBandwidth<Scale extends AxisScale>(s?: Scale) {
   return s && 'bandwidth' in s ? s?.bandwidth() ?? 0 : 0;
 }

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -342,6 +342,6 @@ export type ConnectNetworkEvent = CustomEvent<Partial<NetworkConfig>>;
 
 export type PerpetualMarketOrderbookLevel = OrderbookLine & {
   side?: 'ask' | 'bid';
-  mine: number;
+  mine: number | undefined;
   key: string;
 };

--- a/src/constants/charts.ts
+++ b/src/constants/charts.ts
@@ -1,3 +1,4 @@
+import { Nullable } from '@dydxprotocol/v4-abacus';
 import { OrderSide } from '@dydxprotocol/v4-client-js';
 
 import { FundingDirection } from './markets';
@@ -12,7 +13,7 @@ export enum DepthChartSeries {
 export type DepthChartDatum = {
   size: number;
   price: number;
-  depth: number;
+  depth: Nullable<number>;
   seriesKey: DepthChartSeries;
 };
 

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -1,9 +1,9 @@
-import { Asset, PerpetualMarket } from '@/constants/abacus';
+import { Asset, Nullable, PerpetualMarket } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 
 export type MarketData = {
   asset: Asset;
-  tickSizeDecimals: number;
+  tickSizeDecimals: Nullable<number>;
   oneDaySparkline?: number[];
   isNew?: boolean;
   listingDate?: Date;

--- a/src/constants/menus.ts
+++ b/src/constants/menus.ts
@@ -25,7 +25,7 @@ export type MenuItem<MenuItemValue, MenuItemTypes = string> = {
   labelRight?: React.ReactNode;
   tag?: React.ReactNode;
   slotAfter?: React.ReactNode;
-  description?: string;
+  description?: React.ReactNode;
   slotCustomContent?: React.ReactNode;
 
   href?: string;

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -4,7 +4,7 @@ import { timeUnits } from './time';
 
 export const mockHistoricalFundingData = Array.from(
   { length: 100 },
-  (_, i) =>
+  (_, i): MarketHistoricalFunding =>
     ({
       effectiveAtMilliseconds:
         timeUnits.hour * Math.floor(Date.now() / timeUnits.hour) - (100 - i - 1) * timeUnits.hour,

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -110,7 +110,7 @@ export type Notifications = Record<NotificationId, Notification<any>>;
 export type NotificationDisplayData = {
   icon?: React.ReactNode;
   title: string; // Title for Toast, Notification, and Push Notification
-  body?: string; // Description body for Toast, Notification, and Push Notification
+  body?: string | React.ReactNode; // Description body for Toast, Notification, and Push Notification
 
   slotTitleLeft?: React.ReactNode;
   slotTitleRight?: React.ReactNode;

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -23,13 +23,16 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
       orderbook?.asks?.toArray() ?? []
     )
       .map(
-        (row: OrderbookLine, idx: number) =>
-          ({
-            key: `ask-${idx}`,
-            side: 'ask',
-            mine: subaccountOrderSizeBySideAndPrice[OrderSide.SELL]?.[row.price],
-            ...row,
-          }) as PerpetualMarketOrderbookLevel
+        (row: OrderbookLine, idx: number): PerpetualMarketOrderbookLevel =>
+          Object.assign(
+            {},
+            {
+              key: `ask-${idx}`,
+              side: 'ask' as const,
+              mine: subaccountOrderSizeBySideAndPrice[OrderSide.SELL]?.[row.price],
+            },
+            row
+          )
       )
       .slice(0, maxRowsPerSide);
 
@@ -37,13 +40,16 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
       orderbook?.bids?.toArray() ?? []
     )
       .map(
-        (row: OrderbookLine, idx: number) =>
-          ({
-            key: `bid-${idx}`,
-            side: 'bid',
-            mine: subaccountOrderSizeBySideAndPrice[OrderSide.BUY]?.[row.price],
-            ...row,
-          }) as PerpetualMarketOrderbookLevel
+        (row: OrderbookLine, idx: number): PerpetualMarketOrderbookLevel =>
+          Object.assign(
+            {},
+            {
+              key: `bid-${idx}`,
+              side: 'bid' as const,
+              mine: subaccountOrderSizeBySideAndPrice[OrderSide.BUY]?.[row.price],
+            },
+            row
+          )
       )
       .slice(0, maxRowsPerSide);
 
@@ -97,11 +103,15 @@ export const useOrderbookValuesForDepthChart = () => {
   return useMemo(() => {
     const bids = (orderbook?.bids?.toArray() ?? [])
       .filter(Boolean)
-      .map((datum) => ({ ...datum, seriesKey: DepthChartSeries.Bids }) as DepthChartDatum);
+      .map(
+        (datum): DepthChartDatum => Object.assign({}, datum, { seriesKey: DepthChartSeries.Bids })
+      );
 
     const asks = (orderbook?.asks?.toArray() ?? [])
       .filter(Boolean)
-      .map((datum) => ({ ...datum, seriesKey: DepthChartSeries.Asks }) as DepthChartDatum);
+      .map(
+        (datum): DepthChartDatum => Object.assign({}, datum, { seriesKey: DepthChartSeries.Asks })
+      );
 
     const lowestBid = bids[bids.length - 1];
     const highestBid = bids[0];

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -11,6 +11,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketOrderbook } from '@/state/perpetualsSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
+import { safeAssign } from '@/lib/objectHelpers';
 
 export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number }) => {
   const orderbook = useAppSelector(getCurrentMarketOrderbook, shallowEqual);
@@ -24,7 +25,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
     )
       .map(
         (row: OrderbookLine, idx: number): PerpetualMarketOrderbookLevel =>
-          Object.assign(
+          safeAssign(
             {},
             {
               key: `ask-${idx}`,
@@ -41,7 +42,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
     )
       .map(
         (row: OrderbookLine, idx: number): PerpetualMarketOrderbookLevel =>
-          Object.assign(
+          safeAssign(
             {},
             {
               key: `bid-${idx}`,
@@ -103,15 +104,11 @@ export const useOrderbookValuesForDepthChart = () => {
   return useMemo(() => {
     const bids = (orderbook?.bids?.toArray() ?? [])
       .filter(Boolean)
-      .map(
-        (datum): DepthChartDatum => Object.assign({}, datum, { seriesKey: DepthChartSeries.Bids })
-      );
+      .map((datum): DepthChartDatum => safeAssign({}, datum, { seriesKey: DepthChartSeries.Bids }));
 
     const asks = (orderbook?.asks?.toArray() ?? [])
       .filter(Boolean)
-      .map(
-        (datum): DepthChartDatum => Object.assign({}, datum, { seriesKey: DepthChartSeries.Asks })
-      );
+      .map((datum): DepthChartDatum => safeAssign({}, datum, { seriesKey: DepthChartSeries.Asks }));
 
     const lowestBid = bids[bids.length - 1];
     const highestBid = bids[0];

--- a/src/hooks/useBreakpoints.ts
+++ b/src/hooks/useBreakpoints.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import breakpoints from '@/styles/breakpoints';
 
+import { objectEntries } from '@/lib/objectHelpers';
+
 export enum MediaQueryKeys {
   isMobile = 'isMobile',
   isNotMobile = 'isNotMobile',
@@ -25,7 +27,7 @@ const mediaQueryLists = {
 export const useBreakpoints = () => {
   // { [typeof breakpoints['string']]: [boolean, () => void] }
   const state = Object.fromEntries(
-    Object.entries(mediaQueryLists).map(([key, mediaQueryList]) => [
+    objectEntries(mediaQueryLists).map(([key, mediaQueryList]) => [
       key,
       // this is technically okay since the loop is fully deterministic and the object won't change
       // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -37,7 +39,7 @@ export const useBreakpoints = () => {
     // { [typeof breakpoints['string']]: () => void }
     const callbacks: { [key: string]: (e: MediaQueryListEvent) => void } = {};
 
-    Object.entries(mediaQueryLists).forEach(([key, mediaQueryList]) => {
+    objectEntries(mediaQueryLists).forEach(([key, mediaQueryList]) => {
       const [, setMatches] = state[key];
 
       callbacks[key] = (e) => {
@@ -50,7 +52,7 @@ export const useBreakpoints = () => {
     });
 
     return () => {
-      Object.entries(mediaQueryLists).forEach(([key, mediaQueryList]) => {
+      objectEntries(mediaQueryLists).forEach(([key, mediaQueryList]) => {
         if (mediaQueryList.removeEventListener) {
           mediaQueryList.removeEventListener('change', callbacks[key]);
         }
@@ -60,7 +62,7 @@ export const useBreakpoints = () => {
 
   // { [typeof breakpoints['string']]: boolean }
   const breakpointMatches = Object.fromEntries(
-    Object.entries(state).map(([key, [matches]]) => [key, matches])
+    objectEntries(state).map(([key, [matches]]) => [key, matches])
   );
 
   return breakpointMatches;

--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -59,12 +59,12 @@ export const useComplianceState = () => {
           : undefined,
         EMAIL: complianceSupportEmail,
       },
-    }) as string;
+    });
   } else if (complianceStatus === ComplianceStatus.BLOCKED) {
     complianceMessage = stringGetter({
       key: STRING_KEYS.PERMANENTLY_BLOCKED_MESSAGE,
       params: { EMAIL: complianceSupportEmail },
-    }) as string;
+    });
   } else if (geo && isBlockedGeo(geo)) {
     complianceMessage = stringGetter({
       key: STRING_KEYS.BLOCKED_MESSAGE,
@@ -75,7 +75,7 @@ export const useComplianceState = () => {
           </Link>
         ),
       },
-    }) as string;
+    });
   }
 
   return {

--- a/src/hooks/useEndpointsConfig.ts
+++ b/src/hooks/useEndpointsConfig.ts
@@ -16,7 +16,7 @@ interface EndpointsConfig {
 
 export const useEndpointsConfig = () => {
   const selectedNetwork = useAppSelector(getSelectedNetwork);
-  const endpointsConfig = ENVIRONMENT_CONFIG_MAP[selectedNetwork].endpoints as EndpointsConfig;
+  const endpointsConfig: EndpointsConfig = ENVIRONMENT_CONFIG_MAP[selectedNetwork].endpoints;
 
   return {
     indexer: endpointsConfig.indexers[0], // assume there's only one option for indexer endpoints

--- a/src/hooks/useGovernanceVariables.ts
+++ b/src/hooks/useGovernanceVariables.ts
@@ -13,6 +13,6 @@ export interface GovernanceVariables {
 
 export const useGovernanceVariables = (): GovernanceVariables => {
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
-  const governanceVars = GOVERNANCE_CONFIG_MAP[selectedDydxChainId] as GovernanceVariables;
+  const governanceVars = GOVERNANCE_CONFIG_MAP[selectedDydxChainId];
   return governanceVars;
 };

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -14,6 +14,7 @@ import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
+import { objectKeys } from '@/lib/objectHelpers';
 import { orEmptyObj } from '@/lib/typeUtils';
 
 const filterFunctions = {
@@ -50,7 +51,7 @@ export const useMarketsData = (
 ): {
   markets: MarketData[];
   filteredMarkets: MarketData[];
-  marketFilters: string[];
+  marketFilters: MarketFilters[];
 } => {
   const allPerpetualMarkets = orEmptyObj(useAppSelector(getPerpetualMarkets, shallowEqual));
   const allAssets = orEmptyObj(useAppSelector(getAssets, shallowEqual));
@@ -59,7 +60,7 @@ export const useMarketsData = (
   const markets = useMemo(() => {
     return Object.values(allPerpetualMarkets)
       .filter(isTruthy)
-      .map((marketData) => {
+      .map((marketData): MarketData => {
         const sevenDaySparklineEntries = sevenDaysSparklineData?.[marketData.id]?.length ?? 0;
         const isNew = Boolean(
           sevenDaysSparklineData && sevenDaySparklineEntries < SEVEN_DAY_SPARKLINE_ENTRIES
@@ -79,16 +80,19 @@ export const useMarketsData = (
           listingDate.setHours(listingDate.getHours() - sevenDaySparklineEntries * 4);
         }
 
-        return {
-          asset: allAssets[marketData.assetId] ?? {},
-          tickSizeDecimals: marketData.configs?.tickSizeDecimals,
-          isNew,
-          listingDate,
-          ...marketData,
-          ...marketData.perpetual,
-          ...marketData.configs,
-        };
-      }) as MarketData[];
+        return Object.assign(
+          {},
+          {
+            asset: allAssets[marketData.assetId] ?? {},
+            tickSizeDecimals: marketData.configs?.tickSizeDecimals,
+            isNew,
+            listingDate,
+          },
+          marketData,
+          marketData.perpetual,
+          marketData.configs
+        );
+      });
   }, [allPerpetualMarkets, allAssets, sevenDaysSparklineData]);
 
   const filteredMarkets = useMemo(() => {
@@ -109,7 +113,7 @@ export const useMarketsData = (
     () => [
       MarketFilters.ALL,
       MarketFilters.NEW,
-      ...Object.keys(MARKET_FILTER_LABELS).filter((marketFilter) =>
+      ...objectKeys(MARKET_FILTER_LABELS).filter((marketFilter) =>
         markets.some((market) => market.asset?.tags?.toArray().some((tag) => tag === marketFilter))
       ),
     ],

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -14,7 +14,7 @@ import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
-import { objectKeys } from '@/lib/objectHelpers';
+import { objectKeys, safeAssign } from '@/lib/objectHelpers';
 import { orEmptyObj } from '@/lib/typeUtils';
 
 const filterFunctions = {
@@ -80,7 +80,7 @@ export const useMarketsData = (
           listingDate.setHours(listingDate.getHours() - sevenDaySparklineEntries * 4);
         }
 
-        return Object.assign(
+        return safeAssign(
           {},
           {
             asset: allAssets[marketData.assetId] ?? {},

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -170,19 +170,17 @@ const useNotificationsContext = () => {
           if (notificationPreferences[notificationCategory] !== false) {
             // New unique key - create new notification
             if (!notification) {
-              const thisNotification = (notifications[key] = {
+              const newStatus = isNew ? NotificationStatus.Triggered : NotificationStatus.Cleared;
+              const thisNotification: Notification = (notifications[key] = {
                 id,
                 type,
                 timestamps: {},
+                status: newStatus,
                 updateKey,
-              } as Notification);
-              updateStatus(
-                thisNotification,
-                isNew ? NotificationStatus.Triggered : NotificationStatus.Cleared
-              );
+              });
+              updateStatus(thisNotification, newStatus);
             } else if (JSON.stringify(updateKey) !== JSON.stringify(notification.updateKey)) {
               // updateKey changed - update existing notification
-
               const thisNotification = notifications[key];
 
               thisNotification.updateKey = updateKey;

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -20,7 +20,6 @@ import type {
   HumanReadablePlaceOrderPayload,
   HumanReadableTriggerOrdersPayload,
   ParsingError,
-  SubAccountHistoricalPNLs,
 } from '@/constants/abacus';
 import { AMOUNT_RESERVED_FOR_GAS_USDC } from '@/constants/account';
 import { STRING_KEYS } from '@/constants/localization';
@@ -258,7 +257,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
 
   useEffect(() => {
     dispatch(setSubaccount(undefined));
-    dispatch(setHistoricalPnl([] as unknown as SubAccountHistoricalPNLs));
+    dispatch(setHistoricalPnl([]));
   }, [dydxAddress]);
 
   // ------ Deposit/Withdraw Methods ------ //

--- a/src/lib/abacus/stateNotification.ts
+++ b/src/lib/abacus/stateNotification.ts
@@ -6,7 +6,6 @@ import type {
   AbacusNotification,
   AbacusStateNotificationProtocol,
   AccountBalance,
-  Asset,
   Nullable,
   ParsingErrors,
   PerpetualMarket,
@@ -72,11 +71,16 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
         dispatch(
           setAssets(
             Object.fromEntries(
-              (updatedState?.assetIds()?.toArray() ?? []).map((assetId: string) => {
-                const assetData = updatedState?.asset(assetId);
-                return [assetId, assetData];
-              })
-            ) as Record<string, Asset>
+              (updatedState?.assetIds()?.toArray() ?? [])
+                .map((assetId: string) => {
+                  const assetData = updatedState?.asset(assetId);
+                  if (assetData == null) {
+                    return undefined;
+                  }
+                  return [assetId, assetData];
+                })
+                .filter(isTruthy)
+            )
           )
         );
       }
@@ -128,12 +132,15 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
           setMarkets({
             markets: Object.fromEntries(
               (marketIds ?? updatedState.marketIds()?.toArray() ?? [])
-                .map((marketId: string) => {
+                .map((marketId: string): undefined | [string, PerpetualMarket] => {
                   const marketData = updatedState.market(marketId);
+                  if (marketData == null) {
+                    return undefined;
+                  }
                   return [marketId, marketData];
                 })
                 .filter(isTruthy)
-            ) as Record<string, PerpetualMarket>,
+            ),
             update: !!marketIds,
           })
         );

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,5 +1,7 @@
 import { allTimeUnits, timeUnits } from '@/constants/time';
 
+import { objectEntries } from './objectHelpers';
+
 // Given a literal from Intl.RelativeTimeFormat formatToParts,
 // strip out words/symbols unrelated to time unit
 const isolateTimeUnit = (literal: string) =>
@@ -55,7 +57,7 @@ export const formatRelativeTime = (
   const unitParts = [];
 
   // eslint-disable-next-line no-restricted-syntax
-  for (const [unit, amount] of Object.entries(timeUnits).slice(
+  for (const [unit, amount] of objectEntries(timeUnits).slice(
     Object.keys(timeUnits).findIndex((u) => u === largestUnit)
   ))
     if (Math.abs(elapsed) >= amount) {

--- a/src/lib/objectEntries.ts
+++ b/src/lib/objectEntries.ts
@@ -1,3 +1,0 @@
-/** Object.entries() with key types preserved */
-export const objectEntries = <T extends object>(t: T) =>
-  Object.entries(t) as { [K in keyof T]: [K, T[K]] }[keyof T][];

--- a/src/lib/objectHelpers.ts
+++ b/src/lib/objectHelpers.ts
@@ -1,0 +1,7 @@
+/** Object.entries() with key types preserved */
+export const objectEntries = <T extends object>(t: T) =>
+  Object.entries(t) as { [K in keyof T]: [K, T[K]] }[keyof T][];
+
+// Object.keys() with key types preserved - NOT SAFE for mutable variables, only readonly/consts that are never modified
+// since typescript is structurally typed and objects can contain extra keys and still be valid objects of type T
+export const objectKeys = <T extends object>(t: T) => Object.keys(t) as Array<keyof T>;

--- a/src/lib/objectHelpers.ts
+++ b/src/lib/objectHelpers.ts
@@ -5,3 +5,8 @@ export const objectEntries = <T extends object>(t: T) =>
 // Object.keys() with key types preserved - NOT SAFE for mutable variables, only readonly/consts that are never modified
 // since typescript is structurally typed and objects can contain extra keys and still be valid objects of type T
 export const objectKeys = <T extends object>(t: T) => Object.keys(t) as Array<keyof T>;
+
+// An alias for Object.assign. Our Abacus-generated types contian properties as getter functions which typescript can't be sure
+// can be safely splatted like {...someObject}. Object.assign is slightly slower but guarantees all the properties will get copied
+// and the result is typed correctly by the type system
+export const safeAssign = Object.assign;

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,3 +1,4 @@
+import { OrderSide } from '@dydxprotocol/v4-client-js';
 import { DateTime } from 'luxon';
 
 import {
@@ -5,6 +6,7 @@ import {
   AbacusOrderType,
   AbacusOrderTypes,
   KotlinIrEnumValues,
+  Nullable,
   TRADE_TYPES,
   type Asset,
   type OrderStatus,
@@ -108,6 +110,13 @@ export const relativeTimeString = ({
 }) =>
   DateTime.fromMillis(timeInMs).setLocale(selectedLocale).toLocaleString(DateTime.DATETIME_SHORT);
 
+type AddedProps = {
+  asset: Asset | undefined;
+  stepSizeDecimals: Nullable<number>;
+  tickSizeDecimals: Nullable<number>;
+  orderSide?: Nullable<OrderSide>;
+};
+
 export const getHydratedTradingData = <
   T extends SubaccountOrder | SubaccountFill | SubaccountFundingPayment,
 >({
@@ -116,13 +125,13 @@ export const getHydratedTradingData = <
   perpetualMarkets,
 }: {
   data: T;
-  assets?: Record<string, Asset>;
-  perpetualMarkets?: Record<string, PerpetualMarket>;
-}) => ({
+  assets: Record<string, Asset>;
+  perpetualMarkets: Record<string, PerpetualMarket>;
+}): T & AddedProps => ({
   ...data,
-  asset: assets && perpetualMarkets && assets[perpetualMarkets[data.marketId]?.assetId],
-  stepSizeDecimals: perpetualMarkets?.[data.marketId]?.configs?.stepSizeDecimals,
-  tickSizeDecimals: perpetualMarkets?.[data.marketId]?.configs?.tickSizeDecimals,
+  asset: assets[perpetualMarkets[data.marketId]?.assetId],
+  stepSizeDecimals: perpetualMarkets[data.marketId]?.configs?.stepSizeDecimals,
+  tickSizeDecimals: perpetualMarkets[data.marketId]?.configs?.tickSizeDecimals,
   ...('side' in data && { orderSide: convertAbacusOrderSide(data.side) }),
 });
 

--- a/src/lib/positions.ts
+++ b/src/lib/positions.ts
@@ -1,6 +1,8 @@
 import { Nullable, SubaccountPosition, type Asset, type PerpetualMarket } from '@/constants/abacus';
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 
+import { safeAssign } from './objectHelpers';
+
 type HydratedPositionData = SubaccountPosition & {
   asset?: Asset;
   stepSizeDecimals: number;
@@ -17,7 +19,7 @@ export const getHydratedPositionData = ({
   assets?: Record<string, Asset>;
   perpetualMarkets?: Record<string, PerpetualMarket>;
 }): HydratedPositionData => {
-  return Object.assign({}, data, {
+  return safeAssign({}, data, {
     asset: assets?.[data.assetId],
     stepSizeDecimals: perpetualMarkets?.[data.id]?.configs?.stepSizeDecimals ?? TOKEN_DECIMALS,
     tickSizeDecimals: perpetualMarkets?.[data.id]?.configs?.tickSizeDecimals ?? USD_DECIMALS,

--- a/src/lib/positions.ts
+++ b/src/lib/positions.ts
@@ -16,12 +16,11 @@ export const getHydratedPositionData = ({
   data: SubaccountPosition;
   assets?: Record<string, Asset>;
   perpetualMarkets?: Record<string, PerpetualMarket>;
-}) => {
-  return {
-    ...data,
+}): HydratedPositionData => {
+  return Object.assign({}, data, {
     asset: assets?.[data.assetId],
     stepSizeDecimals: perpetualMarkets?.[data.id]?.configs?.stepSizeDecimals ?? TOKEN_DECIMALS,
     tickSizeDecimals: perpetualMarkets?.[data.id]?.configs?.tickSizeDecimals ?? USD_DECIMALS,
     oraclePrice: perpetualMarkets?.[data.id]?.oraclePrice,
-  } as HydratedPositionData;
+  });
 };

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -20,6 +20,8 @@ import { type RootStore } from '@/state/_store';
 import { setCandles } from '@/state/perpetuals';
 import { getMarketConfig, getPerpetualBarsForPriceChart } from '@/state/perpetualsSelectors';
 
+import { objectKeys } from '@/lib/objectHelpers';
+
 import { log } from '../../telemetry';
 import { getHistorySlice, getSymbol, mapCandle } from '../utils';
 import { lastBarsCache } from './cache';
@@ -28,7 +30,7 @@ import { subscribeOnStream, unsubscribeFromStream } from './streaming';
 const timezone = DateTime.local().get('zoneName') as unknown as Timezone;
 
 const configurationData: DatafeedConfiguration = {
-  supported_resolutions: Object.keys(RESOLUTION_MAP) as ResolutionString[],
+  supported_resolutions: objectKeys(RESOLUTION_MAP),
   exchanges: [
     {
       value: 'dYdX', // `exchange` argument for the `searchSymbols` method, if a user selects this exchange
@@ -84,7 +86,7 @@ export const getDydxDatafeed = (
 
       session: '24x7',
       intraday_multipliers: ['1', '5', '15', '30', '60', '240'],
-      supported_resolutions: configurationData.supported_resolutions as ResolutionString[],
+      supported_resolutions: configurationData.supported_resolutions!,
       data_status: 'streaming',
       timezone,
       format: 'price',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import { store } from './state/_store';
 
 const Router = import.meta.env.VITE_ROUTER_TYPE === 'hash' ? HashRouter : BrowserRouter;
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <ErrorBoundary>
     <StrictMode>
       <Provider store={store}>

--- a/src/pages/portfolio/Fees.tsx
+++ b/src/pages/portfolio/Fees.tsx
@@ -170,7 +170,7 @@ export const Fees = () => {
                   />
                 ),
               },
-            ] as ColumnDef<FeeTier>[]
+            ] satisfies Array<false | ColumnDef<FeeTier>>
           ).filter(isTruthy)}
           selectionBehavior="replace"
           paginationBehavior="showAll"

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -94,7 +94,7 @@ export const getCurrentMarketPositionData = (state: RootState) => {
 
   return Object.fromEntries(
     (getOpenPositions(state) ?? []).map((positionData) => [positionData.id, positionData])
-  )[currentMarketId as string];
+  )[currentMarketId!];
 };
 
 /**
@@ -325,7 +325,11 @@ export const getOrderDetails = () =>
     (orders, assets, perpetualMarkets, orderId) => {
       const matchingOrder = orders?.find((order) => order.id === orderId);
       return matchingOrder
-        ? getHydratedTradingData({ data: matchingOrder, assets, perpetualMarkets })
+        ? getHydratedTradingData({
+            data: matchingOrder,
+            assets: assets ?? {},
+            perpetualMarkets: perpetualMarkets ?? {},
+          })
         : undefined;
     }
   );
@@ -364,7 +368,11 @@ export const getFillDetails = () =>
     (fills, assets, perpetualMarkets, fillId) => {
       const matchingFill = fills?.find((fill) => fill.id === fillId);
       return matchingFill
-        ? getHydratedTradingData({ data: matchingFill, assets, perpetualMarkets })
+        ? getHydratedTradingData({
+            data: matchingFill,
+            assets: assets ?? {},
+            perpetualMarkets: perpetualMarkets ?? {},
+          })
         : undefined;
     }
   );

--- a/src/state/inputs.ts
+++ b/src/state/inputs.ts
@@ -49,10 +49,9 @@ export const inputsSlice = createSlice({
         inputErrors: errors?.toArray(),
         tradeInputs: trade,
         closePositionInputs: closePosition,
-        transferInputs: {
-          ...transfer,
+        transferInputs: Object.assign({}, transfer, {
           isCctp: !!transfer?.isCctp,
-        } as Nullable<TransferInputs>,
+        }),
         triggerOrdersInputs: triggerOrders,
       };
     },

--- a/src/state/inputs.ts
+++ b/src/state/inputs.ts
@@ -12,6 +12,8 @@ import type {
 } from '@/constants/abacus';
 import { CLEARED_SIZE_INPUTS, CLEARED_TRADE_INPUTS } from '@/constants/trade';
 
+import { safeAssign } from '@/lib/objectHelpers';
+
 type TradeFormInputs = typeof CLEARED_TRADE_INPUTS & typeof CLEARED_SIZE_INPUTS;
 
 export interface InputsState {
@@ -49,7 +51,7 @@ export const inputsSlice = createSlice({
         inputErrors: errors?.toArray(),
         tradeInputs: trade,
         closePositionInputs: closePosition,
-        transferInputs: Object.assign({}, transfer, {
+        transferInputs: safeAssign({}, transfer, {
           isCctp: !!transfer?.isCctp,
         }),
         triggerOrdersInputs: triggerOrders,

--- a/src/state/perpetuals.ts
+++ b/src/state/perpetuals.ts
@@ -13,6 +13,7 @@ import { LocalStorageKey } from '@/constants/localStorage';
 import { DEFAULT_MARKETID, MarketFilters } from '@/constants/markets';
 
 import { getLocalStorage } from '@/lib/localStorage';
+import { objectKeys } from '@/lib/objectHelpers';
 import { processOrderbookToCreateMap } from '@/lib/orderbookHelpers';
 
 interface CandleDataByMarket {
@@ -137,7 +138,7 @@ export const perpetualsSlice = createSlice({
         ? { ...state.candles[marketId], selectedResolution: resolution }
         : {
             data: Object.fromEntries(
-              Object.keys(RESOLUTION_MAP).map((resolutionString: string) => [resolutionString, []])
+              objectKeys(RESOLUTION_MAP).map((resolutionString) => [resolutionString, []])
             ),
             selectedResolution: resolution,
           };
@@ -155,7 +156,7 @@ export const perpetualsSlice = createSlice({
         ...initialState,
         currentMarketId:
           getLocalStorage({ key: LocalStorageKey.LastViewedMarket }) ?? DEFAULT_MARKETID,
-      }) as PerpetualsState,
+      }) satisfies PerpetualsState,
   },
 });
 

--- a/src/state/perpetualsSelectors.ts
+++ b/src/state/perpetualsSelectors.ts
@@ -1,5 +1,5 @@
 import { Candle, TradingViewBar } from '@/constants/candles';
-import { EMPTY_ARR } from '@/constants/objects';
+import { EMPTY_ARR, EMPTY_OBJ } from '@/constants/objects';
 
 import { mapCandle } from '@/lib/tradingView/utils';
 
@@ -40,7 +40,7 @@ export const getMarketData = (state: RootState, marketId: string) =>
  * @returns marketIds of all markets
  */
 export const getMarketIds = (state: RootState) =>
-  Object.keys(getPerpetualMarkets(state) ?? EMPTY_ARR);
+  Object.keys(getPerpetualMarkets(state) ?? EMPTY_OBJ);
 
 /**
  * @returns PerpetualMarket data of the market the user is currently viewing

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -103,7 +103,7 @@ const MarketsDropdownContent = ({ onRowAction }: { onRowAction?: (market: Key) =
             />
           ),
         },
-      ] as ColumnDef<MarketData>[],
+      ] satisfies ColumnDef<MarketData>[],
     [stringGetter, selectedLocale]
   );
 
@@ -112,7 +112,7 @@ const MarketsDropdownContent = ({ onRowAction }: { onRowAction?: (market: Key) =
       <$Toolbar>
         <MarketFilter
           selectedFilter={filter}
-          filters={marketFilters as MarketFilters[]}
+          filters={marketFilters}
           onChangeFilter={setFilter}
           onSearchTextChange={setSearchFilter}
         />

--- a/src/views/charts/DepthChart/Tooltip.tsx
+++ b/src/views/charts/DepthChart/Tooltip.tsx
@@ -205,7 +205,7 @@ export const DepthChartTooltipContent = ({
                         type={OutputType.Fiat}
                         value={
                           nearestDatum != null
-                            ? nearestDatum.datum.price * nearestDatum.datum.depth
+                            ? nearestDatum.datum.price * (nearestDatum.datum.depth ?? 0)
                             : undefined
                         }
                       />

--- a/src/views/charts/DepthChart/index.tsx
+++ b/src/views/charts/DepthChart/index.tsx
@@ -129,7 +129,7 @@ export const DepthChart = ({
       0,
       [...bids, ...asks]
         .filter((datum) => datum.price >= newDomain[0] && datum.price <= newDomain[1])
-        .map((datum) => datum.depth)
+        .map((datum) => datum.depth ?? 0)
         .reduce((a, b) => Math.max(a, b), 0),
     ] as const;
 
@@ -141,20 +141,20 @@ export const DepthChart = ({
       let price;
       let size;
       if (point instanceof Point) {
-        const { x, y } = point as Point;
+        const { x, y } = point;
         price = x;
         size = y;
       } else {
-        const { svgPoint: { x, y } = {} } = point as EventHandlerParams<object>;
-        price = x;
-        size = y;
+        const { svgPoint: { x, y } = {} } = point;
+        price = x ?? 0;
+        size = y ?? 0;
       }
 
       return {
         side: MustBigNumber(price).lt(midMarketPrice!) ? OrderSide.BUY : OrderSide.SELL,
         price,
         size,
-      } as DepthChartPoint;
+      } satisfies DepthChartPoint;
     },
     [midMarketPrice]
   );

--- a/src/views/charts/FundingChart/Tooltip.tsx
+++ b/src/views/charts/FundingChart/Tooltip.tsx
@@ -101,7 +101,7 @@ export const FundingChartTooltipContent = ({
                 : stringGetter({ key: STRING_KEYS.TIME }),
               value: <Output type={OutputType.DateTime} value={tooltipDatum.time} />,
             },
-          ].filter(Boolean) as Array<DetailsItem>
+          ] satisfies Array<DetailsItem>
         }
       />
     </TooltipContent>

--- a/src/views/charts/FundingChart/index.tsx
+++ b/src/views/charts/FundingChart/index.tsx
@@ -49,7 +49,7 @@ export const FundingChart = ({ selectedLocale }: ElementProps) => {
   const stringGetter = useStringGetter();
 
   // Chart data
-  const data = useAppSelector(calculateFundingRateHistory, shallowEqual) as FundingChartDatum[];
+  const data = useAppSelector(calculateFundingRateHistory, shallowEqual);
 
   const latestDatum = data?.[data.length - 1];
 
@@ -127,7 +127,7 @@ export const FundingChart = ({ selectedLocale }: ElementProps) => {
     >
       <$FundingRateToggle>
         <ToggleGroup
-          items={Object.keys(FundingRateResolution).map((rate: string) => ({
+          items={Object.keys(FundingRateResolution).map((rate) => ({
             value: rate as FundingRateResolution,
             label:
               {

--- a/src/views/charts/PnlChart.tsx
+++ b/src/views/charts/PnlChart.tsx
@@ -31,6 +31,7 @@ import { getAppTheme } from '@/state/configsSelectors';
 import abacusStateManager from '@/lib/abacus';
 import { formatRelativeTime } from '@/lib/dateTime';
 import { isTruthy } from '@/lib/isTruthy';
+import { objectEntries } from '@/lib/objectHelpers';
 
 enum PnlSide {
   Profit = 'Profit',
@@ -116,20 +117,19 @@ export const PnlChart = ({
           ]
             .filter(isTruthy)
             .map(
-              (datum) =>
-                ({
-                  id: datum.createdAtMilliseconds,
-                  subaccountId,
-                  equity: Number(datum.equity),
-                  totalPnl: Number(datum.totalPnl),
-                  netTransfers: Number(datum.netTransfers),
-                  createdAt: new Date(datum.createdAtMilliseconds).valueOf(),
-                  side: {
-                    [-1]: PnlSide.Loss,
-                    0: PnlSide.Flat,
-                    1: PnlSide.Profit,
-                  }[Math.sign(datum.equity)],
-                }) as PnlDatum
+              (datum): PnlDatum => ({
+                id: datum.createdAtMilliseconds,
+                subaccountId: subaccountId ?? 0,
+                equity: Number(datum.equity),
+                totalPnl: Number(datum.totalPnl),
+                netTransfers: Number(datum.netTransfers),
+                createdAt: new Date(datum.createdAtMilliseconds).valueOf(),
+                side: {
+                  [-1]: PnlSide.Loss,
+                  0: PnlSide.Flat,
+                  1: PnlSide.Profit,
+                }[Math.sign(datum.equity)]!,
+              })
             )
         : [],
     [pnlData, equity?.current, now, lastPnlTick, subaccountId]
@@ -188,7 +188,7 @@ export const PnlChart = ({
   // e.g. oldest pnl is 31 days old -> show 90d option
   const getPeriodOptions = useCallback(
     (oldestPnlMs: number): HistoricalPnlPeriods[] =>
-      Object.entries(HISTORICAL_PNL_PERIODS).reduce(
+      objectEntries(HISTORICAL_PNL_PERIODS).reduce(
         (acc: HistoricalPnlPeriods[], [, period], i, arr) => {
           if (oldestPnlMs < now - msForPeriod(period, false)) {
             const nextPeriod = get(arr, [i + 1, 0]);

--- a/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
@@ -40,58 +40,60 @@ export const FillDetailsDialog = ({ fillId, setIsOpen }: ElementProps) => {
     tickSizeDecimals,
   } = useParameterizedSelector(getFillDetails, fillId)! ?? {};
 
-  const detailItems = [
-    {
-      key: 'market',
-      label: stringGetter({ key: STRING_KEYS.MARKET }),
-      value: marketId,
-    },
-    {
-      key: 'side',
-      label: stringGetter({ key: STRING_KEYS.SIDE }),
-      value: <OrderSideTag orderSide={orderSide!} />,
-    },
-    {
-      key: 'liquidity',
-      label: stringGetter({ key: STRING_KEYS.LIQUIDITY }),
-      value: resources.liquidityStringKey
-        ? stringGetter({ key: resources.liquidityStringKey })
-        : null,
-    },
-    {
-      key: 'amount',
-      label: stringGetter({ key: STRING_KEYS.AMOUNT }),
-      value: <Output type={OutputType.Asset} value={size} fractionDigits={stepSizeDecimals} />,
-    },
-    {
-      key: 'price',
-      label: stringGetter({ key: STRING_KEYS.PRICE }),
-      value: <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />,
-    },
-    {
-      key: 'total',
-      label: stringGetter({ key: STRING_KEYS.TOTAL }),
-      value: <Output type={OutputType.Fiat} value={MustBigNumber(price).times(size)} />,
-    },
-    {
-      key: 'fee',
-      label: stringGetter({
-        key: STRING_KEYS.FEE,
-      }),
-      value: <Output type={OutputType.Fiat} value={MustBigNumber(fee)} />,
-    },
-    {
-      key: 'created-at',
-      label: stringGetter({ key: STRING_KEYS.CREATED_AT }),
-      value: (
-        <time>
-          {DateTime.fromMillis(createdAtMilliseconds)
-            .setLocale(selectedLocale as string)
-            .toLocaleString(DateTime.DATETIME_SHORT)}
-        </time>
-      ),
-    },
-  ].filter((item) => Boolean(item.value)) as DetailsItem[];
+  const detailItems = (
+    [
+      {
+        key: 'market',
+        label: stringGetter({ key: STRING_KEYS.MARKET }),
+        value: marketId,
+      },
+      {
+        key: 'side',
+        label: stringGetter({ key: STRING_KEYS.SIDE }),
+        value: <OrderSideTag orderSide={orderSide!} />,
+      },
+      {
+        key: 'liquidity',
+        label: stringGetter({ key: STRING_KEYS.LIQUIDITY }),
+        value: resources.liquidityStringKey
+          ? stringGetter({ key: resources.liquidityStringKey })
+          : null,
+      },
+      {
+        key: 'amount',
+        label: stringGetter({ key: STRING_KEYS.AMOUNT }),
+        value: <Output type={OutputType.Asset} value={size} fractionDigits={stepSizeDecimals} />,
+      },
+      {
+        key: 'price',
+        label: stringGetter({ key: STRING_KEYS.PRICE }),
+        value: <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />,
+      },
+      {
+        key: 'total',
+        label: stringGetter({ key: STRING_KEYS.TOTAL }),
+        value: <Output type={OutputType.Fiat} value={MustBigNumber(price).times(size)} />,
+      },
+      {
+        key: 'fee',
+        label: stringGetter({
+          key: STRING_KEYS.FEE,
+        }),
+        value: <Output type={OutputType.Fiat} value={MustBigNumber(fee)} />,
+      },
+      {
+        key: 'created-at',
+        label: stringGetter({ key: STRING_KEYS.CREATED_AT }),
+        value: (
+          <time>
+            {DateTime.fromMillis(createdAtMilliseconds)
+              .setLocale(selectedLocale)
+              .toLocaleString(DateTime.DATETIME_SHORT)}
+          </time>
+        ),
+      },
+    ] satisfies DetailsItem[]
+  ).filter((item) => Boolean(item.value));
 
   return (
     <DetailsDialog

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -88,94 +88,96 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
   const renderOrderTime = ({ timeInMs }: { timeInMs: Nullable<number> }) =>
     timeInMs ? <time>{relativeTimeString({ timeInMs, selectedLocale })}</time> : '-';
 
-  const detailItems = [
-    {
-      key: 'market',
-      label: stringGetter({ key: STRING_KEYS.MARKET }),
-      value: marketId,
-    },
-    {
-      key: 'side',
-      label: stringGetter({ key: STRING_KEYS.SIDE }),
-      value: <OrderSideTag orderSide={orderSide ?? OrderSide.BUY} />,
-    },
-    {
-      key: 'status',
-      label: stringGetter({ key: STRING_KEYS.STATUS }),
-      value: (
-        <$Row>
-          <OrderStatusIcon status={status.rawValue} />
-          <$Status>
-            {resources.statusStringKey && stringGetter({ key: resources.statusStringKey })}
-          </$Status>
-        </$Row>
-      ),
-    },
-    {
-      key: 'cancel-reason',
-      label: stringGetter({ key: STRING_KEYS.CANCEL_REASON }),
-      value: cancelReason
-        ? stringGetter({ key: STRING_KEYS[cancelReason as StringKey] })
-        : undefined,
-    },
-    {
-      key: 'amount',
-      label: stringGetter({ key: STRING_KEYS.AMOUNT }),
-      value: <Output type={OutputType.Asset} value={size} fractionDigits={stepSizeDecimals} />,
-    },
-    {
-      key: 'filled',
-      label: stringGetter({ key: STRING_KEYS.AMOUNT_FILLED }),
-      value: (
-        <Output type={OutputType.Asset} value={totalFilled} fractionDigits={stepSizeDecimals} />
-      ),
-    },
-    {
-      key: 'price',
-      label: stringGetter({ key: STRING_KEYS.PRICE }),
-      value: renderOrderPrice({ type, price, tickSizeDecimals: tickSizeDecimals ?? 0 }),
-    },
-    {
-      key: 'trigger-price',
-      label: stringGetter({ key: STRING_KEYS.TRIGGER_PRICE_SHORT }),
-      value: triggerPrice
-        ? renderOrderPrice({ price: triggerPrice, tickSizeDecimals: tickSizeDecimals ?? 0 })
-        : undefined,
-    },
-    {
-      key: 'trailing-percent',
-      label: stringGetter({ key: STRING_KEYS.TRAILING_PERCENT }),
-      value: trailingPercent ? (
-        <Output type={OutputType.Percent} value={MustBigNumber(trailingPercent).div(100)} />
-      ) : undefined,
-    },
-    {
-      key: 'time-in-force',
-      label: stringGetter({ key: STRING_KEYS.TIME_IN_FORCE }),
-      value: resources.timeInForceStringKey
-        ? stringGetter({ key: resources.timeInForceStringKey })
-        : undefined,
-    },
-    {
-      key: 'execution',
-      label: stringGetter({ key: STRING_KEYS.EXECUTION }),
-      value: reduceOnly
-        ? stringGetter({ key: STRING_KEYS.REDUCE_ONLY })
-        : postOnly
-          ? stringGetter({ key: STRING_KEYS.POST_ONLY })
-          : '-',
-    },
-    {
-      key: 'good-til',
-      label: stringGetter({ key: STRING_KEYS.GOOD_TIL }),
-      value: renderOrderTime({ timeInMs: expiresAtMilliseconds }),
-    },
-    {
-      key: 'created-at',
-      label: stringGetter({ key: STRING_KEYS.CREATED_AT }),
-      value: renderOrderTime({ timeInMs: createdAtMilliseconds }),
-    },
-  ].filter((item) => Boolean(item.value)) as DetailsItem[];
+  const detailItems = (
+    [
+      {
+        key: 'market',
+        label: stringGetter({ key: STRING_KEYS.MARKET }),
+        value: marketId,
+      },
+      {
+        key: 'side',
+        label: stringGetter({ key: STRING_KEYS.SIDE }),
+        value: <OrderSideTag orderSide={orderSide ?? OrderSide.BUY} />,
+      },
+      {
+        key: 'status',
+        label: stringGetter({ key: STRING_KEYS.STATUS }),
+        value: (
+          <$Row>
+            <OrderStatusIcon status={status.rawValue} />
+            <$Status>
+              {resources.statusStringKey && stringGetter({ key: resources.statusStringKey })}
+            </$Status>
+          </$Row>
+        ),
+      },
+      {
+        key: 'cancel-reason',
+        label: stringGetter({ key: STRING_KEYS.CANCEL_REASON }),
+        value: cancelReason
+          ? stringGetter({ key: STRING_KEYS[cancelReason as StringKey] })
+          : undefined,
+      },
+      {
+        key: 'amount',
+        label: stringGetter({ key: STRING_KEYS.AMOUNT }),
+        value: <Output type={OutputType.Asset} value={size} fractionDigits={stepSizeDecimals} />,
+      },
+      {
+        key: 'filled',
+        label: stringGetter({ key: STRING_KEYS.AMOUNT_FILLED }),
+        value: (
+          <Output type={OutputType.Asset} value={totalFilled} fractionDigits={stepSizeDecimals} />
+        ),
+      },
+      {
+        key: 'price',
+        label: stringGetter({ key: STRING_KEYS.PRICE }),
+        value: renderOrderPrice({ type, price, tickSizeDecimals: tickSizeDecimals ?? 0 }),
+      },
+      {
+        key: 'trigger-price',
+        label: stringGetter({ key: STRING_KEYS.TRIGGER_PRICE_SHORT }),
+        value: triggerPrice
+          ? renderOrderPrice({ price: triggerPrice, tickSizeDecimals: tickSizeDecimals ?? 0 })
+          : undefined,
+      },
+      {
+        key: 'trailing-percent',
+        label: stringGetter({ key: STRING_KEYS.TRAILING_PERCENT }),
+        value: trailingPercent ? (
+          <Output type={OutputType.Percent} value={MustBigNumber(trailingPercent).div(100)} />
+        ) : undefined,
+      },
+      {
+        key: 'time-in-force',
+        label: stringGetter({ key: STRING_KEYS.TIME_IN_FORCE }),
+        value: resources.timeInForceStringKey
+          ? stringGetter({ key: resources.timeInForceStringKey })
+          : undefined,
+      },
+      {
+        key: 'execution',
+        label: stringGetter({ key: STRING_KEYS.EXECUTION }),
+        value: reduceOnly
+          ? stringGetter({ key: STRING_KEYS.REDUCE_ONLY })
+          : postOnly
+            ? stringGetter({ key: STRING_KEYS.POST_ONLY })
+            : '-',
+      },
+      {
+        key: 'good-til',
+        label: stringGetter({ key: STRING_KEYS.GOOD_TIL }),
+        value: renderOrderTime({ timeInMs: expiresAtMilliseconds }),
+      },
+      {
+        key: 'created-at',
+        label: stringGetter({ key: STRING_KEYS.CREATED_AT }),
+        value: renderOrderTime({ timeInMs: createdAtMilliseconds }),
+      },
+    ] satisfies DetailsItem[]
+  ).filter((item) => Boolean(item.value));
 
   const onCancelClick = () => {
     cancelOrder({ orderId });

--- a/src/views/forms/AdjustIsolatedMarginForm.tsx
+++ b/src/views/forms/AdjustIsolatedMarginForm.tsx
@@ -26,6 +26,7 @@ import { getOpenPositionFromId, getSubaccount } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getMarketConfig } from '@/state/perpetualsSelectors';
 
+import { objectEntries } from '@/lib/objectHelpers';
 import { calculatePositionMargin } from '@/lib/tradeData';
 
 type ElementProps = {
@@ -220,7 +221,7 @@ export const AdjustIsolatedMarginForm = ({ marketId }: ElementProps) => {
       />
 
       <$ToggleGroup
-        items={Object.entries(SIZE_PERCENT_OPTIONS).map(([key, value]) => ({
+        items={objectEntries(SIZE_PERCENT_OPTIONS).map(([key, value]) => ({
           label: key,
           value: value.toString(),
         }))}

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -46,6 +46,7 @@ import { getCurrentMarketConfig, getCurrentMarketId } from '@/state/perpetualsSe
 
 import abacusStateManager from '@/lib/abacus';
 import { MustBigNumber } from '@/lib/numbers';
+import { objectEntries } from '@/lib/objectHelpers';
 import { getTradeInputAlert } from '@/lib/tradeData';
 
 import { PlaceOrderButtonAndReceipt } from './TradeForm/PlaceOrderButtonAndReceipt';
@@ -244,7 +245,7 @@ export const ClosePositionForm = ({
       />
 
       <$ToggleGroup
-        items={Object.entries(SIZE_PERCENT_OPTIONS).map(([key, value]) => ({
+        items={objectEntries(SIZE_PERCENT_OPTIONS).map(([key, value]) => ({
           label: key === MAX_KEY ? stringGetter({ key: STRING_KEYS.FULL_CLOSE }) : key,
           value: value.toString(),
         }))}

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -172,7 +172,7 @@ export const TransferForm = ({
       } else {
         const txResponse = await transfer(
           amountBN.toNumber(),
-          recipientAddress as string,
+          recipientAddress!,
           tokensConfigs[asset]?.denom,
           memo ?? undefined
         );

--- a/src/views/menus/useGlobalCommands.tsx
+++ b/src/views/menus/useGlobalCommands.tsx
@@ -39,10 +39,9 @@ export const useGlobalCommands = (): MenuConfig<string, string> => {
   const allPerpetualMarkets = orEmptyObj(useAppSelector(getPerpetualMarkets, shallowEqual));
   const allAssets = orEmptyObj(useAppSelector(getAssets, shallowEqual));
 
-  const joinedPerpetualMarketsAndAssets = Object.values(allPerpetualMarkets).map((market) => ({
-    ...market,
-    ...(market != null ? allAssets[market.assetId] : {}),
-  })) as Array<PerpetualMarket & Asset>;
+  const joinedPerpetualMarketsAndAssets = Object.values(allPerpetualMarkets).map(
+    (market): PerpetualMarket & Asset => Object.assign({}, market, allAssets[market?.assetId] ?? {})
+  );
 
   return [
     {

--- a/src/views/menus/useGlobalCommands.tsx
+++ b/src/views/menus/useGlobalCommands.tsx
@@ -20,6 +20,7 @@ import {
 import { setSelectedTradeLayout } from '@/state/layout';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
+import { safeAssign } from '@/lib/objectHelpers';
 import { orEmptyObj } from '@/lib/typeUtils';
 
 enum LayoutItems {
@@ -40,7 +41,7 @@ export const useGlobalCommands = (): MenuConfig<string, string> => {
   const allAssets = orEmptyObj(useAppSelector(getAssets, shallowEqual));
 
   const joinedPerpetualMarketsAndAssets = Object.values(allPerpetualMarkets).map(
-    (market): PerpetualMarket & Asset => Object.assign({}, market, allAssets[market?.assetId] ?? {})
+    (market): PerpetualMarket & Asset => safeAssign({}, market, allAssets[market?.assetId] ?? {})
   );
 
   return [

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -159,14 +159,16 @@ const getFillsTableColumnDef = ({
         label: stringGetter({ key: STRING_KEYS.ACTION }),
         renderCell: ({ asset, orderSide }) => (
           <$TableCell>
-            <$Side side={orderSide}>
-              {stringGetter({
-                key: {
-                  [OrderSide.BUY]: STRING_KEYS.BUY,
-                  [OrderSide.SELL]: STRING_KEYS.SELL,
-                }[orderSide ?? OrderSide.BUY],
-              })}
-            </$Side>
+            {orderSide && (
+              <$Side side={orderSide}>
+                {stringGetter({
+                  key: {
+                    [OrderSide.BUY]: STRING_KEYS.BUY,
+                    [OrderSide.SELL]: STRING_KEYS.SELL,
+                  }[orderSide],
+                })}
+              </$Side>
+            )}
             <Output type={OutputType.Text} value={asset?.id} />
           </$TableCell>
         ),
@@ -222,9 +224,8 @@ const getFillsTableColumnDef = ({
         columnKey: 'side',
         getCellValue: (row) => row.orderSide,
         label: stringGetter({ key: STRING_KEYS.SIDE }),
-        renderCell: ({ orderSide }) => (
-          <OrderSideTag orderSide={orderSide ?? OrderSide.BUY} size={TagSize.Medium} />
-        ),
+        renderCell: ({ orderSide }) =>
+          orderSide && <OrderSideTag orderSide={orderSide} size={TagSize.Medium} />,
       },
       [FillsTableColumnKey.SideLongShort]: {
         columnKey: 'side',

--- a/src/views/tables/FundingPaymentsTable.tsx
+++ b/src/views/tables/FundingPaymentsTable.tsx
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
-import type { Asset, SubaccountFundingPayment } from '@/constants/abacus';
+import type { Asset, Nullable, SubaccountFundingPayment } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
 
@@ -24,6 +24,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
+import { isTruthy } from '@/lib/isTruthy';
 import { MustBigNumber } from '@/lib/numbers';
 import { getHydratedTradingData } from '@/lib/orders';
 import { getStringsForDateTimeDiff } from '@/lib/timeUtils';
@@ -39,9 +40,9 @@ type StyleProps = {
 };
 
 export type FundingPaymentTableRow = {
-  asset: Asset;
-  stepSizeDecimals: number;
-  tickSizeDecimals: number;
+  asset: Nullable<Asset>;
+  stepSizeDecimals: Nullable<number>;
+  tickSizeDecimals: Nullable<number>;
 } & SubaccountFundingPayment;
 
 export const FundingPaymentsTable = ({
@@ -60,13 +61,14 @@ export const FundingPaymentsTable = ({
   const allPerpetualMarkets = orEmptyObj(useAppSelector(getPerpetualMarkets, shallowEqual));
   const allAssets = orEmptyObj(useAppSelector(getAssets, shallowEqual));
 
-  const fundingPaymentsData = fundingPayments.map((fundingPayment: SubaccountFundingPayment) =>
-    getHydratedTradingData({
-      data: fundingPayment,
-      assets: allAssets,
-      perpetualMarkets: allPerpetualMarkets,
-    })
-  ) as FundingPaymentTableRow[];
+  const fundingPaymentsData = fundingPayments.map(
+    (fundingPayment: SubaccountFundingPayment): FundingPaymentTableRow =>
+      getHydratedTradingData({
+        data: fundingPayment,
+        assets: allAssets,
+        perpetualMarkets: allPerpetualMarkets,
+      })
+  );
 
   return (
     <$Table
@@ -81,7 +83,7 @@ export const FundingPaymentsTable = ({
             getCellValue: (row) => row.marketId,
             label: stringGetter({ key: STRING_KEYS.MARKET }),
             renderCell: ({ asset, marketId }) => (
-              <MarketTableCell asset={asset} marketId={marketId} />
+              <MarketTableCell asset={asset ?? undefined} marketId={marketId} />
             ),
           },
           {
@@ -124,7 +126,7 @@ export const FundingPaymentsTable = ({
                   type={OutputType.Asset}
                   value={Math.abs(positionSize)}
                   fractionDigits={stepSizeDecimals}
-                  tag={asset.id}
+                  tag={asset?.id}
                 />
                 <$Output
                   type={OutputType.Text}
@@ -146,8 +148,8 @@ export const FundingPaymentsTable = ({
               <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
             ),
           },
-        ] as ColumnDef<FundingPaymentTableRow>[]
-      ).filter(Boolean)}
+        ] satisfies Array<false | ColumnDef<FundingPaymentTableRow>>
+      ).filter(isTruthy)}
       slotEmpty={<h4>{stringGetter({ key: STRING_KEYS.FUNDING_PAYMENTS_EMPTY_STATE })}</h4>}
       initialPageSize={initialPageSize}
       withOuterBorder={withOuterBorder}

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -92,7 +92,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 </TableCell>
               ),
             },
-          ] as ColumnDef<MarketData>[])
+          ] satisfies ColumnDef<MarketData>[])
         : ([
             {
               columnKey: 'market',
@@ -189,7 +189,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 />
               ),
             },
-          ] as ColumnDef<MarketData>[]),
+          ] satisfies ColumnDef<MarketData>[]),
     [stringGetter, isTablet]
   );
 
@@ -205,7 +205,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
           compactLayout
           searchPlaceholderKey={STRING_KEYS.SEARCH_MARKETS}
           selectedFilter={filter}
-          filters={marketFilters as MarketFilters[]}
+          filters={marketFilters}
           onChangeFilter={setFilter}
           onSearchTextChange={setSearchFilter}
         />

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -59,24 +59,23 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
   return useMemo(() => {
     const asks = (orderbook?.asks?.toArray() ?? [])
       .map(
-        (row: OrderbookLine, idx: number) =>
-          ({
+        (row: OrderbookLine, idx: number): RowData =>
+          Object.assign({}, row, {
             key: `ask-${idx}`,
-            side: 'ask',
+            side: 'ask' as const,
             mine: subaccountOrderSizeBySideAndPrice[OrderSide.SELL]?.[row.price],
-          }) as RowData
+          })
       )
       .slice(0, maxRowsPerSide);
 
     const bids = (orderbook?.bids?.toArray() ?? [])
       .map(
-        (row: OrderbookLine, idx: number) =>
-          ({
+        (row: OrderbookLine, idx: number): RowData =>
+          Object.assign({}, row, {
             key: `bid-${idx}`,
-            side: 'bid',
+            side: 'bid' as const,
             mine: subaccountOrderSizeBySideAndPrice[OrderSide.BUY]?.[row.price],
-            ...row,
-          }) as RowData
+          })
       )
       .slice(0, maxRowsPerSide);
 
@@ -277,33 +276,28 @@ export const Orderbook = ({
       maxRowsPerSide,
     });
 
-  const data = useMemo(
-    () =>
-      [
-        ...bids.reverse(),
-        {
-          key: 'spread',
-          // TODO - should probably refactor this to not break the lint rule
-          // eslint-disable-next-line react/no-unstable-nested-components
-          slotCustomRow: (props) => (
-            <$SpreadTableRow key="spread" {...props}>
-              <td>
-                <WithTooltip tooltip="spread">
-                  {stringGetter({ key: STRING_KEYS.ORDERBOOK_SPREAD })}
-                </WithTooltip>
-              </td>
-              {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-              <td>
-                <Output type={OutputType.Number} value={spread} fractionDigits={tickSizeDecimals} />
-              </td>
-              <td>{!isTablet && <Output type={OutputType.Percent} value={spreadPercent} />}</td>
-            </$SpreadTableRow>
-          ),
-        } as CustomRowConfig,
-        ...asks,
-      ].reverse(),
-    [asks, bids, spread, spreadPercent, isTablet]
-  );
+  const data = useMemo(() => {
+    const customRow: CustomRowConfig = {
+      key: 'spread',
+      // TODO - should probably refactor this to not break the lint rule
+      // eslint-disable-next-line react/no-unstable-nested-components
+      slotCustomRow: (props) => (
+        <$SpreadTableRow key="spread" {...props}>
+          <td>
+            <WithTooltip tooltip="spread">
+              {stringGetter({ key: STRING_KEYS.ORDERBOOK_SPREAD })}
+            </WithTooltip>
+          </td>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+          <td>
+            <Output type={OutputType.Number} value={spread} fractionDigits={tickSizeDecimals} />
+          </td>
+          <td>{!isTablet && <Output type={OutputType.Percent} value={spreadPercent} />}</td>
+        </$SpreadTableRow>
+      ),
+    };
+    return [...bids.reverse(), customRow, ...asks].reverse();
+  }, [asks, bids, spread, spreadPercent, isTablet, stringGetter, tickSizeDecimals]);
 
   const onRowAction = useCallback(
     (key: Key, row: RowData) => {

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -30,6 +30,7 @@ import { getCurrentMarketConfig, getCurrentMarketOrderbook } from '@/state/perpe
 
 import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { MustBigNumber } from '@/lib/numbers';
+import { safeAssign } from '@/lib/objectHelpers';
 
 import { OrderbookTradesOutput, OrderbookTradesTable } from './OrderbookTradesTable';
 
@@ -60,7 +61,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
     const asks = (orderbook?.asks?.toArray() ?? [])
       .map(
         (row: OrderbookLine, idx: number): RowData =>
-          Object.assign({}, row, {
+          safeAssign({}, row, {
             key: `ask-${idx}`,
             side: 'ask' as const,
             mine: subaccountOrderSizeBySideAndPrice[OrderSide.SELL]?.[row.price],
@@ -71,7 +72,7 @@ const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number 
     const bids = (orderbook?.bids?.toArray() ?? [])
       .map(
         (row: OrderbookLine, idx: number): RowData =>
-          Object.assign({}, row, {
+          safeAssign({}, row, {
             key: `bid-${idx}`,
             side: 'bid' as const,
             mine: subaccountOrderSizeBySideAndPrice[OrderSide.BUY]?.[row.price],

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -73,10 +73,10 @@ export enum OrdersTableColumnKey {
 }
 
 export type OrderTableRow = {
-  asset: Asset;
-  stepSizeDecimals: number;
-  tickSizeDecimals: number;
-  orderSide: OrderSide;
+  asset: Nullable<Asset>;
+  stepSizeDecimals: Nullable<number>;
+  tickSizeDecimals: Nullable<number>;
+  orderSide?: Nullable<OrderSide>;
 } & SubaccountOrder;
 
 const getOrdersTableColumnDef = ({
@@ -102,7 +102,9 @@ const getOrdersTableColumnDef = ({
         columnKey: 'marketId',
         getCellValue: (row) => row.marketId,
         label: stringGetter({ key: STRING_KEYS.MARKET }),
-        renderCell: ({ asset, marketId }) => <MarketTableCell asset={asset} marketId={marketId} />,
+        renderCell: ({ asset, marketId }) => (
+          <MarketTableCell asset={asset ?? undefined} marketId={marketId} />
+        ),
       },
       [OrdersTableColumnKey.Status]: {
         columnKey: 'status',
@@ -130,7 +132,9 @@ const getOrdersTableColumnDef = ({
         columnKey: 'side',
         getCellValue: (row) => row.orderSide,
         label: stringGetter({ key: STRING_KEYS.SIDE }),
-        renderCell: ({ orderSide }) => <OrderSideTag orderSide={orderSide} size={TagSize.Medium} />,
+        renderCell: ({ orderSide }) => (
+          <OrderSideTag orderSide={orderSide ?? OrderSide.BUY} size={TagSize.Medium} />
+        ),
       },
       [OrdersTableColumnKey.AmountFill]: {
         columnKey: 'size',
@@ -147,12 +151,16 @@ const getOrdersTableColumnDef = ({
             <Output
               type={OutputType.Asset}
               value={size}
-              fractionDigits={stepSizeDecimals < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals}
+              fractionDigits={
+                (stepSizeDecimals ?? 0) < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals
+              }
             />
             <Output
               type={OutputType.Asset}
               value={totalFilled}
-              fractionDigits={stepSizeDecimals < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals}
+              fractionDigits={
+                (stepSizeDecimals ?? 0) < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals
+              }
             />
           </TableCell>
         ),
@@ -342,13 +350,14 @@ export const OrdersTable = ({
 
   const ordersData = useMemo(
     () =>
-      orders.map((order: SubaccountOrder) =>
-        getHydratedTradingData({
-          data: order,
-          assets: allAssets,
-          perpetualMarkets: allPerpetualMarkets,
-        })
-      ) as OrderTableRow[],
+      orders.map(
+        (order: SubaccountOrder): OrderTableRow =>
+          getHydratedTradingData({
+            data: order,
+            assets: allAssets,
+            perpetualMarkets: allPerpetualMarkets,
+          })
+      ),
     [orders, allPerpetualMarkets, allAssets]
   );
 
@@ -425,16 +434,17 @@ const $SecondaryColor = styled.span`
   color: var(--color-text-0);
 `;
 
-const $Side = styled.span<{ side: OrderSide }>`
+const $Side = styled.span<{ side?: OrderSide | null }>`
   ${({ side }) =>
-    ({
+    side &&
+    {
       [OrderSide.BUY]: css`
         color: var(--color-positive);
       `,
       [OrderSide.SELL]: css`
         color: var(--color-negative);
       `,
-    })[side]};
+    }[side]};
 `;
 
 const $EmptyIcon = styled(Icon)`

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -43,6 +43,7 @@ import { getAssets } from '@/state/assetsSelectors';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
 import { MustBigNumber, getNumberSign } from '@/lib/numbers';
+import { safeAssign } from '@/lib/objectHelpers';
 import { testFlags } from '@/lib/testFlags';
 import { orEmptyObj } from '@/lib/typeUtils';
 
@@ -428,7 +429,7 @@ export const PositionsTable = ({
   const positionsData = useMemo(
     () =>
       positions.map((position: SubaccountPosition): PositionTableRow => {
-        return Object.assign(
+        return safeAssign(
           {},
           {
             tickSizeDecimals:

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -428,8 +428,6 @@ export const PositionsTable = ({
   const positionsData = useMemo(
     () =>
       positions.map((position: SubaccountPosition): PositionTableRow => {
-        // object splat ... doesn't copy getter defined properties
-        // eslint-disable-next-line prefer-object-spread
         return Object.assign(
           {},
           {


### PR DESCRIPTION
Object literals use satisfies instead of casts and functions returning object literals can just declare a return type for the function rather than using a cast.