### PR TITLE
feat: proposal for lib/statsig

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --ext .ts,.tsx src/",
     "fix-lint": "eslint --fix --ext .ts,.tsx src/",
     "tag": "node scripts/generate-tag.js",
-    "test": "vitest run",
+    "test": "VITE_DISABLE_STATSIG=true vitest run",
     "tsc": "tsc",
     "postinstall": "tar -xzC public -f tradingview/tradingview.tgz",
     "prepare": "husky",

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -18,6 +18,7 @@ import { getInputTradeData } from '@/state/inputsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { identify, track } from '@/lib/analytics';
+import { StatSigFlags } from '@/lib/statsig';
 import { getSelectedTradeType } from '@/lib/tradeData';
 
 import { useAccounts } from './useAccounts';
@@ -25,7 +26,7 @@ import { useApiState } from './useApiState';
 import { useBreakpoints } from './useBreakpoints';
 import { useDydxClient } from './useDydxClient';
 import { useSelectedNetwork } from './useSelectedNetwork';
-import { StatSigFlags, useStatSigGateValue } from './useStatsig';
+import { useStatSigGateValue } from './useStatsig';
 
 export const useAnalytics = () => {
   const latestTag = import.meta.env.VITE_LAST_TAG;

--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -10,10 +10,11 @@ import { useAccounts } from '@/hooks/useAccounts';
 
 import { track } from '@/lib/analytics';
 import { STATUS_ERROR_GRACE_PERIOD, fetchTransferStatus, trackSkipTx } from '@/lib/squid';
+import { StatSigFlags } from '@/lib/statsig';
 
 import { useEndpointsConfig } from './useEndpointsConfig';
 import { useLocalStorage } from './useLocalStorage';
-import { StatSigFlags, useStatSigGateValue } from './useStatsig';
+import { useStatSigGateValue } from './useStatsig';
 
 const LocalNotificationsContext = createContext<
   ReturnType<typeof useLocalNotificationsContext> | undefined

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -14,7 +14,8 @@ export const StatSigProvider = ({ children }: { children: React.ReactNode }) => 
     };
     setAsyncClient();
   }, [statsigClientPromise]);
-  if (!client) return <>{children}</>;
+  // if no client, render without provider until a client exists
+  if (!client) return <div>{children}</div>;
   return <StatsigProvider client={client}> {children} </StatsigProvider>;
 };
 

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -14,9 +14,7 @@ export const StatSigProvider = ({ children }: { children: React.ReactNode }) => 
     };
     setAsyncClient();
   }, [statsigClientPromise]);
-  // we dont want the app to load until statsig configs have been loaded
-  // this enables us to use statsig on libs which load before the react app
-  if (!client) return null;
+  if (!client) return <>{children}</>;
   return <StatsigProvider client={client}> {children} </StatsigProvider>;
 };
 

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -1,13 +1,21 @@
+import { useEffect, useState } from 'react';
+
+import { StatsigClient } from '@statsig/js-client';
 import { StatsigProvider, useStatsigClient } from '@statsig/react-bindings';
 
-import { StatSigFlags, statsigClient } from '@/lib/statsig';
+import { StatSigFlags, statsigClientPromise } from '@/lib/statsig';
 
 export const StatSigProvider = ({ children }: { children: React.ReactNode }) => {
-  // const client = new StatsigClient(`${import.meta.env.VITE_STATSIG_CLIENT_KEY}`, {
-  //   // TODO: fill in with ip address
-  // });
-  // client.initializeSync();
-  return <StatsigProvider client={statsigClient}> {children} </StatsigProvider>;
+  const [client, setClient] = useState<StatsigClient | null>(null);
+  useEffect(() => {
+    const setAsyncClient = async () => {
+      const statsigClient = await statsigClientPromise;
+      setClient(statsigClient);
+    };
+    setAsyncClient();
+  }, [statsigClientPromise]);
+  if (!client) return <></>;
+  return <StatsigProvider client={client}> {children} </StatsigProvider>;
 };
 
 export const useStatSigGateValue = (gate: StatSigFlags) => {

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -14,7 +14,7 @@ export const StatSigProvider = ({ children }: { children: React.ReactNode }) => 
     };
     setAsyncClient();
   }, [statsigClientPromise]);
-  if (!client) return <></>;
+  if (!client) return null;
   return <StatsigProvider client={client}> {children} </StatsigProvider>;
 };
 

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -14,6 +14,8 @@ export const StatSigProvider = ({ children }: { children: React.ReactNode }) => 
     };
     setAsyncClient();
   }, [statsigClientPromise]);
+  // we dont want the app to load until statsig configs have been loaded
+  // this enables us to use statsig on libs which load before the react app
   if (!client) return null;
   return <StatsigProvider client={client}> {children} </StatsigProvider>;
 };

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -1,18 +1,13 @@
-import { StatsigClient } from '@statsig/js-client';
 import { StatsigProvider, useStatsigClient } from '@statsig/react-bindings';
 
