### PR TITLE
style(nits): update exchange billboards and stats, assetIcons

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -652,8 +652,15 @@ const assetIcons = {
   ZIL: '/currencies/zil.png',
   ZK: '/currencies/zk.png',
   ZKF: '/currencies/zkf.png',
+  ZRO: '/currencies/zro.png',
   ZRX: '/currencies/zrx.png',
 } as const;
+
+const Placeholder = ({ className, symbol }: { className?: string; symbol: string }) => (
+  <$Placeholder className={className}>
+    <span>{symbol[0]}</span>
+  </$Placeholder>
+);
 
 const isAssetSymbol = (symbol: Nullable<string>): symbol is AssetSymbol =>
   symbol != null && Object.hasOwn(assetIcons, symbol);
@@ -664,15 +671,32 @@ export const AssetIcon = ({
 }: {
   symbol?: Nullable<string>;
   className?: string;
-}) => (
-  <$Img
-    src={isAssetSymbol(symbol) ? assetIcons[symbol] : '/currencies/unavailable.png'}
-    className={className}
-    alt={symbol ?? undefined}
-  />
-);
+}) =>
+  isAssetSymbol(symbol) ? (
+    <$Img src={assetIcons[symbol]} className={className} alt={symbol} />
+  ) : (
+    <Placeholder className={className} symbol={symbol ?? ''} />
+  );
+
 const $Img = styled.img`
   width: auto;
   height: 1em;
   border-radius: 50%;
+`;
+
+const $Placeholder = styled.div`
+  background-color: var(--color-layer-5);
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  overflow: hidden;
+
+  span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 0.5em;
+  }
 `;

--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -93,7 +93,7 @@ export const ExchangeBillboards: React.FC<ExchangeBillboardsProps> = () => {
 
 const $MarketBillboardsWrapper = styled.div`
   ${layoutMixins.column}
-  gap: 1rem;
+  gap: 0.5rem;
 `;
 const $BillboardContainer = styled.div`
   ${layoutMixins.row}
@@ -101,7 +101,7 @@ const $BillboardContainer = styled.div`
   justify-content: space-between;
 
   background-color: var(--color-layer-3);
-  padding: 0.5rem 1.5rem;
+  padding: 1rem 1.5rem;
   border-radius: 0.625rem;
 `;
 const $BillboardLink = styled(Button)`

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -95,7 +95,9 @@ const $NewTag = styled(Tag)`
 `;
 const $ToggleGroupContainer = styled.div`
   ${layoutMixins.row}
-  margin-left: auto;
+  position: absolute;
+  top: 0.8125rem;
+  right: 1rem;
 
   & button {
     --button-toggle-off-backgroundColor: var(--color-layer-3);
@@ -108,11 +110,10 @@ const $ToggleGroupContainer = styled.div`
 `;
 const $SectionHeader = styled.div`
   ${layoutMixins.row}
+  position: relative;
 
-  justify-content: space-between;
-  padding: 0.5rem 1.5rem;
-  gap: 0.375rem;
-  height: 2.5rem;
+  padding: 1rem 1.5rem;
+  gap: 0.25rem;
 
   & h4 {
     font: var(--font-base-medium);


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1529" alt="Screen Shot 2024-06-25 at 1 57 20 PM" src="https://github.com/dydxprotocol/v4-web/assets/13111994/addece1d-19c4-4d42-855b-f2cdc5a766ac">

<!-- Overall purpose of the PR -->
Fix spacing issues on Markets page
---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketStats>`
  * update vertical padding from `0.5rem` -> `1rem`
  * make `toggleContainer` `position: absolute` so the two cards with SectionHeader texts are aligned.

* `<ExchangeBillboards>`
  * update vertical padding from `0.5rem` -> `1rem`

## Components

* `<AssetIcon>`
  * Re-introduce placeholder

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
