### PR TITLE
chore(memo): clean up memo flag + flip staking to be true in mainnet

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -315,7 +315,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -353,7 +352,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -393,7 +391,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -433,7 +430,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -471,7 +467,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -510,7 +505,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -561,7 +555,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -600,7 +593,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -647,7 +639,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -686,7 +677,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -726,7 +716,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -765,7 +754,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -805,7 +793,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -845,7 +832,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -885,7 +871,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": true,
             "isStakingEnabled": true
          }
       },
@@ -925,8 +910,7 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "showMemoTransferField": false,
-            "isStakingEnabled": false
+            "isStakingEnabled": true
          }
       }
    }

--- a/src/hooks/useEnvFeatures.ts
+++ b/src/hooks/useEnvFeatures.ts
@@ -10,7 +10,6 @@ export interface EnvironmentFeatures {
   CCTPDepositOnly: boolean;
   isSlTpEnabled: boolean;
   isSlTpLimitOrdersEnabled: boolean;
-  showMemoTransferField: boolean;
   isStakingEnabled: boolean;
 }
 

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -62,7 +62,6 @@ export const TransferForm = ({
   className,
 }: TransferFormProps) => {
   const stringGetter = useStringGetter();
-  const { showMemoTransferField } = useEnvFeatures();
 
   const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
   const { dydxAddress } = useAccounts();
@@ -95,7 +94,7 @@ export const TransferForm = ({
   const isUSDCSelected = asset === DydxChainAsset.USDC;
   const amount = isUSDCSelected ? size?.usdcSize : size?.size;
   const showNotEnoughGasWarning = fee && isUSDCSelected && usdcBalance < fee;
-  const showMemoField = showMemoTransferField && isChainTokenSelected;
+  const showMemoField = isChainTokenSelected;
 
   const balance = isUSDCSelected ? freeCollateral?.current : nativeTokenBalance;
 

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -17,7 +17,6 @@ import { DydxChainAsset } from '@/constants/wallets';
 import { useAccountBalance } from '@/hooks/useAccountBalance';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useDydxClient } from '@/hooks/useDydxClient';
-import { useEnvFeatures } from '@/hooks/useEnvFeatures';
 import { useRestrictions } from '@/hooks/useRestrictions';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useSubaccount } from '@/hooks/useSubaccount';


### PR DESCRIPTION
to avoid future misconfigs should try to clean up flags sooner rather than later, and toggle mainnet as soon as safe (can we safely toggle it before then)?