### PR TITLE
feat(staking): hydrate validator dropdown with all options

### DIFF
--- a/src/components/ValidatorDropdown.tsx
+++ b/src/components/ValidatorDropdown.tsx
@@ -32,7 +32,7 @@ const ValidatorsDropdownContent = ({
   setIsPopoverOpen,
 }: {
   availableValidators: Validator[];
-  setSelectedValidator: Dispatch<SetStateAction<Validator>>;
+  setSelectedValidator: Dispatch<SetStateAction<Validator | undefined>>;
   setIsPopoverOpen: (isOpen: boolean) => void;
 }) => {
   const stringGetter = useStringGetter();

--- a/src/components/ValidatorDropdown.tsx
+++ b/src/components/ValidatorDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, memo, useCallback, useMemo, useState } from 'react';
+import { Dispatch, Key, SetStateAction, memo, useCallback, useMemo, useState } from 'react';
 
 import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import styled from 'styled-components';
@@ -97,8 +97,11 @@ const ValidatorsDropdownContent = ({
   }, []);
 
   const onRowAction = useCallback(
-    (key: string) => {
-      setSelectedValidator(availableValidators.find((v) => v.operatorAddress === key));
+    (key: Key) => {
+      const newValidator = availableValidators.find((v) => v.operatorAddress === key);
+      if (newValidator) {
+        setSelectedValidator(newValidator);
+      }
       setIsPopoverOpen(false);
     },
     [setSelectedValidator, setIsPopoverOpen, availableValidators]

--- a/src/components/ValidatorDropdown.tsx
+++ b/src/components/ValidatorDropdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, memo, useCallback, useMemo, useState } from 'react';
 
 import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import styled from 'styled-components';
@@ -27,8 +27,12 @@ import { MustBigNumber } from '@/lib/numbers';
 
 const ValidatorsDropdownContent = ({
   availableValidators,
+  setSelectedValidator,
+  setIsPopoverOpen,
 }: {
   availableValidators: Validator[];
+  setSelectedValidator: Dispatch<SetStateAction<Validator>>;
+  setIsPopoverOpen: (isOpen: boolean) => void;
 }) => {
   const stringGetter = useStringGetter();
   const { chainTokenLabel } = useTokenConfigs();
@@ -86,6 +90,14 @@ const ValidatorsDropdownContent = ({
     return validators;
   }, []);
 
+  const onRowAction = useCallback(
+    (key: string) => {
+      setSelectedValidator(availableValidators.find((v) => v.operatorAddress === key));
+      setIsPopoverOpen(false);
+    },
+    [setSelectedValidator, setIsPopoverOpen, availableValidators]
+  );
+
   return (
     <$ScrollArea>
       <$Table
@@ -93,7 +105,7 @@ const ValidatorsDropdownContent = ({
         label="Validators"
         data={filteredValidators}
         getRowKey={(row: ValidatorData) => row.operatorAddress}
-        // onRowAction // TODO: OTE-449
+        onRowAction={onRowAction}
         columns={columns}
         defaultSortDescriptor={{
           column: 'commission',
@@ -116,7 +128,8 @@ const ValidatorsDropdownContent = ({
 };
 
 export const ValidatorDropdown = memo(() => {
-  const { selectedValidator, availableValidators } = useStakingValidator() ?? {};
+  const { availableValidators, selectedValidator, setSelectedValidator } =
+    useStakingValidator() ?? {};
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -130,14 +143,13 @@ export const ValidatorDropdown = memo(() => {
           fallbackText={selectedValidator?.description?.moniker}
         />
       }
-      slotRight={<$DropdownIcon iconName={IconName.Caret} isOpen={isOpen} />}
     />
   );
 
   const slotTrigger = selectedValidator?.description?.website ? (
-    <Link href={selectedValidator?.description?.website} withIcon>
+    <$Link href={selectedValidator?.description?.website} withIcon>
       {output}
-    </Link>
+    </$Link>
   ) : (
     output
   );
@@ -146,13 +158,22 @@ export const ValidatorDropdown = memo(() => {
     <$Popover
       open={isOpen}
       onOpenChange={setIsOpen}
-      slotTrigger={slotTrigger}
+      slotTrigger={
+        <$Trigger>
+          {slotTrigger}
+          <$DropdownIcon iconName={IconName.Caret} isOpen={isOpen} />
+        </$Trigger>
+      }
       triggerType={TriggerType.MarketDropdown}
       align="end"
       sideOffset={8}
       withPortal
     >
-      <ValidatorsDropdownContent availableValidators={availableValidators ?? []} />
+      <ValidatorsDropdownContent
+        availableValidators={availableValidators ?? []}
+        setSelectedValidator={setSelectedValidator}
+        setIsPopoverOpen={setIsOpen}
+      />
     </$Popover>
   );
 });
@@ -176,7 +197,16 @@ const $Table = styled(Table)`
   --tableCell-padding: 0.5rem 1rem;
 ` as typeof Table;
 
+const $Trigger = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
 const $Output = styled(Output)`
+  color: var(--color-text-1);
+`;
+
+const $Link = styled(Link)`
   color: var(--color-text-1);
 `;
 

--- a/src/hooks/useStakingValidator.ts
+++ b/src/hooks/useStakingValidator.ts
@@ -50,9 +50,10 @@ export const useStakingValidator = () => {
     const response = await getValidators();
 
     // Filter out jailed and unbonded validators
-    const availableValidators = response?.validators.filter(
-      (validator: Validator) => validator.status === 3 && validator.jailed === false
-    );
+    const availableValidators =
+      response?.validators.filter(
+        (validator: Validator) => validator.status === 3 && validator.jailed === false
+      ) ?? [];
 
     // Sort validators 1/ in ascending commission and 2/ by descending stake weight
     const sortByCommission = (validatorA: Validator, validatorB: Validator): number => {
@@ -127,7 +128,7 @@ export const useStakingValidator = () => {
     setSelectedValidator,
     availableValidators: data?.availableValidators,
     stakingValidators: data?.stakingValidators,
-    unbondingValidator: data?.unbondingValidator,
+    unbondingValidator: data?.unbondingValidators,
     currentDelegations,
   };
 };

--- a/src/hooks/useStakingValidator.ts
+++ b/src/hooks/useStakingValidator.ts
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 
-import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
+import {
+  BondStatus,
+  Validator,
+} from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import { useQuery } from '@tanstack/react-query';
 import { groupBy } from 'lodash';
 import { shallowEqual } from 'react-redux';
@@ -52,7 +55,8 @@ export const useStakingValidator = () => {
     // Filter out jailed and unbonded validators
     const availableValidators =
       response?.validators.filter(
-        (validator: Validator) => validator.status === 3 && validator.jailed === false
+        (validator: Validator) =>
+          validator.status === BondStatus.BOND_STATUS_BONDED && validator.jailed === false
       ) ?? [];
 
     // Sort validators 1/ in ascending commission and 2/ by descending stake weight
@@ -108,7 +112,6 @@ export const useStakingValidator = () => {
       ) ?? [];
 
     return {
-      validatorWithFewestTokens,
       availableValidators,
       stakingValidators: groupBy(stakingValidators, ({ operatorAddress }) => operatorAddress),
       unbondingValidators: groupBy(unbondingValidators, ({ operatorAddress }) => operatorAddress),

--- a/src/hooks/useStakingValidator.ts
+++ b/src/hooks/useStakingValidator.ts
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+
+import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import { useQuery } from '@tanstack/react-query';
 import { groupBy } from 'lodash';
 import { shallowEqual } from 'react-redux';
@@ -8,6 +11,7 @@ import { getStakingDelegations, getUnbondingDelegations } from '@/state/accountS
 import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
+import { MustBigNumber } from '../lib/numbers';
 import { useDydxClient } from './useDydxClient';
 
 export const useStakingValidator = () => {
@@ -22,6 +26,9 @@ export const useStakingValidator = () => {
       };
     }
   );
+
+  const [selectedValidator, setSelectedValidator] = useState<Validator>();
+
   const validatorWhitelist = ENVIRONMENT_CONFIG_MAP[selectedNetwork].stakingValidators?.map(
     (delegation) => {
       return delegation.toLowerCase();
@@ -42,9 +49,53 @@ export const useStakingValidator = () => {
 
     const response = await getValidators();
 
-    const filteredValidators = response?.validators.filter((validator) =>
+    // Filter out jailed and unbonded validators
+    const availableValidators = response?.validators.filter(
+      (validator: Validator) => validator.status === 3 && validator.jailed === false
+    );
+
+    // Sort validators 1/ in ascending commission and 2/ by descending stake weight
+    const sortByCommission = (validatorA: Validator, validatorB: Validator): number => {
+      return MustBigNumber(validatorA.commission?.commissionRates?.rate ?? 0).gt(
+        MustBigNumber(validatorB.commission?.commissionRates?.rate ?? 0)
+      )
+        ? 1
+        : -1;
+    };
+
+    const sortByCommissionAndStakeWeight = (
+      validatorA: Validator,
+      validatorB: Validator
+    ): number => {
+      if (
+        (validatorA.commission?.commissionRates?.rate ?? 0) ===
+        (validatorB.commission?.commissionRates?.rate ?? 0)
+      ) {
+        return MustBigNumber(validatorA.delegatorShares).gt(
+          MustBigNumber(validatorB.delegatorShares)
+        )
+          ? -1
+          : 1;
+      }
+      return 0;
+    };
+
+    availableValidators.sort(sortByCommission);
+    availableValidators.sort(sortByCommissionAndStakeWeight);
+
+    // Set the default validator to be the validator with the fewest tokens, selected from validators configured in the whitelist
+    const whitelistedValidators = response?.validators.filter((validator) =>
       validatorOptions.includes(validator.operatorAddress.toLowerCase())
     );
+
+    const validatorWithFewestTokens = (whitelistedValidators ?? availableValidators ?? []).reduce(
+      (prev, curr) => {
+        return BigInt(curr.tokens) < BigInt(prev.tokens) ? curr : prev;
+      }
+    );
+
+    setSelectedValidator(validatorWithFewestTokens);
+
     const stakingValidators =
       response?.validators.filter((validator) =>
         currentDelegations?.some((d) => d.validator === validator.operatorAddress.toLowerCase())
@@ -55,31 +106,28 @@ export const useStakingValidator = () => {
         unbondingDelegations?.some((d) => d.validator === validator.operatorAddress.toLowerCase())
       ) ?? [];
 
-    if (!filteredValidators || filteredValidators.length === 0) {
-      return undefined;
-    }
-
-    // Find the validator with the fewest tokens
-    const validatorWithFewestTokens = filteredValidators.reduce((prev, curr) => {
-      return BigInt(curr.tokens) < BigInt(prev.tokens) ? curr : prev;
-    });
-
     return {
-      selectedValidator: validatorWithFewestTokens,
-      availableValidators: filteredValidators, // TODO: OTE-434
+      validatorWithFewestTokens,
+      availableValidators,
       stakingValidators: groupBy(stakingValidators, ({ operatorAddress }) => operatorAddress),
       unbondingValidators: groupBy(unbondingValidators, ({ operatorAddress }) => operatorAddress),
-      currentDelegations,
     };
   };
 
   const { data } = useQuery({
     queryKey: ['stakingValidator', selectedNetwork, currentDelegations, unbondingDelegations],
     queryFn,
-    enabled: Boolean(isCompositeClientConnected && validatorWhitelist?.length > 0),
+    enabled: Boolean(isCompositeClientConnected),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
 
-  return data;
+  return {
+    selectedValidator,
+    setSelectedValidator,
+    availableValidators: data?.availableValidators,
+    stakingValidators: data?.stakingValidators,
+    unbondingValidator: data?.unbondingValidator,
+    currentDelegations,
+  };
 };

--- a/src/hooks/useStakingValidator.ts
+++ b/src/hooks/useStakingValidator.ts
@@ -128,7 +128,7 @@ export const useStakingValidator = () => {
     setSelectedValidator,
     availableValidators: data?.availableValidators,
     stakingValidators: data?.stakingValidators,
-    unbondingValidator: data?.unbondingValidators,
+    unbondingValidators: data?.unbondingValidators,
     currentDelegations,
   };
 };

--- a/src/pages/token/rewards/StakingPanel.tsx
+++ b/src/pages/token/rewards/StakingPanel.tsx
@@ -82,7 +82,7 @@ export const StakingPanel = ({ className }: { className?: string }) => {
             </$label>
             <$BalanceOutput type={OutputType.Asset} value={nativeTokenBalance} />
           </div>
-          {canAccountTrade && selectedValidator && (
+          {canAccountTrade && (
             <div>
               <Button
                 action={ButtonAction.Primary}

--- a/src/pages/token/rewards/StakingPanel.tsx
+++ b/src/pages/token/rewards/StakingPanel.tsx
@@ -8,7 +8,6 @@ import { STRING_KEYS } from '@/constants/localization';
 
 import { useAccountBalance } from '@/hooks/useAccountBalance';
 import { useComplianceState } from '@/hooks/useComplianceState';
-import { useStakingValidator } from '@/hooks/useStakingValidator';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
 
@@ -36,7 +35,6 @@ export const StakingPanel = ({ className }: { className?: string }) => {
   const { complianceState } = useComplianceState();
   const { nativeTokenBalance, nativeStakingBalance } = useAccountBalance();
   const { chainTokenLabel } = useTokenConfigs();
-  const { selectedValidator } = useStakingValidator() ?? {};
 
   const unstakedApr = 16.94; /* OTE-406: Hardcoded for now until I get the APY endpoint working */
   const stakedApr = 16.94; /* OTE-406: Hardcoded for now until I get the APY endpoint working */

--- a/src/views/forms/StakeForm/index.tsx
+++ b/src/views/forms/StakeForm/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
-import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import BigNumber from 'bignumber.js';
 import { type NumberFormatValues } from 'react-number-format';
 import styled from 'styled-components';
@@ -142,6 +141,13 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
     },
   ];
 
+  const openKeplrDialog = () =>
+    dispatch(
+      forceOpenDialog({
+        type: DialogTypes.ExternalNavKeplr,
+      })
+    );
+
   const openStrideDialog = () =>
     dispatch(
       forceOpenDialog({
@@ -192,8 +198,13 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
         />
         <$LegalDisclaimer>
           {stringGetter({
-            key: STRING_KEYS.STAKING_LEGAL_DISCLAIMER_WITH_DEFAULT,
+            key: STRING_KEYS.STAKING_LEGAL_DISCLAIMER,
             params: {
+              KEPLR_DASHBOARD_LINK: (
+                <$Link withIcon onClick={openKeplrDialog}>
+                  {stringGetter({ key: STRING_KEYS.KEPLR_DASHBOARD })}
+                </$Link>
+              ),
               STRIDE_LINK: (
                 <$Link withIcon onClick={openStrideDialog}>
                   Stride
@@ -209,7 +220,6 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
 
 const $Form = styled.form`
   ${formMixins.transfersForm}
-  --color-text-form: var(--color-text-0);
 `;
 
 const $Description = styled.div`
@@ -224,16 +234,14 @@ const $Footer = styled.footer`
   flex-direction: column;
   gap: 1rem;
 `;
-
 const $WithDetailsReceipt = styled(WithDetailsReceipt)`
   --withReceipt-backgroundColor: var(--color-layer-2);
-  color: var(--color-text-form);
 `;
 
 const $LegalDisclaimer = styled.div`
   text-align: center;
   color: var(--color-text-0);
-  font: var(--font-mini-book);
+  font: var(--font-small-book);
 `;
 
 const $Link = styled(Link)`

--- a/src/views/forms/StakeForm/index.tsx
+++ b/src/views/forms/StakeForm/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
+import { Validator } from '@dydxprotocol/v4-client-js/build/node_modules/@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/staking';
 import BigNumber from 'bignumber.js';
 import { type NumberFormatValues } from 'react-number-format';
 import styled from 'styled-components';

--- a/src/views/forms/StakeForm/index.tsx
+++ b/src/views/forms/StakeForm/index.tsx
@@ -141,13 +141,6 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
     },
   ];
 
-  const openKeplrDialog = () =>
-    dispatch(
-      forceOpenDialog({
-        type: DialogTypes.ExternalNavKeplr,
-      })
-    );
-
   const openStrideDialog = () =>
     dispatch(
       forceOpenDialog({
@@ -198,13 +191,8 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
         />
         <$LegalDisclaimer>
           {stringGetter({
-            key: STRING_KEYS.STAKING_LEGAL_DISCLAIMER,
+            key: STRING_KEYS.STAKING_LEGAL_DISCLAIMER_WITH_DEFAULT,
             params: {
-              KEPLR_DASHBOARD_LINK: (
-                <$Link withIcon onClick={openKeplrDialog}>
-                  {stringGetter({ key: STRING_KEYS.KEPLR_DASHBOARD })}
-                </$Link>
-              ),
               STRIDE_LINK: (
                 <$Link withIcon onClick={openStrideDialog}>
                   Stride
@@ -220,6 +208,7 @@ export const StakeForm = ({ onDone, className }: StakeFormProps) => {
 
 const $Form = styled.form`
   ${formMixins.transfersForm}
+  --color-text-form: var(--color-text-0);
 `;
 
 const $Description = styled.div`
@@ -234,14 +223,16 @@ const $Footer = styled.footer`
   flex-direction: column;
   gap: 1rem;
 `;
+
 const $WithDetailsReceipt = styled(WithDetailsReceipt)`
   --withReceipt-backgroundColor: var(--color-layer-2);
+  color: var(--color-text-form);
 `;
 
 const $LegalDisclaimer = styled.div`
   text-align: center;
   color: var(--color-text-0);
-  font: var(--font-small-book);
+  font: var(--font-mini-book);
 `;
 
 const $Link = styled(Link)`


### PR DESCRIPTION
Requirements:
- fetch all validators and filter out any jailed or unbonded validators
- default selection of validator should still be from the preconfigured list in env.json (based on lowest stake weight)
- validators should otherwise be displayed in order of ascending commission and descending stake weight

Added some polishes
- fixed caret rendering before link out icon 

| Dropdown Open | Dropdown Closed |
| ---- | ---- | 
|<img width="552" alt="Screenshot 2024-06-19 at 7 10 38 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/c02b0cf2-5be6-41b8-815a-dbe3aa840bfb"> | <img width="533" alt="Screenshot 2024-06-19 at 7 10 49 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/f8fe30cb-8e0a-47a2-8968-5f9540dc09a4"> |



---

<!-- Reorder/delete the following sections accordingly: -->

## Components

* `StakingPanel`  
  * Updated to not block rendering staking button on whether `selectedValidator` is set; the stake form won't let you submit without a `selectedValidator` anyways

* `ValidatorDropdown`
  * Update to set selected validator on click of the row 


## Hooks

* `hooks/useStakingValidator`
  * Updated to not block query on whether `validatorWhitelist` is a non-empty list given that we now fall back to entire validator list if it is
  * Add state management of `selectedValidator` here and do sorting on validator list here


<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
