### PR TITLE
chore(staking): merge tradingrewardsrehaul + enablestaking flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,8 +84,7 @@ const Content = () => {
   const { dialogAreaRef } = useDialogArea() ?? {};
 
   const showChainTokenPage =
-    complianceState === ComplianceStates.FULL_ACCESS ||
-    (testFlags.tradingRewardsRehaul && testFlags.enableStaking);
+    complianceState === ComplianceStates.FULL_ACCESS || testFlags.enableStaking;
 
   return (
     <>

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -42,8 +42,7 @@ export const HeaderDesktop = () => {
 
   const hasSeenLaunchIncentives = useAppSelector(getHasSeenLaunchIncentives);
   const showChainTokenPage =
-    complianceState === ComplianceStates.FULL_ACCESS ||
-    (testFlags.tradingRewardsRehaul && testFlags.enableStaking);
+    complianceState === ComplianceStates.FULL_ACCESS || testFlags.enableStaking;
 
   const navItems = [
     {

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -48,10 +48,6 @@ class TestFlags {
     return !!this.queryParams.staking;
   }
 
-  get tradingRewardsRehaul() {
-    return !!this.queryParams.tradingrewardsrehaul;
-  }
-
   get referrer() {
     return this.queryParams.utm_source;
   }

--- a/src/pages/token/Token.tsx
+++ b/src/pages/token/Token.tsx
@@ -40,7 +40,7 @@ const Token = () => {
   return (
     <WithSidebar
       sidebar={
-        isTablet || testFlags.tradingRewardsRehaul ? null : (
+        isTablet || testFlags.enableStaking ? null : (
           <$SideBar>
             <$NavigationMenu
               items={[

--- a/src/pages/token/rewards/GovernancePanel.tsx
+++ b/src/pages/token/rewards/GovernancePanel.tsx
@@ -18,7 +18,7 @@ export const GovernancePanel = ({ className }: { className?: string }) => {
   const dispatch = useAppDispatch();
   const { governanceLearnMore } = useURLConfigs();
 
-  const tradingRewardsRehaulEnabled = testFlags.tradingRewardsRehaul;
+  const stakingEnabled = testFlags.enableStaking;
 
   const openKeplrDialog = useCallback(
     () => dispatch(openDialog({ type: DialogTypes.ExternalNavKeplr })),
@@ -29,9 +29,7 @@ export const GovernancePanel = ({ className }: { className?: string }) => {
     <RewardsNavPanel
       title={stringGetter({ key: STRING_KEYS.GOVERNANCE })}
       description={stringGetter({
-        key: tradingRewardsRehaulEnabled
-          ? STRING_KEYS.GOVERNANCE_DETAILS
-          : STRING_KEYS.GOVERNANCE_DESCRIPTION,
+        key: stakingEnabled ? STRING_KEYS.GOVERNANCE_DETAILS : STRING_KEYS.GOVERNANCE_DESCRIPTION,
       })}
       learnMore={governanceLearnMore}
       onNav={openKeplrDialog}

--- a/src/pages/token/rewards/NewMarketsPanel.tsx
+++ b/src/pages/token/rewards/NewMarketsPanel.tsx
@@ -30,7 +30,7 @@ export const NewMarketsPanel = ({ className }: { className?: string }) => {
     Number(`1e${chainTokenDecimals}`)
   );
 
-  const tradingRewardsRehaulEnabled = testFlags.tradingRewardsRehaul;
+  const stakingEnabled = testFlags.enableStaking;
   const navToMarket = useCallback(
     () => navigate(`${AppRoute.Markets}/${MarketsRoute.New}`),
     [navigate]
@@ -39,10 +39,10 @@ export const NewMarketsPanel = ({ className }: { className?: string }) => {
   if (!hasPotentialMarketsData) return null;
 
   const description = stringGetter({
-    key: tradingRewardsRehaulEnabled
+    key: stakingEnabled
       ? STRING_KEYS.ADD_NEW_MARKET_DETAILS
       : STRING_KEYS.NEW_MARKET_REWARDS_ENTRY_DESCRIPTION,
-    params: tradingRewardsRehaulEnabled
+    params: stakingEnabled
       ? {
           AMOUNT: (
             <$Output
@@ -70,11 +70,11 @@ export const NewMarketsPanel = ({ className }: { className?: string }) => {
   return (
     <RewardsNavPanel
       title={stringGetter({
-        key: tradingRewardsRehaulEnabled
+        key: stakingEnabled
           ? STRING_KEYS.ADD_NEW_MARKET_CAPITALIZED
           : STRING_KEYS.ADD_A_MARKET,
       })}
-      titleTag={tradingRewardsRehaulEnabled ? undefined : stringGetter({ key: STRING_KEYS.NEW })}
+      titleTag={stakingEnabled ? undefined : stringGetter({ key: STRING_KEYS.NEW })}
       description={description}
       onNav={navToMarket}
       className={className}

--- a/src/pages/token/rewards/NewMarketsPanel.tsx
+++ b/src/pages/token/rewards/NewMarketsPanel.tsx
@@ -70,9 +70,7 @@ export const NewMarketsPanel = ({ className }: { className?: string }) => {
   return (
     <RewardsNavPanel
       title={stringGetter({
-        key: stakingEnabled
-          ? STRING_KEYS.ADD_NEW_MARKET_CAPITALIZED
-          : STRING_KEYS.ADD_A_MARKET,
+        key: stakingEnabled ? STRING_KEYS.ADD_NEW_MARKET_CAPITALIZED : STRING_KEYS.ADD_A_MARKET,
       })}
       titleTag={stakingEnabled ? undefined : stringGetter({ key: STRING_KEYS.NEW })}
       description={description}

--- a/src/pages/token/rewards/RewardsHelpPanel.tsx
+++ b/src/pages/token/rewards/RewardsHelpPanel.tsx
@@ -19,7 +19,7 @@ export const RewardsHelpPanel = () => {
   const stringGetter = useStringGetter();
   const { tradingRewardsLearnMore } = useURLConfigs();
 
-  const tradingRewardsRehaulEnabled = testFlags.tradingRewardsRehaul;
+  const stakingEnabled = testFlags.enableStaking;
 
   return (
     <$HelpCard
@@ -57,7 +57,7 @@ export const RewardsHelpPanel = () => {
             header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_QUESTION }),
             content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_ANSWER }),
           },
-          tradingRewardsRehaulEnabled && {
+          stakingEnabled && {
             header: stringGetter({ key: STRING_KEYS.FAQ_WHAT_IS_STAKING_QUESTION }),
             content: stringGetter({
               key: STRING_KEYS.FAQ_WHAT_IS_STAKING_ANSWER,
@@ -70,11 +70,11 @@ export const RewardsHelpPanel = () => {
               },
             }),
           },
-          tradingRewardsRehaulEnabled && {
+          stakingEnabled && {
             header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_STAKE_AND_CLAIM_QUESTION }),
             content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_STAKE_AND_CLAIM_ANSWER }),
           },
-          tradingRewardsRehaulEnabled && {
+          stakingEnabled && {
             header: stringGetter({ key: STRING_KEYS.FAQ_WHAT_ARE_THE_RISKS_OF_STAKING_QUESTION }),
             content: stringGetter({ key: STRING_KEYS.FAQ_WHAT_ARE_THE_RISKS_OF_STAKING_ANSWER }),
           },

--- a/src/pages/token/rewards/RewardsNavPanel.tsx
+++ b/src/pages/token/rewards/RewardsNavPanel.tsx
@@ -38,13 +38,13 @@ export const RewardsNavPanel = ({
   className,
 }: ElementProps & StyleProps) => {
   const stringGetter = useStringGetter();
-  const tradingRewardsRehaulEnabled = testFlags.tradingRewardsRehaul;
+  const stakingEnabled = testFlags.enableStaking;
 
   return (
     <Panel
       className={className}
       slotHeaderContent={
-        <$Title tradingRewardsRehaulEnabled={tradingRewardsRehaulEnabled}>
+        <$Title stakingEnabled={stakingEnabled}>
           {title} {titleTag && <$Tag>{titleTag}</$Tag>}
         </$Title>
       }
@@ -71,12 +71,12 @@ export const RewardsNavPanel = ({
   );
 };
 
-const $Title = styled.h3<{ tradingRewardsRehaulEnabled: boolean }>`
+const $Title = styled.h3<{ stakingEnabled: boolean }>`
   ${layoutMixins.inlineRow}
   font: var(--font-medium-book);
 
-  ${({ tradingRewardsRehaulEnabled }) =>
-    tradingRewardsRehaulEnabled
+  ${({ stakingEnabled }) =>
+    stakingEnabled
       ? css`
           margin-bottom: -1.5rem;
           color: var(--color-text-1);

--- a/src/pages/token/rewards/RewardsPage.tsx
+++ b/src/pages/token/rewards/RewardsPage.tsx
@@ -1,6 +1,7 @@
 import { shallowEqual } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { formatUnits } from 'viem';
 
 import { AccountBalance } from '@/constants/abacus';
 import { ComplianceStates } from '@/constants/compliance';
@@ -46,7 +47,7 @@ const RewardsPage = () => {
   const { isTablet, isNotTablet } = useBreakpoints();
   const { usdcDenom } = useTokenConfigs();
   const usdcDecimals = 24; // hardcoded solution; fix in OTE-390
-  const { enableStaking, tradingRewardsRehaul: tradingRewardsRehaulEnabled } = testFlags;
+  const stakingEnabled = testFlags.enableStaking;
 
   const stakingRewards: AccountBalance[] =
     useAppSelector(getStakingRewards, shallowEqual)?.totalRewards?.toArray() ?? [];
@@ -59,13 +60,12 @@ const RewardsPage = () => {
   }, 0);
 
   const showMigratePanel = import.meta.env.VITE_V3_TOKEN_ADDRESS && isNotTablet;
-  const showGeoblockedPanel =
-    tradingRewardsRehaulEnabled && complianceState !== ComplianceStates.FULL_ACCESS;
-  const showStakingRewardPanel = totalUsdcRewards > 0 && !showGeoblockedPanel && enableStaking;
+  const showGeoblockedPanel = stakingEnabled && complianceState !== ComplianceStates.FULL_ACCESS;
+  const showStakingRewardPanel = totalUsdcRewards > 0 && !showGeoblockedPanel && stakingEnabled;
 
   const stakingRewardPanel = (
     <StakingRewardPanel
-      usdcRewards={MustBigNumber(totalUsdcRewards).div(Number(`1e${usdcDecimals}`))}
+      usdcRewards={MustBigNumber(formatUnits(BigInt(totalUsdcRewards), usdcDecimals))}
     />
   );
   const legalDisclaimer = (
@@ -83,16 +83,16 @@ const RewardsPage = () => {
       <$DetachedSection>
         {showGeoblockedPanel && <GeoblockedPanel />}
         {showStakingRewardPanel && stakingRewardPanel}
-        {enableStaking ? <StakingPanel /> : <DYDXBalancePanel />}
+        {stakingEnabled ? <StakingPanel /> : <DYDXBalancePanel />}
         {/* List of unstaking panels */}
-        {tradingRewardsRehaulEnabled && <TradingRewardsChartPanel />}
+        {stakingEnabled && <TradingRewardsChartPanel />}
         <LaunchIncentivesPanel />
-        {!tradingRewardsRehaulEnabled && <TradingRewardsSummaryPanel />}
-        {tradingRewardsRehaulEnabled && <NewMarketsPanel />}
-        {tradingRewardsRehaulEnabled && <GovernancePanel />}
+        {!stakingEnabled && <TradingRewardsSummaryPanel />}
+        {stakingEnabled && <NewMarketsPanel />}
+        {stakingEnabled && <GovernancePanel />}
         <RewardHistoryPanel />
         <RewardsHelpPanel />
-        {tradingRewardsRehaulEnabled && legalDisclaimer}
+        {stakingEnabled && legalDisclaimer}
       </$DetachedSection>
     </div>
   ) : (
@@ -100,20 +100,20 @@ const RewardsPage = () => {
       {showMigratePanel && <MigratePanel />}
       <$DoubleColumnView>
         <$LeftColumn>
-          {tradingRewardsRehaulEnabled && <TradingRewardsChartPanel />}
+          {stakingEnabled && <TradingRewardsChartPanel />}
           <LaunchIncentivesPanel />
-          {!tradingRewardsRehaulEnabled && <TradingRewardsSummaryPanel />}
+          {!stakingEnabled && <TradingRewardsSummaryPanel />}
           <RewardHistoryPanel />
         </$LeftColumn>
         <$RightColumn>
           {showGeoblockedPanel && <GeoblockedPanel />}
           {showStakingRewardPanel && stakingRewardPanel}
-          {enableStaking ? <StakingPanel /> : <DYDXBalancePanel />}
+          {stakingEnabled ? <StakingPanel /> : <DYDXBalancePanel />}
           {/* List of unstaking panels */}
-          {tradingRewardsRehaulEnabled && <NewMarketsPanel />}
-          {tradingRewardsRehaulEnabled && <GovernancePanel />}
+          {stakingEnabled && <NewMarketsPanel />}
+          {stakingEnabled && <GovernancePanel />}
           <RewardsHelpPanel />
-          {tradingRewardsRehaulEnabled && legalDisclaimer}
+          {stakingEnabled && legalDisclaimer}
         </$RightColumn>
       </$DoubleColumnView>
     </$DetachedSection>


### PR DESCRIPTION
and address follow up from https://github.com/dydxprotocol/v4-web/pull/632#discussion_r1628496812.

merged both into `enableStaking` since they both serve the same purpose.

Tested by rendering token page with `enableStaking` on and off.

