### PR TITLE
feat: compact, consistent asset amount rendering in orderbook + trades

### DIFF
--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -178,7 +178,9 @@ export function formatNumberOutput(
         style: 'decimal',
         notation: 'compact',
         maximumSignificantDigits: 3,
-      }).format(Math.abs(value));
+      })
+        .format(Math.abs(value))
+        .toLowerCase();
     },
     [OutputType.Number]: () => getFormattedVal(valueBN, 0),
     [OutputType.Fiat]: () => getFormattedVal(valueBN, USD_DECIMALS, { prefix: '$' }),
@@ -193,7 +195,9 @@ export function formatNumberOutput(
         currency: 'USD',
         notation: 'compact',
         maximumSignificantDigits: 3,
-      }).format(Math.abs(value));
+      })
+        .format(Math.abs(value))
+        .toLowerCase();
     },
     [OutputType.Asset]: () => getFormattedVal(valueBN, TOKEN_DECIMALS),
     [OutputType.Percent]: () =>

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -178,9 +178,7 @@ export function formatNumberOutput(
         style: 'decimal',
         notation: 'compact',
         maximumSignificantDigits: 3,
-      })
-        .format(Math.abs(value))
-        .toLowerCase();
+      }).format(Math.abs(value));
     },
     [OutputType.Number]: () => getFormattedVal(valueBN, 0),
     [OutputType.Fiat]: () => getFormattedVal(valueBN, USD_DECIMALS, { prefix: '$' }),
@@ -195,9 +193,7 @@ export function formatNumberOutput(
         currency: 'USD',
         notation: 'compact',
         maximumSignificantDigits: 3,
-      })
-        .format(Math.abs(value))
-        .toLowerCase();
+      }).format(Math.abs(value));
     },
     [OutputType.Asset]: () => getFormattedVal(valueBN, TOKEN_DECIMALS),
     [OutputType.Percent]: () =>

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -390,6 +390,7 @@ export const useDrawOrderbook = ({
     theme,
     currentOrderbookMap,
     displayUnit,
+    canvas,
   ]);
 
   return { canvasRef };

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -240,7 +240,7 @@ export const useDrawOrderbook = ({
       formatNumberOutput(sizeToRender, OutputType.Number, {
         decimalSeparator,
         groupSeparator,
-        fractionDigits: tickSizeDecimals,
+        fractionDigits: 0,
       });
 
     // Size text

--- a/src/lib/consistentAssetSize.ts
+++ b/src/lib/consistentAssetSize.ts
@@ -57,7 +57,10 @@ export const getConsistentAssetSizeString = (
       return { displayDivisor: 1, displaySuffix: '' };
     }
     const unitToUse =
-      supportedLocaleToCompactSuffixByPowerOfTen[selectedLocale][Math.log10(stepSize)];
+      supportedLocaleToCompactSuffixByPowerOfTen[selectedLocale][Math.floor(Math.log10(stepSize))];
+    if (unitToUse == null) {
+      return { displayDivisor: 1, displaySuffix: '' };
+    }
     return {
       displayDivisor: 10 ** supportedLocaleToSuffixPowers[selectedLocale][unitToUse],
       displaySuffix: unitToUse,

--- a/src/lib/consistentAssetSize.ts
+++ b/src/lib/consistentAssetSize.ts
@@ -4,6 +4,8 @@ import { SUPPORTED_LOCALE_STRING_LABELS, SupportedLocales } from '@/constants/lo
 
 import { formatNumberOutput, OutputType } from '@/components/Output';
 
+// for each locale, an array of the correct compact number suffix to use for 10^{index}
+// e.g. for "en" we have ['', '', '', 'K', 'K', 'K', 'M', 'M', 'M', 'B', 'B', 'B', 'T', 'T', 'T']
 const supportedLocaleToCompactSuffixByPowerOfTen = mapValues(
   SUPPORTED_LOCALE_STRING_LABELS,
   (name, lang) =>
@@ -26,6 +28,8 @@ const zipObjectFn = <T extends string, K>(arr: T[], valueGenerator: (val: T) => 
     arr.map((val) => valueGenerator(val))
   );
 
+// for each locale, look up a given suffix (from map above) and get the correct power of ten to divide numbers by when using this suffix
+// e.g. for "en" if you look up "K" you get 3 (1000), if you look up "M" you get 6 (1,000,000)
 const supportedLocaleToSuffixPowers = mapValues(
   supportedLocaleToCompactSuffixByPowerOfTen,
   (values) => zipObjectFn([...new Set(values)], (f) => values.indexOf(f))

--- a/src/lib/consistentAssetSize.ts
+++ b/src/lib/consistentAssetSize.ts
@@ -5,7 +5,7 @@ import { SUPPORTED_LOCALE_STRING_LABELS, SupportedLocales } from '@/constants/lo
 import { formatNumberOutput, OutputType } from '@/components/Output';
 
 // for each locale, an array of the correct compact number suffix to use for 10^{index}
-// e.g. for "en" we have ['', '', '', 'K', 'K', 'K', 'M', 'M', 'M', 'B', 'B', 'B', 'T', 'T', 'T']
+// e.g. for "en" we have ['', '', '', 'k', 'k', 'k', 'm', 'm', 'm', 'b', 'b', 'b', 't', 't', 't']
 const supportedLocaleToCompactSuffixByPowerOfTen = mapValues(
   SUPPORTED_LOCALE_STRING_LABELS,
   (name, lang) =>
@@ -20,6 +20,7 @@ const supportedLocaleToCompactSuffixByPowerOfTen = mapValues(
       // first capture group grabs all the numbers with normal separator, then we grab any groups of whitespace+numbers
       // this is so we know which languages keep whitespace before the suffix
       .map((b) => b.replace(/(^[\d,.]+){1}(\s\d+)*/, ''))
+      .map((b) => b.toLowerCase())
 );
 
 const zipObjectFn = <T extends string, K>(arr: T[], valueGenerator: (val: T) => K) =>
@@ -29,7 +30,7 @@ const zipObjectFn = <T extends string, K>(arr: T[], valueGenerator: (val: T) => 
   );
 
 // for each locale, look up a given suffix (from map above) and get the correct power of ten to divide numbers by when using this suffix
-// e.g. for "en" if you look up "K" you get 3 (1000), if you look up "M" you get 6 (1,000,000)
+// e.g. for "en" if you look up "k" you get 3 (1000), if you look up "m" you get 6 (1,000,000)
 const supportedLocaleToSuffixPowers = mapValues(
   supportedLocaleToCompactSuffixByPowerOfTen,
   (values) => zipObjectFn([...new Set(values)], (f) => values.indexOf(f))


### PR DESCRIPTION
Use asset stepSize to determine a valid divisor+suffix and render a compact representation of the asset size. 
BEFORE + AFTER:
![image](https://github.com/dydxprotocol/v4-web/assets/169097417/4cbfc07a-001e-4914-a532-aa3ae5447c09)

AFTERS:
![image](https://github.com/dydxprotocol/v4-web/assets/169097417/82cc1e2c-adf0-4ac7-8de9-6557c2c52dc9)
![image](https://github.com/dydxprotocol/v4-web/assets/169097417/6041b3d8-91e6-4ca4-a9a5-ef4a96bbf09e)
