### PR TITLE
chore: override post order position margin for full close position on isolated market

### DIFF
--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -1,13 +1,23 @@
+import { AbacusMarginMode } from '@/constants/abacus';
 import { OnboardingState, OnboardingSteps } from '@/constants/account';
 
 import {
+  getCurrentMarketHasOpenIsolatedOrders,
+  getCurrentMarketPositionData,
   getOnboardingGuards,
   getOnboardingState,
   getSubaccountId,
   getUncommittedOrderClientIds,
 } from '@/state/accountSelectors';
 
+import { MustBigNumber } from '@/lib/numbers';
+
 import { createAppSelector } from './appTypes';
+import {
+  getCurrentInput,
+  getInputClosePositionData,
+  getInputTradeMarginMode,
+} from './inputsSelectors';
 
 export const calculateOnboardingStep = createAppSelector(
   [getOnboardingState, getOnboardingGuards],
@@ -104,3 +114,35 @@ export const calculateShouldRenderActionsInPositionsTable = () =>
       return !isAccountViewOnly && hasActionsInColumn;
     }
   );
+
+export const calculateShouldShowIsolatedMarketPostOrderPositionMarginAsZero = createAppSelector(
+  [
+    getCurrentInput,
+    getInputTradeMarginMode,
+    getCurrentMarketHasOpenIsolatedOrders,
+    getInputClosePositionData,
+    getCurrentMarketPositionData,
+  ],
+  (
+    currentInput,
+    marginMode,
+    hasOpenIsolatedOrders,
+    closePositionInputData,
+    currentMarketPosition
+  ) => {
+    const { size: sizeInputData } = closePositionInputData ?? {};
+    const { size } = sizeInputData ?? {};
+    const { size: currentPositionSize } = currentMarketPosition ?? {};
+    const { current: currentSize } = currentPositionSize ?? {};
+    const isFullClose = MustBigNumber(currentSize)
+      .abs()
+      .eq(size ?? 0);
+
+    return (
+      currentInput === 'closePosition' &&
+      marginMode === AbacusMarginMode.isolated &&
+      !hasOpenIsolatedOrders &&
+      isFullClose
+    );
+  }
+);

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -201,10 +201,10 @@ export const getSubaccountOpenOrders = createAppSelector([getSubaccountOrders], 
   )
 );
 
