### PR TITLE
fix: portfolio page content sizing

### DIFF
--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -79,6 +79,8 @@ export const Overview = () => {
           showClosePositionAction={shouldRenderActions}
           withOuterBorder
         />
+      </$AttachedExpandingSection>
+      <DetachedSection>
         <$MaybeUnopenedIsolatedPositionsPanel
           header={
             <ContentSectionHeader
@@ -87,7 +89,7 @@ export const Overview = () => {
           }
           onViewOrders={handleViewUnopenedIsolatedOrders}
         />
-      </$AttachedExpandingSection>
+      </DetachedSection>
     </div>
   );
 };

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -309,5 +309,4 @@ const $IconContainer = styled.div`
 
 const $MobileContent = styled.article`
   ${layoutMixins.contentContainerPage}
-  --content-container-width: var(100vw);
 `;

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -133,7 +133,7 @@ const PortfolioPage = () => {
   return isTablet ? (
     <$PortfolioMobile>
       <PortfolioNavMobile />
-      {routesComponent}
+      <$MobileContent>{routesComponent}</$MobileContent>
     </$PortfolioMobile>
   ) : (
     <WithSidebar
@@ -305,4 +305,9 @@ const $IconContainer = styled.div`
   background-color: var(--color-layer-4);
   border-radius: 50%;
   margin-left: -0.25rem;
+`;
+
+const $MobileContent = styled.article`
+  ${layoutMixins.contentContainerPage}
+  --content-container-width: var(100vw);
 `;

--- a/src/pages/portfolio/Positions.tsx
+++ b/src/pages/portfolio/Positions.tsx
@@ -10,7 +10,7 @@ import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useParameterizedSelector } from '@/hooks/useParameterizedSelector';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import { AttachedExpandingSection } from '@/components/ContentSection';
+import { AttachedExpandingSection, DetachedSection } from '@/components/ContentSection';
 import { ContentSectionHeader } from '@/components/ContentSectionHeader';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
@@ -41,49 +41,55 @@ export const Positions = () => {
   }, [navigate]);
 
   return (
-    <$AttachedExpandingSection>
-      {isNotTablet && <ContentSectionHeader title={stringGetter({ key: STRING_KEYS.POSITIONS })} />}
+    <>
+      <$AttachedExpandingSection>
+        {isNotTablet && (
+          <ContentSectionHeader title={stringGetter({ key: STRING_KEYS.POSITIONS })} />
+        )}
 
-      <PositionsTable
-        columnKeys={
-          isTablet
-            ? [
-                PositionsTableColumnKey.Details,
-                PositionsTableColumnKey.IndexEntry,
-                PositionsTableColumnKey.PnL,
-              ]
-            : [
-                PositionsTableColumnKey.Market,
-                PositionsTableColumnKey.Size,
-                PositionsTableColumnKey.Margin,
-                PositionsTableColumnKey.UnrealizedPnl,
-                PositionsTableColumnKey.RealizedPnl,
-                PositionsTableColumnKey.NetFunding,
-                PositionsTableColumnKey.AverageOpenAndClose,
-                PositionsTableColumnKey.LiquidationAndOraclePrice,
-                shouldRenderTriggers && PositionsTableColumnKey.Triggers,
-                shouldRenderActions && PositionsTableColumnKey.Actions,
-              ].filter(isTruthy)
-        }
-        currentRoute={`${AppRoute.Portfolio}/${PortfolioRoute.Positions}`}
-        withOuterBorder={isNotTablet}
-        showClosePositionAction={shouldRenderActions}
-        navigateToOrders={() =>
-          navigate(`${AppRoute.Portfolio}/${PortfolioRoute.Orders}`, {
-            state: { from: AppRoute.Portfolio },
-          })
-        }
-      />
+        <PositionsTable
+          columnKeys={
+            isTablet
+              ? [
+                  PositionsTableColumnKey.Details,
+                  PositionsTableColumnKey.IndexEntry,
+                  PositionsTableColumnKey.PnL,
+                ]
+              : [
+                  PositionsTableColumnKey.Market,
+                  PositionsTableColumnKey.Size,
+                  PositionsTableColumnKey.Margin,
+                  PositionsTableColumnKey.UnrealizedPnl,
+                  PositionsTableColumnKey.RealizedPnl,
+                  PositionsTableColumnKey.NetFunding,
+                  PositionsTableColumnKey.AverageOpenAndClose,
+                  PositionsTableColumnKey.LiquidationAndOraclePrice,
+                  shouldRenderTriggers && PositionsTableColumnKey.Triggers,
+                  shouldRenderActions && PositionsTableColumnKey.Actions,
+                ].filter(isTruthy)
+          }
+          currentRoute={`${AppRoute.Portfolio}/${PortfolioRoute.Positions}`}
+          withOuterBorder={isNotTablet}
+          showClosePositionAction={shouldRenderActions}
+          navigateToOrders={() =>
+            navigate(`${AppRoute.Portfolio}/${PortfolioRoute.Orders}`, {
+              state: { from: AppRoute.Portfolio },
+            })
+          }
+        />
+      </$AttachedExpandingSection>
 
-      <$MaybeUnopenedIsolatedPositionsPanel
-        header={
-          <ContentSectionHeader
-            title={stringGetter({ key: STRING_KEYS.UNOPENED_ISOLATED_POSITIONS })}
-          />
-        }
-        onViewOrders={handleViewUnopenedIsolatedOrders}
-      />
-    </$AttachedExpandingSection>
+      <DetachedSection>
+        <$MaybeUnopenedIsolatedPositionsPanel
+          header={
+            <ContentSectionHeader
+              title={stringGetter({ key: STRING_KEYS.UNOPENED_ISOLATED_POSITIONS })}
+            />
+          }
+          onViewOrders={handleViewUnopenedIsolatedOrders}
+        />
+      </DetachedSection>
+    </>
   );
 };
 


### PR DESCRIPTION
This fixes an issue where unopened isolated position cards never wrap and instead force page horizontal scrolling.

Cards sections should be detached since they should never horizontally scroll

Mobile page needs to have a contentContainerPage somewhere since all the components use mixins that assume its within one. 

