### PR TITLE
fix: analytics property names

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -20,7 +20,7 @@ export type AnalyticsEventTrackMeta<T extends AnalyticsEventTypes> = {
 };
 export type AnalyticsEventIdentifyMeta<T extends AnalyticsUserPropertyTypes> = {
   detail: {
-    property: T;
+    property: (typeof AnalyticsUserPropertyLoggableTypes)[T];
     propertyValue: AnalyticsUserPropertyPayloads[T];
   };
 };
@@ -65,6 +65,18 @@ export const AnalyticsUserProperties = unionize(
   },
   { tag: 'type' as const, value: 'payload' as const }
 );
+
+export const AnalyticsUserPropertyLoggableTypes = {
+  Locale: 'selectedLocale',
+  Breakpoint: 'breakpoint',
+  Version: 'version',
+  Network: 'network',
+  WalletType: 'walletType',
+  WalletConnectionType: 'walletConnectionType',
+  WalletAddress: 'walletAddress',
+  DydxAddress: 'dydxAddress',
+  SubaccountNumber: 'subaccountNumber',
+} as const satisfies Record<AnalyticsUserPropertyTypes, string>;
 
 export type AnalyticsUserProperty = UnionOf<typeof AnalyticsUserProperties>;
 export type AnalyticsUserPropertyTypes = TagsOf<typeof AnalyticsUserProperties>;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import {
+  AnalyticsUserPropertyLoggableTypes,
   customIdentifyEvent,
   customTrackEvent,
   type AnalyticsEvent,
@@ -10,13 +11,15 @@ import { testFlags } from './testFlags';
 const DEBUG_ANALYTICS = false;
 
 export const identify = (property: AnalyticsUserProperty) => {
+  const propertyTypeToLog = AnalyticsUserPropertyLoggableTypes[property.type];
+
   if (DEBUG_ANALYTICS) {
     // eslint-disable-next-line no-console
-    console.log(`[Analytics:Identify] ${property.type}`, property.payload);
+    console.log(`[Analytics:Identify] ${propertyTypeToLog}`, property.payload);
   }
 
   const customEvent = customIdentifyEvent({
-    detail: { property: property.type, propertyValue: property.payload },
+    detail: { property: propertyTypeToLog, propertyValue: property.payload },
   });
 
   globalThis.dispatchEvent(customEvent);


### PR DESCRIPTION
I didn't notice the string literal names in the old enum didn't match the names :( 