-export const getPendingIsolatedOrders = createAppSelector(
-  [getSubaccountOrders, getExistingOpenPositions, getPerpetualMarkets],
-  (allOrders, allOpenPositions, allMarkets) => {
-    const allValidOrders = (allOrders ?? [])
+export const getOpenIsolatedOrders = createAppSelector(
+  [getSubaccountOrders, getPerpetualMarkets],
+  (allOrders, allMarkets) =>
+    (allOrders ?? [])
       .filter(
         (o) =>
           (o.status === AbacusOrderStatus.open ||
@@ -214,13 +214,23 @@ export const getPendingIsolatedOrders = createAppSelector(
           o.marginMode === AbacusMarginMode.isolated
       )
       // eslint-disable-next-line prefer-object-spread
-      .map((o) => Object.assign({}, o, { assetId: allMarkets?.[o.marketId]?.assetId }));
+      .map((o) => Object.assign({}, o, { assetId: allMarkets?.[o.marketId]?.assetId }))
+);
+
+export const getPendingIsolatedOrders = createAppSelector(
+  [getOpenIsolatedOrders, getExistingOpenPositions],
+  (isolatedOrders, allOpenPositions) => {
     const allOpenPositionAssetIds = new Set(allOpenPositions?.map((p) => p.assetId) ?? []);
     return groupBy(
-      allValidOrders.filter((o) => !allOpenPositionAssetIds.has(o.assetId ?? '')),
+      isolatedOrders.filter((o) => !allOpenPositionAssetIds.has(o.assetId ?? '')),
       (o) => o.marketId
     );
   }
+);
+
+export const getCurrentMarketHasOpenIsolatedOrders = createAppSelector(
+  [getOpenIsolatedOrders, getCurrentMarketId],
+  (openOrders, marketId) => openOrders.some((o) => o.marketId === marketId)
 );
 
 /**

--- a/src/views/CanvasOrderbook/index.tsx
+++ b/src/views/CanvasOrderbook/index.tsx
@@ -5,7 +5,7 @@ import styled, { css } from 'styled-components';
 
 import { Nullable, type PerpetualMarketOrderbookLevel } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
-import { USD_DECIMALS } from '@/constants/numbers';
+import { SMALL_USD_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { ORDERBOOK_HEIGHT, ORDERBOOK_MAX_ROWS_PER_SIDE } from '@/constants/orderbook';
 
 import { useCenterOrderbook } from '@/hooks/Orderbook/useCenterOrderbook';
@@ -104,12 +104,12 @@ export const CanvasOrderbook = forwardRef(
           // avoid scientific notation for when converting small number to string
           dispatch(
             setTradeFormInputs({
-              limitPriceInput: MustBigNumber(price).toFixed(tickSizeDecimals ?? USD_DECIMALS),
+              limitPriceInput: MustBigNumber(price).toFixed(tickSizeDecimals ?? SMALL_USD_DECIMALS),
             })
           );
         }
       },
-      [currentInput]
+      [currentInput, tickSizeDecimals]
     );
 
     const { canvasRef: asksCanvasRef } = useDrawOrderbook({

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -258,6 +258,8 @@ export const ClosePositionForm = ({
     </$InputsColumn>
   );
 
+  const isFullClose = percent === SIZE_PERCENT_OPTIONS[MAX_KEY] || currentSizeBN.eq(size ?? 0);
+
   return (
     <$ClosePositionForm onSubmit={onSubmit} className={className}>
       {!isTablet ? (
@@ -306,6 +308,7 @@ export const ClosePositionForm = ({
             buttonTextStringKey: STRING_KEYS.CLOSE_POSITION,
             buttonAction: ButtonAction.Destroy,
           }}
+          isFullClose={isFullClose}
         />
       </$Footer>
     </$ClosePositionForm>

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -258,8 +258,6 @@ export const ClosePositionForm = ({
     </$InputsColumn>
   );
 
-  const isFullClose = percent === SIZE_PERCENT_OPTIONS[MAX_KEY] || currentSizeBN.eq(size ?? 0);
-
   return (
     <$ClosePositionForm onSubmit={onSubmit} className={className}>
       {!isTablet ? (
@@ -308,7 +306,6 @@ export const ClosePositionForm = ({
             buttonTextStringKey: STRING_KEYS.CLOSE_POSITION,
             buttonAction: ButtonAction.Destroy,
           }}
-          isFullClose={isFullClose}
         />
       </$Footer>
     </$ClosePositionForm>

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -22,12 +22,11 @@ import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
 import { WithTooltip } from '@/components/WithTooltip';
 import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton';
 
-import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import {
-  getCurrentMarketHasOpenIsolatedOrders,
-  getCurrentMarketPositionData,
-  getSubaccountId,
-} from '@/state/accountSelectors';
+  calculateCanAccountTrade,
+  calculateShouldShowIsolatedMarketPostOrderPositionMarginAsZero,
+} from '@/state/accountCalculators';
+import { getCurrentMarketPositionData, getSubaccountId } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
 import { getCurrentInput, getInputTradeMarginMode } from '@/state/inputsSelectors';
@@ -55,7 +54,6 @@ type ElementProps = {
   currentStep?: MobilePlaceOrderSteps;
   showDeposit?: boolean;
   confirmButtonConfig: ConfirmButtonConfig;
-  isFullClose?: boolean;
 };
 
 export const PlaceOrderButtonAndReceipt = ({
@@ -66,7 +64,6 @@ export const PlaceOrderButtonAndReceipt = ({
   currentStep,
   showDeposit,
   confirmButtonConfig,
-  isFullClose,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
   const dispatch = useAppDispatch();
@@ -102,7 +99,9 @@ export const PlaceOrderButtonAndReceipt = ({
   // check if required fields are filled and summary has been calculated
   const areInputsFilled = fee != null || reward != null;
 
-  const hasOpenIsolatedOrders = useAppSelector(getCurrentMarketHasOpenIsolatedOrders);
+  const isIsolatedMarketPostOrderPositionMarginZero = useAppSelector(
+    calculateShouldShowIsolatedMarketPostOrderPositionMarginAsZero
+  );
 
   const renderMarginValue = () => {
     if (marginMode === AbacusMarginMode.cross) {
@@ -131,16 +130,14 @@ export const PlaceOrderButtonAndReceipt = ({
       );
     }
 
-    const isPostOrderPositionMarginZero = isFullClose && !hasOpenIsolatedOrders;
-
     return (
       <DiffOutput
         useGrouping
         type={OutputType.Fiat}
         value={equity?.current}
-        newValue={isPostOrderPositionMarginZero ? null : equity?.postOrder}
+        newValue={isIsolatedMarketPostOrderPositionMarginZero ? null : equity?.postOrder}
         withDiff={
-          isPostOrderPositionMarginZero
+          isIsolatedMarketPostOrderPositionMarginZero
             ? nullIfZero(equity?.current) != null
             : areInputsFilled && getTradeStateWithDoubleValuesHasDiff(equity)
         }

--- a/src/views/tables/Orderbook.tsx
+++ b/src/views/tables/Orderbook.tsx
@@ -6,7 +6,7 @@ import styled, { css, keyframes } from 'styled-components';
 
 import { type OrderbookLine } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
-import { USD_DECIMALS } from '@/constants/numbers';
+import { SMALL_USD_DECIMALS } from '@/constants/numbers';
 import { ORDERBOOK_MAX_ROWS_PER_SIDE } from '@/constants/orderbook';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
@@ -306,12 +306,14 @@ export const Orderbook = ({
       if (currentInput === 'trade' && key !== 'spread' && row?.price) {
         dispatch(
           setTradeFormInputs({
-            limitPriceInput: MustBigNumber(row.price).toFixed(tickSizeDecimals ?? USD_DECIMALS),
+            limitPriceInput: MustBigNumber(row.price).toFixed(
+              tickSizeDecimals ?? SMALL_USD_DECIMALS
+            ),
           })
         );
       }
     },
-    [currentInput]
+    [tickSizeDecimals, currentInput]
   );
 
   const orderbookTableProps = {


### PR DESCRIPTION
when full closing an isolated position, post order position margin should be displayed as zero in the place order receipt

to test:
- open an isolated position
- check close position -> full closing should show position margin going to null
- open an order in the same market
- check close position -> full closing should show similar position margin instead of going to null

![Screenshot 2024-06-12 at 5 13 38 PM](https://github.com/dydxprotocol/v4-web/assets/9400120/e581e13a-7f7d-4f7c-a0b5-8ec05df9a356)
