### PR TITLE
chore: improve order statuses

### DIFF
--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -155,6 +155,7 @@ export enum PlaceOrderStatuses {
   Submitted,
   Placed,
   Filled,
+  Canceled,
 }
 
 export enum CancelOrderStatuses {

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -152,15 +152,15 @@ export const CLEARED_SIZE_INPUTS = {
 };
 
 export enum PlaceOrderStatuses {
-  Submitted,
-  Placed,
-  Filled,
-  Canceled,
+  Submitted = 0,
+  Placed = 1,
+  Filled = 2,
+  Canceled = 3,
 }
 
 export enum CancelOrderStatuses {
-  Submitted,
-  Canceled,
+  Submitted = 0,
+  Canceled = 1,
 }
 
 export type LocalPlaceOrderData = {

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -624,7 +624,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 />
               ),
             },
-            [localPlace.submissionStatus],
+            [localPlace.submissionStatus, localPlace.errorStringKey],
             true
           );
         }

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -638,6 +638,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
           if (!existingOrder) return;
 
           // share same notification with existing local order if exists
+          // so that canceling a local order will not add an extra notification
           const key = (existingOrder.clientId ?? localCancel.orderId).toString();
 
           trigger(

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -657,7 +657,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 />
               ),
             },
-            [localCancel.submissionStatus],
+            [localCancel.submissionStatus, localCancel.errorStringKey],
             true
           );
         }

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -29,18 +29,19 @@ export const getOrderStatusInfo = ({ status }: { status: string }) => {
       };
     }
     case AbacusOrderStatus.PartiallyFilled.rawValue:
+    case AbacusOrderStatus.PartiallyCanceled.rawValue: {
       return {
         statusIcon: IconName.OrderPartiallyFilled,
         statusIconColor: `var(--color-warning)`,
       };
+    }
     case AbacusOrderStatus.Filled.rawValue: {
       return {
         statusIcon: IconName.OrderFilled,
         statusIconColor: `var(--color-success)`,
       };
     }
