### PR TITLE
fix: Recently Listed Markets View Sorted by `clobPairId`

### DIFF
--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -6,7 +6,7 @@ export type MarketData = {
   tickSizeDecimals: Nullable<number>;
   oneDaySparkline?: number[];
   isNew?: boolean;
-  listingDate?: Date;
+  clobPairId: number;
 } & PerpetualMarket &
   PerpetualMarket['perpetual'] &
   PerpetualMarket['configs'];
@@ -14,6 +14,7 @@ export type MarketData = {
 export enum MarketSorting {
   GAINERS = 'gainers',
   LOSERS = 'losers',
+  HIGHEST_CLOB_PAIR_ID = 'highest_clob_pair_id',
 }
 
 export enum MarketFilters {

--- a/src/state/perpetualsSelectors.ts
+++ b/src/state/perpetualsSelectors.ts
@@ -49,13 +49,16 @@ export const getMarketIds = (state: RootState) =>
  * @returns clobPairIds of all markets, mapped by marketId.
  */
 export const getPerpetualMarketsClobIds = createAppSelector([getPerpetualMarkets], (markets) => {
-  return Object.entries(markets ?? {}).reduce((acc, [marketId, market]) => {
-    const clobPairId: Nullable<string> = market?.configs?.clobPairId;
-    if (clobPairId !== undefined) {
-      acc[marketId] = Number(clobPairId);
-    }
-    return acc;
-  }, {} as Record<string, number>);
+  return Object.entries(markets ?? {}).reduce(
+    (acc, [marketId, market]) => {
+      const clobPairId: Nullable<string> = market?.configs?.clobPairId;
+      if (clobPairId !== undefined) {
+        acc[marketId] = Number(clobPairId);
+      }
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 });
 
 /**

--- a/src/state/perpetualsSelectors.ts
+++ b/src/state/perpetualsSelectors.ts
@@ -45,6 +45,16 @@ export const getMarketIds = (state: RootState) =>
   Object.keys(getPerpetualMarkets(state) ?? EMPTY_OBJ);
 
 /**
+ * @returns clobPairIds of all markets, mapped by marketId.
+ */
+export const getPerpetualMarketsClobIds = createAppSelector([getPerpetualMarkets], (markets) => {
+  return Object.entries(markets ?? {}).reduce((acc, [marketId, market]) => {
+    acc[marketId] = Number(market?.configs?.clobPairId ?? 0);
+    return acc;
+  }, {} as Record<string, number>);
+});
+
+/**
  * @returns PerpetualMarket data of the market the user is currently viewing
  */
 export const getCurrentMarketData = (state: RootState) => {

--- a/src/state/perpetualsSelectors.ts
+++ b/src/state/perpetualsSelectors.ts
@@ -1,3 +1,4 @@
+import { Nullable } from '@/constants/abacus';
 import { Candle, TradingViewBar } from '@/constants/candles';
 import { EMPTY_ARR, EMPTY_OBJ } from '@/constants/objects';
 
@@ -49,7 +50,10 @@ export const getMarketIds = (state: RootState) =>
  */
 export const getPerpetualMarketsClobIds = createAppSelector([getPerpetualMarkets], (markets) => {
   return Object.entries(markets ?? {}).reduce((acc, [marketId, market]) => {
-    acc[marketId] = Number(market?.configs?.clobPairId ?? 0);
+    const clobPairId: Nullable<string> = market?.configs?.clobPairId;
+    if (clobPairId !== undefined) {
+      acc[marketId] = Number(clobPairId);
+    }
     return acc;
   }, {} as Record<string, number>);
 });

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
-import { MarketFilters, MarketSorting } from '@/constants/markets';
+import { MarketSorting } from '@/constants/markets';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -35,7 +35,7 @@ export const MarketsStats = (props: MarketsStatsProps) => {
             <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
           </$RecentlyListed>
         </$SectionHeader>
-        <MarketsCompactTable filters={MarketFilters.NEW} />
+        <MarketsCompactTable sorting={MarketSorting.HIGHEST_CLOB_PAIR_ID} />
       </$Section>
       <$Section>
         <$SectionHeader>

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -299,17 +299,6 @@ const $RecentlyListed = styled.div`
     text-align: right;
     justify-content: flex-end;
   }
-
-  & > span:first-child {
-    color: var(--color-text-0);
-    font: var(--font-mini-medium);
-  }
-
-  & > span:last-child,
-  & > output:first-child {
-    color: var(--color-text-1);
-    font: var(--font-small-medium);
-  }
 `;
 
 const $InterestOutput = styled(Output)`

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -94,12 +94,12 @@ export const MarketsCompactTable = ({
           ? {
               columnKey: 'listing',
               allowsSorting: false,
-              renderCell: ({isNew}) => (
+              renderCell: ({ isNew }) => (
                 <$DetailsCell>
                   {isNew && (
-                  <$RecentlyListed>
-                  <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
-                  </$RecentlyListed>
+                    <$RecentlyListed>
+                      <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
+                    </$RecentlyListed>
                   )}
                   <Icon iconName={IconName.ChevronRight} />
                 </$DetailsCell>
@@ -150,8 +150,11 @@ export const MarketsCompactTable = ({
           ? marketB.priceChange24HPercent - marketA.priceChange24HPercent
           : marketA.priceChange24HPercent - marketB.priceChange24HPercent;
       };
+
       return filteredMarkets.sort(sortingFunction);
     }
+
+    return filteredMarkets;
   }, [sorting, filteredMarkets]);
 
   return (
@@ -312,11 +315,6 @@ const $RecentlyListed = styled.div`
 const $InterestOutput = styled(Output)`
   color: var(--color-text-0);
   font: var(--font-mini-medium);
-`;
-
-const $RelativeTimeOutput = styled(Output)`
-  color: var(--color-text-1);
-  font: var(--font-small-medium);
 `;
 
 const $NewTag = styled(Tag)`

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -21,6 +21,7 @@ import { Output, OutputType } from '@/components/Output';
 import { Table, type ColumnDef } from '@/components/Table';
 import { AssetTableCell } from '@/components/Table/AssetTableCell';
 import { TableCell } from '@/components/Table/TableCell';
+import { Tag } from '@/components/Tag';
 import { TriangleIndicator } from '@/components/TriangleIndicator';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -89,24 +90,17 @@ export const MarketsCompactTable = ({
             </TableCell>
           ),
         },
-        filters === MarketFilters.NEW
+        sorting === MarketSorting.HIGHEST_CLOB_PAIR_ID
           ? {
               columnKey: 'listing',
               allowsSorting: false,
-              renderCell: ({ listingDate }) => (
+              renderCell: ({isNew}) => (
                 <$DetailsCell>
+                  {isNew && (
                   <$RecentlyListed>
-                    <span>Listed</span>
-                    {listingDate && (
-                      <$RelativeTimeOutput
-                        type={OutputType.RelativeTime}
-                        relativeTimeFormatOptions={{
-                          format: 'singleCharacter',
-                        }}
-                        value={listingDate.getTime()}
-                      />
-                    )}
+                  <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
                   </$RecentlyListed>
+                  )}
                   <Icon iconName={IconName.ChevronRight} />
                 </$DetailsCell>
               ),
@@ -134,31 +128,30 @@ export const MarketsCompactTable = ({
   );
 
   const sortedMarkets = useMemo(() => {
-    const sortingFunction = (marketA: MarketData, marketB: MarketData) => {
-      if (marketA.priceChange24HPercent == null && marketB.priceChange24HPercent == null) {
-        return 0;
-      }
-
-      if (marketA.priceChange24HPercent == null) {
-        return 1;
-      }
-
-      if (marketB.priceChange24HPercent == null) {
-        return -1;
-      }
-
-      return sorting === MarketSorting.GAINERS
-        ? marketB.priceChange24HPercent - marketA.priceChange24HPercent
-        : marketA.priceChange24HPercent - marketB.priceChange24HPercent;
-    };
-
-    if (sorting === MarketSorting.LOSERS) {
-      return filteredMarkets
-        .filter((market) => !!market.priceChange24HPercent && market.priceChange24HPercent < 0)
-        .sort(sortingFunction);
+    if (sorting === MarketSorting.HIGHEST_CLOB_PAIR_ID) {
+      return filteredMarkets.sort((a, b) => b.clobPairId - a.clobPairId);
     }
 
-    return filteredMarkets.sort(sortingFunction);
+    if (sorting === MarketSorting.GAINERS || sorting === MarketSorting.LOSERS) {
+      const sortingFunction = (marketA: MarketData, marketB: MarketData) => {
+        if (marketA.priceChange24HPercent == null && marketB.priceChange24HPercent == null) {
+          return 0;
+        }
+
+        if (marketA.priceChange24HPercent == null) {
+          return 1;
+        }
+
+        if (marketB.priceChange24HPercent == null) {
+          return -1;
+        }
+
+        return sorting === MarketSorting.GAINERS
+          ? marketB.priceChange24HPercent - marketA.priceChange24HPercent
+          : marketA.priceChange24HPercent - marketB.priceChange24HPercent;
+      };
+      return filteredMarkets.sort(sortingFunction);
+    }
   }, [sorting, filteredMarkets]);
 
   return (
@@ -324,4 +317,10 @@ const $InterestOutput = styled(Output)`
 const $RelativeTimeOutput = styled(Output)`
   color: var(--color-text-1);
   font: var(--font-small-medium);
+`;
+
+const $NewTag = styled(Tag)`
+  background-color: var(--color-accent-faded);
+  color: var(--color-accent);
+  text-transform: uppercase;
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

Instead of showing now new markets, show the newest markets. Approximate this by using the markets with the highest `clobPairId`.

<img width="440" alt="Screenshot 2024-06-18 at 15 48 23" src="https://github.com/dydxprotocol/v4-web/assets/3680392/e06cc600-bb86-49dd-80b3-f1d0123059fc">
