### PR TITLE
chore: remove deprecated params [OTE-353]

### DIFF
--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -24,3 +24,4 @@ export enum NumberSign {
 export const MAX_CCTP_TRANSFER_AMOUNT = 1_000_000;
 export const MIN_CCTP_TRANSFER_AMOUNT = 10;
 export const MAX_PRICE_IMPACT = 0.02; // 2%
+export const DEFAULT_GAS_LIMIT = 160000;

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -16,6 +16,7 @@ import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
 import { TransferNotificationTypes } from '@/constants/notifications';
 import {
+  DEFAULT_GAS_LIMIT,
   MAX_CCTP_TRANSFER_AMOUNT,
   MAX_PRICE_IMPACT,
   MIN_CCTP_TRANSFER_AMOUNT,
@@ -213,7 +214,6 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     if (!signerWagmi || !publicClientWagmi) throw new Error('Missing signer');
     if (!sourceToken?.address || !sourceToken.decimals)
       throw new Error('Missing source token address');
-    if (!sourceChain?.rpc) throw new Error('Missing source chain rpc');
     if (!requestPayload?.targetAddress) throw new Error('Missing target address');
     if (!requestPayload?.value) throw new Error('Missing transaction value');
     if (sourceToken?.address === NATIVE_TOKEN_ADDRESS) return;
@@ -259,13 +259,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
         if (!signerWagmi) {
           throw new Error('Missing signer');
         }
-        if (
-          !requestPayload?.targetAddress ||
-          !requestPayload.data ||
-          !requestPayload.value ||
-          !requestPayload.gasLimit ||
-          !requestPayload.routeType
-        ) {
+        if (!requestPayload?.targetAddress || !requestPayload.data || !requestPayload.value) {
           throw new Error('Missing request payload');
         }
 
@@ -280,7 +274,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
         const tx = {
           to: requestPayload.targetAddress as EvmAddress,
           data: requestPayload.data as EvmAddress,
-          gasLimit: BigInt(requestPayload.gasLimit),
+          gasLimit: BigInt(requestPayload.gasLimit || DEFAULT_GAS_LIMIT),
           value: requestPayload.routeType !== 'SEND' ? BigInt(requestPayload.value) : undefined,
         };
         const txHash = await signerWagmi.sendTransaction(tx);

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -371,17 +371,6 @@ export const WithdrawForm = () => {
       };
     }
 
-    if (routeErrors) {
-      return {
-        errorMessage: routeErrorMessage
-          ? stringGetter({
-              key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-              params: { ERROR_MESSAGE: routeErrorMessage },
-            })
-          : stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG }),
-      };
-    }
-
     if (!toAddress) {
       return {
         alertType: AlertType.Warning,
@@ -395,6 +384,17 @@ export const WithdrawForm = () => {
           key: STRING_KEYS.TRANSFER_INVALID_DYDX_ADDRESS,
         }),
       };
+
+    if (routeErrors) {
+      return {
+        errorMessage: routeErrorMessage
+          ? stringGetter({
+              key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
+              params: { ERROR_MESSAGE: routeErrorMessage },
+            })
+          : stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG }),
+      };
+    }
 
     if (debouncedAmountBN) {
       if (!chainIdStr && !exchange) {


### PR DESCRIPTION
QA'd locally - just need to set `Skip` on the onboarding routerVendor configs and it routes to the new vendor seamlessly 😄 

Notes on removed gating params:
- gasFee: We set our gas fee really high - 160,000 gwei is about $1000 USD. happy to decrease this if anyone cares.
- routeType: we still use this value to pick between using the passed in value or undefined. 