-    case AbacusOrderStatus.Canceled.rawValue:
-    case AbacusOrderStatus.PartiallyCanceled.rawValue: {
+    case AbacusOrderStatus.Canceled.rawValue: {
       return {
         statusIcon: IconName.OrderCanceled,
         statusIconColor: `var(--color-error)`,
@@ -69,7 +70,10 @@ export const getOrderStatusInfo = ({ status }: { status: string }) => {
 };
 
 export const isOrderStatusClearable = (status: OrderStatus) =>
-  [AbacusOrderStatus.Filled, AbacusOrderStatus.Canceled, AbacusOrderStatus.PartiallyCanceled].some(
+  status === AbacusOrderStatus.Filled || isOrderStatusCanceled(status);
+
+export const isOrderStatusCanceled = (status: OrderStatus) =>
+  [AbacusOrderStatus.Canceled, AbacusOrderStatus.PartiallyCanceled].some(
     (orderStatus) => status === orderStatus
   );
 

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -242,7 +242,7 @@ export const accountSlice = createSlice({
         hasUnseenOrderUpdates: hasNewOrderUpdates,
         localPlaceOrders: canceledOrderIdsInPayload.length
           ? state.localPlaceOrders.map((order) =>
-              order.submissionStatus < PlaceOrderStatuses.Canceled &&
+              order.submissionStatus !== PlaceOrderStatuses.Canceled &&
               order.orderId &&
               canceledOrderIdsInPayload.includes(order.orderId)
                 ? {

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -236,6 +236,12 @@ export const accountSlice = createSlice({
         .filter((order) => isOrderStatusCanceled(order.status))
         .map((order) => order.id);
 
+      // ignore locally canceled orders since it's intentional and already handled
+      // by local cancel tracking and notification
+      const isOrderCanceledByBackend = (orderId: string) =>
+        canceledOrderIdsInPayload.includes(orderId) &&
+        !state.localCancelOrders.map((order) => order.orderId).includes(orderId);
+
       return {
         ...state,
         subaccount: action.payload,
@@ -244,7 +250,7 @@ export const accountSlice = createSlice({
           ? state.localPlaceOrders.map((order) =>
               order.submissionStatus !== PlaceOrderStatuses.Canceled &&
               order.orderId &&
-              canceledOrderIdsInPayload.includes(order.orderId)
+              isOrderCanceledByBackend(order.orderId)
                 ? {
                     ...order,
                     submissionStatus: PlaceOrderStatuses.Canceled,

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -16,7 +16,12 @@ import {
 import { NUM_PARENT_SUBACCOUNTS, OnboardingState } from '@/constants/account';
 import { LEVERAGE_DECIMALS } from '@/constants/numbers';
 
-import { getHydratedTradingData, isStopLossOrder, isTakeProfitOrder } from '@/lib/orders';
+import {
+  getHydratedTradingData,
+  isOrderStatusClearable,
+  isStopLossOrder,
+  isTakeProfitOrder,
+} from '@/lib/orders';
 import { getHydratedPositionData } from '@/lib/positions';
 
 import { type RootState } from './_store';
@@ -195,10 +200,7 @@ export const getCurrentMarketOrders = createAppSelector(
  * @returns list of orders that have not been filled or cancelled
  */
 export const getSubaccountOpenOrders = createAppSelector([getSubaccountOrders], (orders) =>
-  orders?.filter(
-    (order) =>
-      order.status !== AbacusOrderStatus.Filled && order.status !== AbacusOrderStatus.Canceled
-  )
+  orders?.filter((order) => isOpenOrderStatus(order.status))
 );
 
 export const getOpenIsolatedOrders = createAppSelector(
@@ -498,9 +500,7 @@ export const getCurrentMarketFundingPayments = createAppSelector(
  * @param state
  * @returns boolean on whether an order status is considered open
  */
-const isOpenOrderStatus = (status: AbacusOrderStatuses) => {
-  return status !== AbacusOrderStatus.Filled && status !== AbacusOrderStatus.Canceled;
-};
+const isOpenOrderStatus = (status: AbacusOrderStatuses) => !isOrderStatusClearable(status);
 
 /**
  * @param state

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -214,7 +214,11 @@ export const OrderDetailsDialog = ({ orderId, setIsOpen }: ElementProps) => {
   };
 
   const isShortTermOrder = orderFlags === OrderFlags.SHORT_TERM;
-  const isBestEffortCanceled = status === AbacusOrderStatus.Canceling;
+  // we update short term orders to pending status when they are best effort canceled in Abacus
+  const isBestEffortCanceled =
+    (status === AbacusOrderStatus.Pending && cancelReason != null) ||
+    status === AbacusOrderStatus.Canceling;
+
   const isCancelDisabled = !!isOrderCanceling || (isShortTermOrder && isBestEffortCanceled);
 
   return (

--- a/src/views/notifications/OrderCancelNotification.tsx
+++ b/src/views/notifications/OrderCancelNotification.tsx
@@ -56,7 +56,7 @@ export const OrderCancelNotification = ({
     orderStatusStringKey = isPartiallyCanceled
       ? STRING_KEYS.PARTIALLY_FILLED
       : STRING_KEYS.CANCELED;
-    orderStatusIcon = <$OrderStatusIcon status={indexedOrderStatus} />;
+    orderStatusIcon = <$OrderStatusIcon status={AbacusOrderStatus.Canceled.rawValue} />;
   }
 
   if (localCancel.errorStringKey) {

--- a/src/views/notifications/OrderStatusNotification.tsx
+++ b/src/views/notifications/OrderStatusNotification.tsx
@@ -67,24 +67,33 @@ export const OrderStatusNotification = ({
   switch (submissionStatus) {
     case PlaceOrderStatuses.Placed:
     case PlaceOrderStatuses.Filled:
+    case PlaceOrderStatuses.Canceled:
       if (indexedOrderStatus) {
         // skip pending / best effort open state -> still show as submitted (loading)
         if (indexedOrderStatus === AbacusOrderStatus.Pending.rawValue) break;
 
         orderStatusStringKey = ORDER_STATUS_STRINGS[indexedOrderStatus];
         orderStatusIcon = <$OrderStatusIcon status={indexedOrderStatus} />;
-      }
-      if (order && fill) {
-        customContent = (
-          <FillDetails
-            orderSide={ORDER_SIDES[order.side.name]}
-            tradeType={getTradeType(order.type.rawValue) ?? undefined}
-            filledAmount={order.totalFilled}
-            assetId={assetId}
-            averagePrice={order.price}
-            tickSizeDecimals={marketData?.configs?.displayTickSizeDecimals ?? USD_DECIMALS}
-          />
-        );
+
+        if (order && fill) {
+          customContent = (
+            <FillDetails
+              orderSide={ORDER_SIDES[order.side.name]}
+              tradeType={getTradeType(order.type.rawValue) ?? undefined}
+              filledAmount={order.totalFilled}
+              assetId={assetId}
+              averagePrice={order.price}
+              tickSizeDecimals={marketData?.configs?.displayTickSizeDecimals ?? USD_DECIMALS}
+            />
+          );
+        } else if (
+          indexedOrderStatus === AbacusOrderStatus.Canceled.rawValue &&
+          order?.cancelReason
+        ) {
+          // when there's no fill and has a cancel reason, i.e. just plain canceled
+          const cancelReason = order.cancelReason as keyof typeof STRING_KEYS;
+          customContent = <span>{stringGetter({ key: STRING_KEYS[cancelReason] })}</span>;
+        }
       }
       break;
     case PlaceOrderStatuses.Submitted:


### PR DESCRIPTION
- update PartiallyCanceled order status to use partial fill icon -- the way to differentiate between PartiallyFilled vs PartiallyCanceled is its clear-ability (i.e. the latter is clearable)
- fix clearable orders logic, which fixes open orders count in trade info numbers
- for order status toasts, add a new status `PlaceOrderStatuses.Canceled` -- we want to re-trigger the notif when an order is moved to canceled as well (similar to an error state), with the cancel reason
- also retrigger notif when there's an error string; this should make the notification stay a bit longer when there's an error

<img width="1477" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/c974aba3-33c8-4c49-a8db-d0096452e129">
<img width="464" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/5db4fb37-1c0e-482e-8be5-d4a67b04a5f9">
