### PR TITLE
feat(rebalance-wallet): rebalance wallet if usdcBalance is low

### DIFF
--- a/src/constants/account.ts
+++ b/src/constants/account.ts
@@ -51,6 +51,7 @@ export type Hdkey = {
 };
 
 export const AMOUNT_RESERVED_FOR_GAS_USDC = 0.5;
+export const AMOUNT_USDC_BEFORE_REBALANCE = 0.05;
 
 /**
  * @description The number of parentSubaccounts: 0 - 127, 128 is the first childSubaccount

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -72,8 +72,6 @@ export const AccountMenu = () => {
 
   const { showMfaEnrollmentModal } = useMfaEnrollment();
 
-  // const usdcBalance = freeCollateral?.current ?? 0;
-
   const onRecoverKeys = () => {
     dispatch(openDialog({ type: DialogTypes.Onboarding }));
   };

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -15,6 +15,7 @@ import {
   type StringGetterFunction,
 } from '@/constants/localization';
 import { isDev } from '@/constants/networks';
+import { SMALL_USD_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { DydxChainAsset, WalletType, wallets } from '@/constants/wallets';
 
 import { useAccountBalance } from '@/hooks/useAccountBalance';
@@ -60,7 +61,7 @@ export const AccountMenu = () => {
   const onboardingState = useAppSelector(getOnboardingState);
   const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
 
-  const { nativeTokenBalance } = useAccountBalance();
+  const { nativeTokenBalance, usdcBalance } = useAccountBalance();
   const { usdcLabel, chainTokenLabel } = useTokenConfigs();
   const theme = useAppSelector(getAppTheme);
 
@@ -71,7 +72,7 @@ export const AccountMenu = () => {
 
   const { showMfaEnrollmentModal } = useMfaEnrollment();
 
-  const usdcBalance = freeCollateral?.current ?? 0;
+  // const usdcBalance = freeCollateral?.current ?? 0;
 
   const onRecoverKeys = () => {
     dispatch(openDialog({ type: DialogTypes.Onboarding }));
@@ -169,6 +170,24 @@ export const AccountMenu = () => {
                   stringGetter={stringGetter}
                 />
               </div>
+              {isDev && (
+                <div>
+                  <div>
+                    <$label>
+                      {stringGetter({
+                        key: STRING_KEYS.WALLET_BALANCE,
+                        params: { ASSET: usdcLabel },
+                      })}
+                      <AssetIcon symbol="USDC" />
+                    </$label>
+                    <$BalanceOutput
+                      type={OutputType.Asset}
+                      value={usdcBalance}
+                      fractionDigits={SMALL_USD_DECIMALS}
+                    />
+                  </div>
+                </div>
+              )}
               <div>
                 <div>
                   <$label>
@@ -178,7 +197,11 @@ export const AccountMenu = () => {
                     })}
                     <AssetIcon symbol="USDC" />
                   </$label>
-                  <$BalanceOutput type={OutputType.Asset} value={usdcBalance} fractionDigits={2} />
+                  <$BalanceOutput
+                    type={OutputType.Asset}
+                    value={freeCollateral?.current ?? 0}
+                    fractionDigits={USD_DECIMALS}
+                  />
                 </div>
                 <AssetActions
                   asset={DydxChainAsset.USDC}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

Reblance wallet if usdc balance drops below `$0.05`.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<AccountMenu>`
  * Add `Wallet Balance` in AccountMenu when `isDev`
  * <img width="371" alt="Screen Shot 2024-06-13 at 10 29 18 AM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/ee34eb09-151a-4f15-99f7-12762e7e4fac">

## Constants/Types

* `constants/account`
  * add `AMOUNT_USDC_BEFORE_REBALANCE`

## Hooks

* `hooks/useSubaccount`
  * Add `rebalanceWalletFunds` to handle deposits and withdraws

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->

Tested by spending gas and logging the refill

<img width="679" alt="Screen Shot 2024-06-13 at 11 05 45 AM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/01dad431-9fca-4eb1-8d7c-12bc4d8179ce">
