### PR TITLE
fix: update markets fee estimation

### DIFF
--- a/src/hooks/usePerpetualMarketsStats.ts
+++ b/src/hooks/usePerpetualMarketsStats.ts
@@ -1,18 +1,11 @@
 import { useMemo } from 'react';
 
-import { getChainRevenue } from '@/services/numia';
-import { useQuery } from '@tanstack/react-query';
 import { shallowEqual } from 'react-redux';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
-import { wrapAndLogError } from '@/lib/asyncUtils';
 import { isPresent, orEmptyObj } from '@/lib/typeUtils';
-
-const endDate = new Date();
-const startDate = new Date();
-startDate.setDate(startDate.getDate() - 1);
 
 export const usePerpetualMarketsStats = () => {
   const perpetualMarkets = orEmptyObj(useAppSelector(getPerpetualMarkets, shallowEqual));
@@ -21,22 +14,6 @@ export const usePerpetualMarketsStats = () => {
     () => Object.values(perpetualMarkets).filter(isPresent),
     [perpetualMarkets]
   );
-
-  const { data } = useQuery({
-    queryKey: ['chain-revenue', startDate.toISOString(), endDate.toISOString()],
-    queryFn: wrapAndLogError(
-      () =>
-        getChainRevenue({
-          startDate,
-          endDate,
-        }),
-      'usePerpetualMarketsStats getChainRevenue',
-      true
-    ),
-    refetchOnWindowFocus: false,
-    gcTime: 1_000 * 60 * 5, // 5 minutes
-    staleTime: 1_000 * 60 * 10, // 10 minutes
-  });
 
   const stats = useMemo(() => {
     let volume24HUSDC = 0;
@@ -56,17 +33,7 @@ export const usePerpetualMarketsStats = () => {
     };
   }, [markets]);
 
-  const feesEarnedChart = useMemo(
-    () =>
-      data?.map((point, x) => ({
-        x: x + 1,
-        y: point.total,
-      })) ?? [],
-    [data]
-  );
-
   return {
     stats,
-    feesEarnedChart,
   };
 };

--- a/src/hooks/usePerpetualMarketsStats.ts
+++ b/src/hooks/usePerpetualMarketsStats.ts
@@ -38,12 +38,6 @@ export const usePerpetualMarketsStats = () => {
     staleTime: 1_000 * 60 * 10, // 10 minutes
   });
 
-  const feesEarned = useMemo(() => {
-    if (!data) return null;
-
-    return data.reduce((acc, { total }) => acc + total, 0);
-  }, [data]);
-
   const stats = useMemo(() => {
     let volume24HUSDC = 0;
     let openInterestUSDC = 0;
@@ -58,9 +52,9 @@ export const usePerpetualMarketsStats = () => {
     return {
       volume24HUSDC,
       openInterestUSDC,
-      feesEarned,
+      feesEarned: volume24HUSDC * 0.0002, // approximation derived from volume * 2bps
     };
-  }, [markets, feesEarned]);
+  }, [markets]);
 
   const feesEarnedChart = useMemo(
     () =>

--- a/src/hooks/usePerpetualMarketsStats.ts
+++ b/src/hooks/usePerpetualMarketsStats.ts
@@ -7,6 +7,8 @@ import { getPerpetualMarkets } from '@/state/perpetualsSelectors';
 
 import { isPresent, orEmptyObj } from '@/lib/typeUtils';
 
+const FEE_ESTIMATION_MULTIPLIER = 0.0002; // 2bps
+
 export const usePerpetualMarketsStats = () => {
   const perpetualMarkets = orEmptyObj(useAppSelector(getPerpetualMarkets, shallowEqual));
 
@@ -29,7 +31,7 @@ export const usePerpetualMarketsStats = () => {
     return {
       volume24HUSDC,
       openInterestUSDC,
-      feesEarned: volume24HUSDC * 0.0002, // approximation derived from volume * 2bps
+      feesEarned: volume24HUSDC * FEE_ESTIMATION_MULTIPLIER,
     };
   }, [markets]);
 

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -14,7 +14,6 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { Button } from '@/components/Button';
 import { Output, OutputType } from '@/components/Output';
 import { Tag } from '@/components/Tag';
-import { SparklineChart } from '@/components/visx/SparklineChart';
 
 type ExchangeBillboardsProps = {
   className?: string;
@@ -26,7 +25,6 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
 
   const {
     stats: { volume24HUSDC, openInterestUSDC, feesEarned },
-    feesEarnedChart,
   } = usePerpetualMarketsStats();
   return (
     <$MarketBillboardsWrapper>
@@ -53,24 +51,12 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
           tagKey: STRING_KEYS._24H,
           value: feesEarned,
           type: OutputType.CompactFiat,
-          chartData: feesEarnedChart,
           linkLabelKey: STRING_KEYS.LEARN_MORE_ARROW,
           link: `${chainTokenLabel}/${TokenRoute.StakingRewards}`,
           slotLeft: '~',
         },
       ].map(
-        ({
-          key,
-          labelKey,
-          tagKey,
-          value,
-          fractionDigits,
-          type,
-          chartData,
-          link,
-          linkLabelKey,
-          slotLeft,
-        }) => (
+        ({ key, labelKey, tagKey, value, fractionDigits, type, link, linkLabelKey, slotLeft }) => (
           <$BillboardContainer key={key}>
             <$BillboardStat>
               <$BillboardTitle>
@@ -97,18 +83,6 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
                 </$BillboardLink>
               ) : null}
             </$BillboardStat>
-            {chartData ? (
-              <$BillboardChart>
-                <SparklineChart
-                  data={chartData}
-                  xAccessor={(datum) => datum.x}
-                  yAccessor={(datum) => datum.y}
-                  positive
-                />
-              </$BillboardChart>
-            ) : (
-              false
-            )}
           </$BillboardContainer>
         )
       )}
@@ -128,10 +102,6 @@ const $BillboardContainer = styled.div`
   background-color: var(--color-layer-3);
   padding: 1.5rem;
   border-radius: 0.625rem;
-`;
-const $BillboardChart = styled.div`
-  width: 130px;
-  height: 40px;
 `;
 const $BillboardLink = styled(Button)`
   --button-textColor: var(--color-accent);

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -52,7 +52,7 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
           labelKey: STRING_KEYS.EARNED_BY_STAKERS,
           tagKey: STRING_KEYS._24H,
           value: feesEarned,
-          type: OutputType.Fiat,
+          type: OutputType.CompactFiat,
           chartData: feesEarnedChart,
           linkLabelKey: STRING_KEYS.LEARN_MORE_ARROW,
           link: `${chainTokenLabel}/${TokenRoute.StakingRewards}`,


### PR DESCRIPTION
update fee estimation to be 2bps of total volume instead of relying on numia since integration is curr broken. Also removed the chart since it's going to be inaccurate and we're shifting off (and our approximation is not enough data to allow us to render the chart). [context](https://dydx-team.slack.com/archives/C03GKH23YAZ/p1718002439106939)

<img width="1371" alt="Screenshot 2024-06-10 at 11 33 22 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/453a5880-024a-46ae-ae1f-23d676db0542">


<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->


## Components

* `src/views/ExchangeBillboards.tsx`
  * Updated fee output rendering to `compactFiat` since it's an approximation (and weird to see decimals on an approximation)

