### PR TITLE
fix: fix decimal places on order size/amount in positions + orders table

### DIFF
--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -154,16 +154,12 @@ const getOrdersTableColumnDef = ({
             <Output
               type={OutputType.Asset}
               value={size}
-              fractionDigits={
-                (stepSizeDecimals ?? 0) < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals
-              }
+              fractionDigits={stepSizeDecimals ?? TOKEN_DECIMALS}
             />
             <Output
               type={OutputType.Asset}
               value={totalFilled}
-              fractionDigits={
-                (stepSizeDecimals ?? 0) < TOKEN_DECIMALS ? TOKEN_DECIMALS : stepSizeDecimals
-              }
+              fractionDigits={stepSizeDecimals ?? TOKEN_DECIMALS}
             />
           </TableCell>
         ),

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -76,6 +76,7 @@ type PositionTableRow = {
   fundingRate: Nullable<number>;
   stopLossOrders: SubaccountOrder[];
   takeProfitOrders: SubaccountOrder[];
+  stepSizeDecimals: number;
 } & SubaccountPosition;
 
 const getPositionsTableColumnDef = ({
@@ -192,7 +193,7 @@ const getPositionsTableColumnDef = ({
         getCellValue: (row) => row.notionalTotal?.current,
         label: stringGetter({ key: STRING_KEYS.SIZE }),
         hideOnBreakpoint: MediaQueryKeys.isMobile,
-        renderCell: ({ assetId, size, notionalTotal, tickSizeDecimals }) => (
+        renderCell: ({ assetId, size, notionalTotal, tickSizeDecimals, stepSizeDecimals }) => (
           <TableCell stacked>
             <$OutputSigned
               type={OutputType.Asset}
@@ -200,6 +201,7 @@ const getPositionsTableColumnDef = ({
               tag={assetId}
               showSign={ShowSign.Negative}
               sign={getNumberSign(size?.current)}
+              fractionDigits={stepSizeDecimals}
             />
             <Output
               type={OutputType.Fiat}
@@ -449,6 +451,8 @@ export const PositionsTable = ({
             takeProfitOrders: allTakeProfitOrders.filter(
               (order: SubaccountOrder) => order.marketId === position.id
             ),
+            stepSizeDecimals:
+              perpetualMarkets?.[position.id]?.configs?.stepSizeDecimals ?? TOKEN_DECIMALS,
           },
           position
         );


### PR DESCRIPTION
chatted with brendan and agreed that behavior in fills table was correct - which uses [`stepSizeDecimals`](https://github.com/dydxprotocol/v4-web/blob/main/src/views/tables/FillsTable.tsx#L101)

| Positions Table | Orders Table |
| ---- | ---- | 
| <img width="1387" alt="Screenshot 2024-06-14 at 4 33 08 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/4133e732-c3ca-430c-a759-2fbebe694b94"> | <img width="1381" alt="Screenshot 2024-06-14 at 4 33 15 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/98d98d29-37ec-4aac-b279-70545394df61"> |

---

<!-- Reorder/delete the following sections accordingly: -->

