### PR TITLE
chore: observability for skip migration [OTE-432]

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -14,7 +14,6 @@ import {
   CaretIcon,
   CautionCircleIcon,
   CautionCircleStrokeIcon,
-  ChaosLabsIcon,
   ChatIcon,
   CheckCircleIcon,
   CheckIcon,
@@ -47,7 +46,6 @@ import {
   LinkOutIcon,
   ListIcon,
   LockIcon,
-  LogoShortIcon,
   MenuIcon,
   MigrateIcon,
   MintscanIcon,
@@ -88,6 +86,8 @@ import {
   WhitepaperIcon,
   WithdrawIcon,
 } from '@/icons';
+import { ChaosLabsIcon } from '@/icons/chaos-labs';
+import { LogoShortIcon } from '@/icons/logo-short';
 
 export enum IconName {
   AddressConnector = 'AddressConnector',

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -154,6 +154,7 @@ const transferInputFields = [...TransferInputField.values()] as const;
 export type TransferInputFields = (typeof transferInputFields)[number];
 
 export const TransferType = Abacus.exchange.dydx.abacus.output.input.TransferType;
+export type TransferTypeType = Abacus.exchange.dydx.abacus.output.input.TransferType;
 
 export const AdjustIsolatedMarginInputField =
   Abacus.exchange.dydx.abacus.state.model.AdjustIsolatedMarginInputField;

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -221,6 +221,11 @@ export const AnalyticsEvents = unionize(
       amount?: number;
       validatorAddress?: string;
     }>(),
+    Error: ofType<{
+      location: string;
+      error: Error;
+      metadata?: any;
+    }>(),
   },
   { tag: 'type' as const, value: 'payload' as const }
 );

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -226,6 +226,13 @@ export const AnalyticsEvents = unionize(
       error: Error;
       metadata?: any;
     }>(),
+    RouteError: ofType<{
+      transferType: 'deposit' | 'withdrawal' | 'transferOut' | undefined;
+      errorMessage: string | undefined;
+      amount: string;
+      chainId: string | undefined;
+      assetId: string | undefined;
+    }>(),
   },
   { tag: 'type' as const, value: 'payload' as const }
 );

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -227,11 +227,11 @@ export const AnalyticsEvents = unionize(
       metadata?: any;
     }>(),
     RouteError: ofType<{
-      transferType: 'deposit' | 'withdrawal' | 'transferOut' | undefined;
-      errorMessage: string | undefined;
+      transferType?: 'withdrawal' | 'deposit';
+      errorMessage?: string;
       amount: string;
-      chainId: string | undefined;
-      assetId: string | undefined;
+      chainId?: string;
+      assetId?: string;
     }>(),
   },
   { tag: 'type' as const, value: 'payload' as const }

--- a/src/icons/chaos-labs.tsx
+++ b/src/icons/chaos-labs.tsx
@@ -2,7 +2,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { AppTheme } from '@/state/configs';
 import { getAppTheme } from '@/state/configsSelectors';
 