-export enum StatSigFlags {
-  // When adding a flag here, make sure to add an analytics tracker in useAnalytics.ts
-  ffSkipMigration = 'ff_skip_migration',
-}
+import { StatSigFlags, statsigClient } from '@/lib/statsig';
 
 export const StatSigProvider = ({ children }: { children: React.ReactNode }) => {
-  const client = new StatsigClient(`${import.meta.env.VITE_STATSIG_CLIENT_KEY}`, {
-    // TODO: fill in with ip address
-  });
-  client.initializeSync();
-
-  return <StatsigProvider client={client}> {children} </StatsigProvider>;
+  // const client = new StatsigClient(`${import.meta.env.VITE_STATSIG_CLIENT_KEY}`, {
+  //   // TODO: fill in with ip address
+  // });
+  // client.initializeSync();
+  return <StatsigProvider client={statsigClient}> {children} </StatsigProvider>;
 };
 
 export const useStatSigGateValue = (gate: StatSigFlags) => {

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -104,6 +104,18 @@ class AbacusStateManager {
 
     const appConfigs = AbacusAppConfig.Companion.forWebAppWithIsolatedMargins;
     appConfigs.onboardingConfigs.squidVersion = OnboardingConfig.SquidVersion.V2;
+    this.stateManager = new AsyncAbacusStateManager(
+      '',
+      CURRENT_ABACUS_DEPLOYMENT,
+      appConfigs,
+      ioImplementations,
+      uiImplementations,
+      // @ts-ignore
+      this.stateNotifier
+    );
+
+    // Temporary hack to enable statsig flags on abacus.
+    // This works because the statsig provider will refuse to render the application until it generates the client
     statsigCheckGatePromise(StatSigFlags.ffSkipMigration).then((useSkip) => {
       if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
 

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -46,7 +46,7 @@ import { getInputTradeOptions, getTransferInputs } from '@/state/inputsSelectors
 
 import { LocaleSeparators } from '../numbers';
 // eslint-disable-next-line import/no-cycle
-import { StatSigFlags, statsigClientPromise } from '../statsig';
+import { StatSigFlags, statsigCheckGatePromise } from '../statsig';
 import AbacusAnalytics from './analytics';
 import AbacusChainTransaction from './dydxChainTransactions';
 import AbacusFileSystem from './filesystem';
@@ -104,10 +104,9 @@ class AbacusStateManager {
 
     const appConfigs = AbacusAppConfig.Companion.forWebAppWithIsolatedMargins;
     appConfigs.onboardingConfigs.squidVersion = OnboardingConfig.SquidVersion.V2;
-    const useSkip = statsigClientPromise.then((client) =>
-      client.checkGate(StatSigFlags.ffSkipMigration)
-    );
-    if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
+    statsigCheckGatePromise(StatSigFlags.ffSkipMigration).then((useSkip) => {
+      if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
+    });
 
     this.stateManager = new AsyncAbacusStateManager(
       '',

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -45,8 +45,9 @@ import { setTradeFormInputs } from '@/state/inputs';
 import { getInputTradeOptions, getTransferInputs } from '@/state/inputsSelectors';
 
 import { LocaleSeparators } from '../numbers';
-import AbacusAnalytics from './analytics';
 // eslint-disable-next-line import/no-cycle
+import { StatSigFlags, statsigClient } from '../statsig';
+import AbacusAnalytics from './analytics';
 import AbacusChainTransaction from './dydxChainTransactions';
 import AbacusFileSystem from './filesystem';
 import AbacusFormatter from './formatter';
@@ -103,6 +104,8 @@ class AbacusStateManager {
 
     const appConfigs = AbacusAppConfig.Companion.forWebAppWithIsolatedMargins;
     appConfigs.onboardingConfigs.squidVersion = OnboardingConfig.SquidVersion.V2;
+    const useSkip = statsigClient.checkGate(StatSigFlags.ffSkipMigration);
+    if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
 
     this.stateManager = new AsyncAbacusStateManager(
       '',

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -46,7 +46,7 @@ import { getInputTradeOptions, getTransferInputs } from '@/state/inputsSelectors
 
 import { LocaleSeparators } from '../numbers';
 // eslint-disable-next-line import/no-cycle
-import { StatSigFlags, statsigClient } from '../statsig';
+import { StatSigFlags, statsigClientPromise } from '../statsig';
 import AbacusAnalytics from './analytics';
 import AbacusChainTransaction from './dydxChainTransactions';
 import AbacusFileSystem from './filesystem';
@@ -104,7 +104,9 @@ class AbacusStateManager {
 
     const appConfigs = AbacusAppConfig.Companion.forWebAppWithIsolatedMargins;
     appConfigs.onboardingConfigs.squidVersion = OnboardingConfig.SquidVersion.V2;
-    const useSkip = statsigClient.checkGate(StatSigFlags.ffSkipMigration);
+    const useSkip = statsigClientPromise.then((client) =>
+      client.checkGate(StatSigFlags.ffSkipMigration)
+    );
     if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
 
     this.stateManager = new AsyncAbacusStateManager(

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -106,17 +106,17 @@ class AbacusStateManager {
     appConfigs.onboardingConfigs.squidVersion = OnboardingConfig.SquidVersion.V2;
     statsigCheckGatePromise(StatSigFlags.ffSkipMigration).then((useSkip) => {
       if (useSkip) appConfigs.onboardingConfigs.routerVendor = OnboardingConfig.RouterVendor.Skip;
-    });
 
-    this.stateManager = new AsyncAbacusStateManager(
-      '',
-      CURRENT_ABACUS_DEPLOYMENT,
-      appConfigs,
-      ioImplementations,
-      uiImplementations,
-      // @ts-ignore
-      this.stateNotifier
-    );
+      this.stateManager = new AsyncAbacusStateManager(
+        '',
+        CURRENT_ABACUS_DEPLOYMENT,
+        appConfigs,
+        ioImplementations,
+        uiImplementations,
+        // @ts-ignore
+        this.stateNotifier
+      );
+    });
   }
 
   start = ({ network }: { network?: DydxNetwork } = {}) => {

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -4,11 +4,26 @@ const fetchIp = async () => {
   const resp = await fetch('https://api.ipify.org?format=json');
   return resp.json();
 };
-const ip = await fetchIp();
-export const statsigClient = new StatsigClient(import.meta.env.VITE_STATSIG_CLIENT_KEY, {
-  ip,
-});
-await statsigClient.initializeAsync();
+
+const initStatsig = async () => {
+  const statsigClient = new StatsigClient(
+    import.meta.env.VITE_STATSIG_CLIENT_KEY,
+    {},
+    {
+      disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+      disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+    }
+  );
+  if (import.meta.env.VITE_DISABLE_STATSIG) return statsigClient;
+  const ip = await fetchIp();
+  statsigClient.updateUserSync({
+    ip,
+  });
+  await statsigClient.initializeSync();
+  return statsigClient;
+};
+
+export const statsigClient = await initStatsig();
 
 export enum StatSigFlags {
   // When adding a flag here, make sure to add an analytics tracker in useAnalytics.ts

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -5,25 +5,31 @@ const fetchIp = async () => {
   return (await resp.json())?.ip;
 };
 
+let statsigClient: StatsigClient;
+
 const initStatsig = async () => {
-  const statsigClient = new StatsigClient(
+  if (statsigClient) return statsigClient;
+  statsigClient = new StatsigClient(
     import.meta.env.VITE_STATSIG_CLIENT_KEY,
-    {},
+    {
+      ip: await fetchIp(),
+    },
     {
       disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
       disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
     }
   );
   if (import.meta.env.VITE_DISABLE_STATSIG) return statsigClient;
-  const ip = await fetchIp();
-  await statsigClient.updateUserAsync({
-    ip,
-  });
   await statsigClient.initializeSync();
   return statsigClient;
 };
 
 export const statsigClientPromise = initStatsig();
+
+export const statsigCheckGatePromise = async (gateId: StatSigFlags) => {
+  const client = await statsigClientPromise;
+  return client.checkGate(gateId);
+};
 
 export enum StatSigFlags {
   // When adding a flag here, make sure to add an analytics tracker in useAnalytics.ts

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -23,7 +23,7 @@ const initStatsig = async () => {
   return statsigClient;
 };
 
-export const statsigClient = await initStatsig();
+export const statsigClientPromise = initStatsig();
 
 export enum StatSigFlags {
   // When adding a flag here, make sure to add an analytics tracker in useAnalytics.ts

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -2,7 +2,7 @@ import { StatsigClient } from '@statsig/js-client';
 
 const fetchIp = async () => {
   const resp = await fetch('https://api.ipify.org?format=json');
-  return resp.json();
+  return (await resp.json())?.ip;
 };
 
 const initStatsig = async () => {
@@ -16,7 +16,7 @@ const initStatsig = async () => {
   );
   if (import.meta.env.VITE_DISABLE_STATSIG) return statsigClient;
   const ip = await fetchIp();
-  statsigClient.updateUserSync({
+  await statsigClient.updateUserAsync({
     ip,
   });
   await statsigClient.initializeSync();

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,0 +1,16 @@
+import { StatsigClient } from '@statsig/js-client';
+
+const fetchIp = async () => {
+  const resp = await fetch('https://api.ipify.org?format=json');
+  return resp.json();
+};
+const ip = await fetchIp();
+export const statsigClient = new StatsigClient(import.meta.env.VITE_STATSIG_CLIENT_KEY, {
+  ip,
+});
+await statsigClient.initializeAsync();
+
+export enum StatSigFlags {
+  // When adding a flag here, make sure to add an analytics tracker in useAnalytics.ts
+  ffSkipMigration = 'ff_skip_migration',
+}


### PR DESCRIPTION
Proposal 1: use lib/statsig.

Proposal 2: (WIP, link when it's done) convert abacus/index to a hook

builds on @moo-onthelawn 's PR to introduce the concept of a statsig lib.

it's a little weird to have 2 patterns of access for statsig but the idea is that we now have pre-login/pre-render statsig capabilities with the lib while keeping the `useStatsig` hook as the recommended function for component FF'ing