### PR TITLE
fix(disconnect-cleanup): set localWallet and hdKey to undefined when disconnecting

### DIFF
--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -78,11 +78,11 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
     this.store = store;
   }
 
-  setHdkey(hdkey: Hdkey) {
+  setHdkey(hdkey?: Hdkey) {
     this.hdkey = hdkey;
   }
 
-  setLocalWallet(localWallet: LocalWallet) {
+  setLocalWallet(localWallet?: LocalWallet) {
     this.localWallet = localWallet;
   }
 

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -78,12 +78,18 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
     this.store = store;
   }
 
-  setHdkey(hdkey?: Hdkey) {
+  setHdkey(hdkey: Hdkey) {
     this.hdkey = hdkey;
   }
 
-  setLocalWallet(localWallet?: LocalWallet) {
+  setLocalWallet(localWallet: LocalWallet) {
     this.localWallet = localWallet;
+  }
+
+  clearAccounts() {
+    this.localWallet = undefined;
+    this.nobleWallet = undefined;
+    this.hdkey = undefined;
   }
 
   setNobleWallet(nobleWallet: LocalWallet) {

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -127,8 +127,7 @@ class AbacusStateManager {
   // ------ Breakdown ------ //
   disconnectAccount = () => {
     this.stateManager.accountAddress = null;
-    this.chainTransactions.setLocalWallet(undefined);
-    this.chainTransactions.setHdkey(undefined);
+    this.chainTransactions.clearAccounts();
   };
 
   attemptDisconnectAccount = () => {

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -127,6 +127,8 @@ class AbacusStateManager {
   // ------ Breakdown ------ //
   disconnectAccount = () => {
     this.stateManager.accountAddress = null;
+    this.chainTransactions.setLocalWallet(undefined);
+    this.chainTransactions.setHdkey(undefined);
   };
 
   attemptDisconnectAccount = () => {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Safeguard to keep dydxChainTranscations and Abacus in sync.

---

<!-- Reorder/delete the following sections accordingly: -->

## Functions

* `lib/dydxChainTransactions`
  * add `clearAccount` fn

* `lib/abacus/index`
  * Update `disconnectAccount` function to include breakdown of chainTransactionsProtocol. 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