-const ChaosLabsIcon: React.FC = () => {
+export const ChaosLabsIcon: React.FC = () => {
   const appTheme = useAppSelector(getAppTheme);
 
   const fills = appTheme === AppTheme.Light ? ['#1482E5', '#000000'] : ['#1482E5', '#E5E9EB'];
@@ -57,5 +57,3 @@ const ChaosLabsIcon: React.FC = () => {
     </svg>
   );
 };
-
-export default ChaosLabsIcon;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -103,6 +103,8 @@ export { default as WebsiteIcon } from './website.svg';
 export { default as WhitepaperIcon } from './whitepaper.svg';
 
 // Logos
+// Commented out because of https://github.com/dydxprotocol/v4-web/pull/737
+// Left as comment for context in case people wonder why they're not imported here
 // export { default as ChaosLabsIcon } from './chaos-labs';
 // export { default as LogoShortIcon } from './logo-short';
 export { default as EtherscanIcon } from './logos/etherscan.svg';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,3 +1,4 @@
+// TODO: get rid of this massive barrel file.
 export { default as AddressConnectorIcon } from './address-connector.svg';
 export { default as ArrowIcon } from './arrow.svg';
 export { default as Bar3Icon } from './bar3.svg';
@@ -102,8 +103,8 @@ export { default as WebsiteIcon } from './website.svg';
 export { default as WhitepaperIcon } from './whitepaper.svg';
 
 // Logos
-export { default as ChaosLabsIcon } from './chaos-labs';
-export { default as LogoShortIcon } from './logo-short';
+// export { default as ChaosLabsIcon } from './chaos-labs';
+// export { default as LogoShortIcon } from './logo-short';
 export { default as EtherscanIcon } from './logos/etherscan.svg';
 
 // Trade

--- a/src/icons/logo-short.tsx
+++ b/src/icons/logo-short.tsx
@@ -1,6 +1,6 @@
 import { useAppThemeAndColorModeContext } from '@/hooks/useAppThemeAndColorMode';
 
-const LogoShortIcon: React.FC<{ id?: string }> = ({ id }: { id?: string }) => {
+export const LogoShortIcon: React.FC<{ id?: string }> = ({ id }: { id?: string }) => {
   const theme = useAppThemeAndColorModeContext();
   const fill = theme.logoFill;
 
@@ -48,5 +48,3 @@ const LogoShortIcon: React.FC<{ id?: string }> = ({ id }: { id?: string }) => {
     </svg>
   );
 };
-
-export default LogoShortIcon;

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -14,7 +14,8 @@ import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
 import { useURLConfigs } from '@/hooks/useURLConfigs';
 
-import { BellStrokeIcon, LogoShortIcon } from '@/icons';
+import { BellStrokeIcon } from '@/icons';
+import { LogoShortIcon } from '@/icons/logo-short';
 import breakpoints from '@/styles/breakpoints';
 import { headerMixins } from '@/styles/headerMixins';
 import { layoutMixins } from '@/styles/layoutMixins';

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,4 +1,7 @@
+import { AnalyticsEvents } from '@/constants/analytics';
 import { isDev } from '@/constants/networks';
+
+import { track } from './analytics';
 
 export const log = (location: string, error: Error, metadata?: any) => {
   if (isDev) {
@@ -13,6 +16,14 @@ export const log = (location: string, error: Error, metadata?: any) => {
       metadata,
     },
   });
+
+  track(
+    AnalyticsEvents.Error({
+      location,
+      error,
+      metadata,
+    })
+  );
 
   globalThis.dispatchEvent(customEvent);
 };

--- a/src/pages/token/rewards/LaunchIncentivesPanel.tsx
+++ b/src/pages/token/rewards/LaunchIncentivesPanel.tsx
@@ -13,7 +13,7 @@ import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useQueryChaosLabsIncentives } from '@/hooks/useQueryChaosLabsIncentives';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import { ChaosLabsIcon } from '@/icons';
+import { ChaosLabsIcon } from '@/icons/chaos-labs';
 import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
 

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -378,9 +378,9 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
       track(
         AnalyticsEvents.RouteError({
           transferType: TransferType.deposit.name,
-          errorMessage: routeErrorMessage?.toString(),
+          errorMessage: routeErrorMessage ?? undefined,
           amount: debouncedAmount,
-          chainId: chainIdStr?.toString(),
+          chainId: chainIdStr ?? undefined,
           assetId: sourceToken?.toString(),
         })
       );

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -10,7 +10,7 @@ import erc20 from '@/abi/erc20.json';
 import erc20_usdt from '@/abi/erc20_usdt.json';
 import { TransferInputField, TransferInputTokenResource, TransferType } from '@/constants/abacus';
 import { AlertType } from '@/constants/alerts';
