### PR TITLE
fix: add back precision to earned by stakers

### DIFF
--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -50,7 +50,7 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
           labelKey: STRING_KEYS.EARNED_BY_STAKERS,
           tagKey: STRING_KEYS._24H,
           value: feesEarned,
-          type: OutputType.CompactFiat,
+          type: OutputType.Fiat,
           linkLabelKey: STRING_KEYS.LEARN_MORE_ARROW,
           link: `${chainTokenLabel}/${TokenRoute.StakingRewards}`,
           slotLeft: '~',


### PR DESCRIPTION
by request [here](https://dydx-team.slack.com/archives/C06EMJW8M63/p1718725737016719)

<img width="472" alt="Screenshot 2024-06-19 at 2 06 48 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/2001b239-dcfc-44c0-8381-d0038ccfd441">
