### PR TITLE
fix(staking): fix unstaking validator names not showing on initial render

### DIFF
--- a/src/hooks/useStakingValidator.ts
+++ b/src/hooks/useStakingValidator.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 import { groupBy } from 'lodash';
 import { shallowEqual } from 'react-redux';
@@ -30,7 +28,7 @@ export const useStakingValidator = () => {
     }
   );
 
-  const queryFn = useCallback(async () => {
+  const queryFn = async () => {
     const validatorOptions: string[] = [];
     const intersection = validatorWhitelist.filter((delegation) =>
       currentDelegations?.map((d) => d.validator).includes(delegation)
@@ -72,10 +70,10 @@ export const useStakingValidator = () => {
       unbondingValidators: groupBy(unbondingValidators, ({ operatorAddress }) => operatorAddress),
       currentDelegations,
     };
-  }, [validatorWhitelist, getValidators, currentDelegations, unbondingDelegations]);
+  };
 
   const { data } = useQuery({
-    queryKey: ['stakingValidator', selectedNetwork],
+    queryKey: ['stakingValidator', selectedNetwork, currentDelegations, unbondingDelegations],
     queryFn,
     enabled: Boolean(isCompositeClientConnected && validatorWhitelist?.length > 0),
     refetchOnWindowFocus: false,


### PR DESCRIPTION
Originally, initial load never showed validator name + validator icon on unstaking panels. 

Bug was due to `unbondingDelegations` initially being null and the query not re-running when `unbondingDelegations` updated (even though it was a dep in the `callback` it wasn't a dep on the `useQuery` call). Fixed by adding `unbondingDelegations` and `currentDelegations` to `queryKey`. 
- Also removed `useCallback` wrapper since it's effectively not doing anything here.

## Testing
- `?staking=true`: verify names show on unstaking panels when initially linking wallet



https://github.com/dydxprotocol/v4-web/assets/70078372/4a2ab6ac-b544-403b-b08e-05016b4b8463