-import { AnalyticsEventPayloads } from '@/constants/analytics';
+import { AnalyticsEventPayloads, AnalyticsEvents } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
@@ -49,6 +49,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { getTransferInputs } from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { track } from '@/lib/analytics';
 import { MustBigNumber } from '@/lib/numbers';
 import { getNobleChainId, NATIVE_TOKEN_ADDRESS } from '@/lib/squid';
 import { log } from '@/lib/telemetry';
@@ -374,6 +375,15 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     }
 
     if (routeErrors) {
+      track(
+        AnalyticsEvents.RouteError({
+          transferType: TransferType.deposit.name,
+          errorMessage: routeErrorMessage?.toString(),
+          amount: debouncedAmount,
+          chainId: chainIdStr?.toString(),
+          assetId: sourceToken?.toString(),
+        })
+      );
       return routeErrorMessage
         ? stringGetter({
             key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -396,6 +396,15 @@ export const WithdrawForm = () => {
       };
 
     if (routeErrors) {
+      track(
+        AnalyticsEvents.RouteError({
+          transferType: TransferType.withdrawal.name,
+          errorMessage: routeErrorMessage?.toString(),
+          amount: debouncedAmount,
+          chainId: chainIdStr?.toString(),
+          assetId: toToken?.toString(),
+        })
+      );
       return {
         errorMessage: routeErrorMessage
           ? stringGetter({

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -58,6 +58,7 @@ import { validateCosmosAddress } from '@/lib/addressUtils';
 import { track } from '@/lib/analytics';
 import { MustBigNumber } from '@/lib/numbers';
 import { getNobleChainId } from '@/lib/squid';
+import { log } from '@/lib/telemetry';
 
 import { TokenSelectMenu } from './TokenSelectMenu';
 import { WithdrawButtonAndReceipt } from './WithdrawForm/WithdrawButtonAndReceipt';
@@ -222,6 +223,7 @@ export const WithdrawForm = () => {
           }
         }
       } catch (err) {
+        log('WithdrawForm/onSubmit', err);
         if (err?.code === 429) {
           setError(stringGetter({ key: STRING_KEYS.RATE_LIMIT_REACHED_ERROR_MESSAGE }));
         } else {

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -399,9 +399,9 @@ export const WithdrawForm = () => {
       track(
         AnalyticsEvents.RouteError({
           transferType: TransferType.withdrawal.name,
-          errorMessage: routeErrorMessage?.toString(),
+          errorMessage: routeErrorMessage ?? undefined,
           amount: debouncedAmount,
-          chainId: chainIdStr?.toString(),
+          chainId: chainIdStr ?? undefined,
           assetId: toToken?.toString(),
         })
       );


### PR DESCRIPTION
Adds:
- Error analytics event to every `log` event
- tracks an amplitude error event for every error. we should be able to filter based on location
  - `DepositForm/onSubmit`
  - `WithdrawForm/onSubmit`

- tracks amplitude `routeError` event
  - due to the nature of `errorMessage` being in one giant `useMemo` hook which recalculates more than we want it to, we'lll get duplicate events. **this is expected**. we only want to use this to see if skip or squid has an outsized # of routeError analytics events per user session.


Changes:
- icons.index: we unpack the component svgs `logo-short` and `chaos-labs`.
  -  WHY? well because... telemetry now imports `analytics`, which imports `./dialogs`, which imports `./wallets` which imports `icons`.
  - these icons both use the theme hook, which uses the `state/configs.ts` file, which imports `@/lib/localStorage` which imports `log` from telemetry. this is a somewhat temporary fix as those 2 icons are still circular dependencies waiting to happen (since `log` is still an upstream dependency for them). 
- but we still want to get rid of barrel files anyway, so this should be okay for now

Future changes:
- platform level libs (analytics/etc.) shouldn't be depending on any component level code. so how is this happening? 
  - we use `constants` to contain both value consts and type vars. we're going to want to split these into 2 separate files https://linear.app/dydx/issue/OTE-483/split-types-and-consts-files
