### PR TITLE
chore: another pass for the markets panels padding

### DIFF
--- a/src/views/ExchangeBillboards.tsx
+++ b/src/views/ExchangeBillboards.tsx
@@ -101,7 +101,7 @@ const $BillboardContainer = styled.div`
   justify-content: space-between;
 
   background-color: var(--color-layer-3);
-  padding: 1rem 1.5rem;
+  padding: 1rem 1.25rem;
   border-radius: 0.625rem;
 `;
 const $BillboardLink = styled(Button)`
@@ -119,12 +119,11 @@ const $BillboardTitle = styled.div`
 const $BillboardStat = styled.div`
   ${layoutMixins.column}
 
-  gap: 0.5rem;
   flex: 1;
 
   label {
     color: var(--color-text-0);
-    font: var(--font-base-medium);
+    font: var(--font-small-medium);
   }
 
   output {

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -82,6 +82,7 @@ const $MarketsStats = styled.section`
 const $Section = styled.div`
   background: var(--color-layer-3);
   border-radius: 0.625rem;
+  align-content: center;
 `;
 const $RecentlyListed = styled.h4`
   display: flex;
@@ -96,9 +97,13 @@ const $NewTag = styled(Tag)`
 const $ToggleGroupContainer = styled.div`
   ${layoutMixins.row}
   position: absolute;
-  top: 0.8125rem;
+  top: -0.25rem;
   right: 1rem;
   z-index: 2;
+
+  @media ${breakpoints.tablet} {
+    top: 0.8125rem;
+  }
 
   & button {
     --button-toggle-off-backgroundColor: var(--color-layer-3);
@@ -113,11 +118,15 @@ const $SectionHeader = styled.div`
   ${layoutMixins.row}
   position: relative;
 
-  padding: 1rem 1.5rem 0;
+  padding: 0 1.25rem 1.25rem;
   gap: 0.25rem;
 
   & h4 {
     font: var(--font-base-medium);
     color: var(--color-text-2);
+  }
+
+  @media ${breakpoints.tablet} {
+    padding: 1rem;
   }
 `;

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -184,11 +184,15 @@ export const MarketsCompactTable = ({
 
 const $Table = styled(Table)`
   ${tradeViewMixins.horizontalTable}
-  --tableCell-padding: 0.625rem 1.5rem;
+  --tableCell-padding: 0.625rem 1.25rem;
   --tableRow-backgroundColor: var(--color-layer-3);
   --tableHeader-backgroundColor: var(--color-layer-3);
   border-bottom-right-radius: 0.625rem;
   border-bottom-left-radius: 0.625rem;
+
+  thead {
+    display: none;
+  }
 
   & table {
     --stickyArea1-background: var(--color-layer-5);


### PR DESCRIPTION
hehe another pass coz the table heading x section header alignment is bugging me
im hiding the table header since that's in the original figma so i think its fine
before:
<img width="1311" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/7994c93c-5791-4e1c-8fbf-31096fd084bd">
<img width="696" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/00bc87a5-3ac1-4fb1-b542-48109f8956bd">

after:
<img width="1312" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/84b854b3-fd94-4ae5-9cb2-58d4b0b02ae9">
<img width="695" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/8281945f-6ab7-442a-9dce-bcf9793577ed">

