### PR TITLE
fix(staking): update button styling on tokens page + add error if wallet balance < gas fees on stake form page

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.8.1",
     "@dydxprotocol/v4-client-js": "^1.1.24",
-    "@dydxprotocol/v4-localization": "^1.1.138",
+    "@dydxprotocol/v4-localization": "^1.1.139",
     "@ethersproject/providers": "^5.7.2",
     "@hugocxl/react-to-image": "^0.0.9",
     "@js-joda/core": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.1.24
     version: 1.1.24
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.138
-    version: 1.1.138
+    specifier: ^1.1.139
+    version: 1.1.139
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -1429,8 +1429,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.138:
-    resolution: {integrity: sha512-Vb52xv7+yg1s6d6pGR41tzdBzaFSTIi6BoREXg5rXndBnBkB1nIC/bSosckj9ZSvcWG1ES9BBxZVQtdJ+iJkZA==}
+  /@dydxprotocol/v4-localization@1.1.139:
+    resolution: {integrity: sha512-DD5tpmelnwwMBh2lt4JjIBrTQv42LN/ZcMHVNxNttXpb2d+KHadYVhkiNsYMw0Rt3/A6srLCRACl+0I4ZjrLBA==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:
@@ -12022,6 +12022,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
+    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}

--- a/src/pages/token/rewards/LaunchIncentivesPanel.tsx
+++ b/src/pages/token/rewards/LaunchIncentivesPanel.tsx
@@ -152,7 +152,7 @@ const LaunchIncentivesContent = () => {
       </$ChaosLabsLogo>
       <$ButtonRow>
         <$AboutButton
-          action={ButtonAction.Base}
+          action={ButtonAction.Secondary}
           onClick={() => {
             dispatch(
               openDialog(
@@ -165,7 +165,7 @@ const LaunchIncentivesContent = () => {
           {stringGetter({ key: STRING_KEYS.ABOUT })}
         </$AboutButton>
         <$LeaderboardButton
-          action={ButtonAction.Primary}
+          action={ButtonAction.Secondary}
           onClick={() => {
             dispatch(
               openDialog(
@@ -230,12 +230,13 @@ const $ButtonRow = styled.div`
 
 const $Button = styled(Button)`
   --button-padding: 0 1rem;
-`;
 
-const $AboutButton = styled($Button)`
   --button-textColor: var(--color-text-2);
   --button-backgroundColor: var(--color-layer-6);
   --button-border: solid var(--border-width) var(--color-layer-7);
+`;
+
+const $AboutButton = styled($Button)`
   flex-grow: 1;
 `;
 

--- a/src/pages/token/rewards/StakingPanel.tsx
+++ b/src/pages/token/rewards/StakingPanel.tsx
@@ -1,7 +1,7 @@
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
-import { ButtonAction, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -18,7 +18,8 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Details } from '@/components/Details';
-import { Icon, IconName } from '@/components/Icon';
+import { IconName } from '@/components/Icon';
+import { IconButton } from '@/components/IconButton';
 import { Link } from '@/components/Link';
 import { Output, OutputType } from '@/components/Output';
 import { Panel } from '@/components/Panel';
@@ -77,14 +78,13 @@ export const StakingPanel = ({ className }: { className?: string }) => {
               {!canAccountTrade ? (
                 <OnboardingTriggerButton size={ButtonSize.Small} />
               ) : (
-                <Button
-                  slotLeft={<Icon iconName={IconName.Send} />}
+                <IconButton
+                  iconName={IconName.Send}
+                  shape={ButtonShape.Square}
                   size={ButtonSize.Small}
-                  action={ButtonAction.Primary}
+                  action={ButtonAction.Base}
                   onClick={() => dispatch(openDialog(DialogTypes.Transfer({})))}
-                >
-                  {stringGetter({ key: STRING_KEYS.TRANSFER })}
-                </Button>
+                />
               )}
             </$ActionButtons>
           )}


### PR DESCRIPTION
by request of dan, [designs](https://www.figma.com/design/dhSd8kkcUrY3UBRsdS89kH/dYdX-%E2%80%BA-Legal?node-id=768-911&t=AheVJQAPXWFNpw1i-0)

| LaunchIncentivesPanel | StakingPanel | StakingForm |
| ----- | ----- | ----- | 
| <img width="859" alt="Screenshot 2024-06-26 at 11 25 00 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/13b541a9-a959-47c1-97f2-a6c4ecbe5f3c"> | <img width="431" alt="Screenshot 2024-06-26 at 11 24 53 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/5c68af2c-e8f9-4359-8629-6b281a83cd05"> | <img width="521" alt="Screenshot 2024-06-26 at 11 33 25 AM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/9ea6850e-8397-4c99-918a-58c0e4da3030"> |


<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `StakeForm`
  * Update error if wallet balance < gas fees and hide max button

## Components

* `LaunchIncentivesPanel`
  * Update leaderboardbutton to be secondary, styling is neither secondary nor base due to panel coloring

* `StakingPanel`
  * Update transferbutton to be an icon button with base styling
## Styles/Mixins

## Packages

* `localization`
  * updated: v1.1.38 -> v1.1.39
  * pulls in copy changes

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
