### PR TITLE
fix(staking): fix chart not loading properly

### DIFF
--- a/src/views/charts/TradingRewardsChart.tsx
+++ b/src/views/charts/TradingRewardsChart.tsx
@@ -91,18 +91,19 @@ export const TradingRewardsChart = ({
     SELECTED_PERIOD.name
   );
 
-  const rewardsData = useMemo(
-    () =>
-      periodTradingRewards && canViewAccount
-        ? periodTradingRewards.reverse().map(
-            (datum): TradingRewardsDatum => ({
-              date: new Date(datum.endedAtInMilliseconds).valueOf(),
-              cumulativeAmount: datum.cumulativeAmount,
-            })
-          )
-        : [],
-    [periodTradingRewards, canViewAccount]
-  );
+  const rewardsData = useMemo(() => {
+    if (periodTradingRewards && canViewAccount) {
+      const res = periodTradingRewards.map(
+        (datum): TradingRewardsDatum => ({
+          date: new Date(datum.endedAtInMilliseconds).valueOf(),
+          cumulativeAmount: datum.cumulativeAmount,
+        })
+      );
+      res.sort((datumA, datumB) => datumA.date - datumB.date);
+      return res;
+    }
+    return [];
+  }, [periodTradingRewards, canViewAccount]);
 
   const oldestDataPointDate = rewardsData?.[0]?.date;
   const newestDataPointDate = rewardsData?.[rewardsData.length - 1]?.date;


### PR DESCRIPTION
edge case bug where disconnecting/reconnecting on token page didn't show chart properly on initial load
- figured out it was due to `.reverse` being destructive (not v good practice, my bad, also. makes assumptions about data format being returned), replaced with sort 
- i think this bug only started after we updated our abacus data loading? or maybe something else changed 🤷 

<!-- Featured screenshots/recordings -->

### buggy (before)
https://github.com/dydxprotocol/v4-web/assets/70078372/05d1cc40-077c-487d-8ae8-76030cf361a4 

### fixed (after)
https://github.com/dydxprotocol/v4-web/assets/70078372/4df06c76-3e2f-4764-aad7-e3c4b8efdbe5 






