### PR TITLE
fix(isolated-margin): show diff state in place order cta

### DIFF
--- a/src/lib/tradeData.ts
+++ b/src/lib/tradeData.ts
@@ -169,6 +169,6 @@ export const getPositionMargin = ({ position }: { position: SubaccountPosition }
   return margin;
 };
 
-export const getTradeStateWithDoubleValuesDiff = (tradeState: Nullable<TradeState<number>>) => {
-  return !!tradeState?.postOrder && tradeState.current !== tradeState.postOrder;
+export const getTradeStateWithDoubleValuesHasDiff = (tradeState: Nullable<TradeState<number>>) => {
+  return !!tradeState && tradeState.current !== tradeState.postOrder;
 };

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -30,7 +30,10 @@ import { getCurrentInput, getInputTradeMarginMode } from '@/state/inputsSelector
 
 import { isTruthy } from '@/lib/isTruthy';
 import { nullIfZero } from '@/lib/numbers';
-import { calculateCrossPositionMargin, getTradeStateWithDoubleValuesDiff } from '@/lib/tradeData';
+import {
+  calculateCrossPositionMargin,
+  getTradeStateWithDoubleValuesHasDiff,
+} from '@/lib/tradeData';
 import { orEmptyObj } from '@/lib/typeUtils';
 
 type ConfirmButtonConfig = {
@@ -88,6 +91,9 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const { fee, price: expectedPrice, reward } = summary ?? {};
 
+  // check if required fields are filled and summary has been calculated
+  const areInputsFilled = fee != null || reward != null;
+
   const renderMarginValue = () => {
     if (marginMode === AbacusMarginMode.cross) {
       const currentCrossMargin = nullIfZero(
@@ -110,7 +116,7 @@ export const PlaceOrderButtonAndReceipt = ({
           type={OutputType.Fiat}
           value={currentCrossMargin}
           newValue={postOrderCrossMargin}
-          withDiff={!!notionalTotal?.postOrder && currentCrossMargin !== postOrderCrossMargin}
+          withDiff={areInputsFilled && currentCrossMargin !== postOrderCrossMargin}
         />
       );
     }
@@ -121,7 +127,7 @@ export const PlaceOrderButtonAndReceipt = ({
         type={OutputType.Fiat}
         value={equity?.current}
         newValue={equity?.postOrder}
-        withDiff={getTradeStateWithDoubleValuesDiff(equity)}
+        withDiff={areInputsFilled && getTradeStateWithDoubleValuesHasDiff(equity)}
       />
     );
   };
@@ -145,7 +151,7 @@ export const PlaceOrderButtonAndReceipt = ({
           type={OutputType.Fiat}
           value={liquidationPrice?.current}
           newValue={liquidationPrice?.postOrder}
-          withDiff={getTradeStateWithDoubleValuesDiff(liquidationPrice)}
+          withDiff={areInputsFilled && getTradeStateWithDoubleValuesHasDiff(liquidationPrice)}
         />
       ),
     },
@@ -162,8 +168,8 @@ export const PlaceOrderButtonAndReceipt = ({
           useGrouping
           type={OutputType.Multiple}
           value={nullIfZero(leverage?.current)}
-          newValue={nullIfZero(leverage?.postOrder)}
-          withDiff={getTradeStateWithDoubleValuesDiff(leverage)}
+          newValue={leverage?.postOrder}
+          withDiff={areInputsFilled && getTradeStateWithDoubleValuesHasDiff(leverage)}
           showSign={ShowSign.None}
         />
       ),


### PR DESCRIPTION
postOrder can be null but if we still want to show that diff state that it's becoming null
<img width="467" alt="Screenshot 2024-06-10 at 4 54 57 PM" src="https://github.com/dydxprotocol/v4-web/assets/9400120/0500d183-9a71-45a1-90ef-df47d10f4e2b">
