### PR TITLE
chore(liquidation-price): use tickSizeDecimals

### DIFF
--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -158,6 +158,7 @@ export const PlaceOrderButtonAndReceipt = ({
         <DiffOutput
           useGrouping
           type={OutputType.Fiat}
+          fractionDigits={tickSizeDecimals}
           value={liquidationPrice?.current}
           newValue={liquidationPrice?.postOrder}
           withDiff={areInputsFilled && getTradeStateWithDoubleValuesHasDiff(liquidationPrice)}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Display full `liquidationPrice` in trade receipt.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<PlaceOrderButtonAndReceipt>`
  * Update `liquidation-price` output to use tickSizeDecimals

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
