### PR TITLE
fix: use await for initial statsig config

### DIFF
--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -8,9 +8,9 @@ import { useAppDispatch } from '@/state/appTypes';
 
 import abacusStateManager from '@/lib/abacus';
 import { validateAgainstAvailableEnvironments } from '@/lib/network';
-import { getStatsigConfigPromise } from '@/lib/statsig';
 
 import { useLocalStorage } from './useLocalStorage';
+import { useAllStatsigGateValues } from './useStatsig';
 
 export const useInitializePage = () => {
   const dispatch = useAppDispatch();
@@ -21,14 +21,11 @@ export const useInitializePage = () => {
     defaultValue: DEFAULT_APP_ENVIRONMENT,
     validateFn: validateAgainstAvailableEnvironments,
   });
+  const statsigConfig = useAllStatsigGateValues();
 
   useEffect(() => {
-    const start = async () => {
-      dispatch(initializeLocalization());
-      const statsigConfig = await getStatsigConfigPromise();
-      abacusStateManager.setStatsigConfigs(statsigConfig);
-      abacusStateManager.start({ network: localStorageNetwork });
-    };
-    start();
-  }, []);
+    dispatch(initializeLocalization());
+    abacusStateManager.setStatsigConfigs(statsigConfig);
+    abacusStateManager.start({ network: localStorageNetwork });
+  }, [dispatch, localStorageNetwork, statsigConfig]);
 };

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -8,9 +8,9 @@ import { useAppDispatch } from '@/state/appTypes';
 
 import abacusStateManager from '@/lib/abacus';
 import { validateAgainstAvailableEnvironments } from '@/lib/network';
+import { getStatsigConfigPromise } from '@/lib/statsig';
 
 import { useLocalStorage } from './useLocalStorage';
-import { useAllStatsigGateValues } from './useStatsig';
 
 export const useInitializePage = () => {
   const dispatch = useAppDispatch();
@@ -21,11 +21,14 @@ export const useInitializePage = () => {
     defaultValue: DEFAULT_APP_ENVIRONMENT,
     validateFn: validateAgainstAvailableEnvironments,
   });
-  const statsigConfig = useAllStatsigGateValues();
 
   useEffect(() => {
-    dispatch(initializeLocalization());
-    abacusStateManager.setStatsigConfigs(statsigConfig);
-    abacusStateManager.start({ network: localStorageNetwork });
-  }, [dispatch, localStorageNetwork, statsigConfig]);
+    const start = async () => {
+      dispatch(initializeLocalization());
+      const statsigConfig = await getStatsigConfigPromise();
+      abacusStateManager.setStatsigConfigs(statsigConfig);
+      abacusStateManager.start({ network: localStorageNetwork });
+    };
+    start();
+  }, []);
 };

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
@@ -7,20 +7,20 @@ import {
   useStatsigClient,
 } from '@statsig/react-bindings';
 
-import { initStatsig } from '@/lib/statsig';
+const statsigClient = new StatsigClient(
+  // need to default to empty string or it breaks if no key is supplied
+  import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
+  { userID: 'test-id' },
+  {
+    disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+    disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+  }
+);
+// TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
+statsigClient.initializeSync();
 
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
-  const [client, setClient] = useState<StatsigClient | null>(null);
-  useEffect(() => {
-    const setAsyncClient = async () => {
-      const statsigClient = await initStatsig();
-      setClient(statsigClient);
-    };
-    setAsyncClient();
-  }, [initStatsig]);
-  // if no client, render without provider until a client exists
-  if (!client) return <div>{children}</div>;
-  return <StatsigProviderInternal client={client}> {children} </StatsigProviderInternal>;
+  return <StatsigProviderInternal client={statsigClient}> {children} </StatsigProviderInternal>;
 };
 
 export const useStatsigGateValue = (gate: StatSigFlags) => {

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -10,15 +10,18 @@ import {
 const statsigClient = new StatsigClient(
   // need to default to empty string or it breaks if no key is supplied
   import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
-  { userID: 'test-id' },
+  {},
   {
     disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
     disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
   }
 );
 // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
+// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
 statsigClient.initializeSync();
 
+// Once we figure out how to initialize statsig async, this provider will actually have meaning
+// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
   return <StatsigProviderInternal client={statsigClient}> {children} </StatsigProviderInternal>;
 };

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,17 +1,19 @@
-import { StatsigClient } from '@statsig/js-client';
+// import { StatsigClient } from '@statsig/js-client';
 
-let statsigClient: StatsigClient;
+// let statsigClient: StatsigClient;
 
-export const initStatsig = async () => {
-  if (statsigClient) return statsigClient;
-  statsigClient = new StatsigClient(
-    import.meta.env.VITE_STATSIG_CLIENT_KEY,
-    {},
-    {
-      disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-      disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
-    }
-  );
-  await statsigClient.initializeAsync();
-  return statsigClient;
-};
+// export const initStatsig = async () => {
+//   if (statsigClient) return statsigClient;
+//   statsigClient = new StatsigClient(
+//     import.meta.env.VITE_STATSIG_CLIENT_KEY,
+//     {},
+//     {
+//       disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+//       disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+//     }
+//   );
+//   await statsigClient.initializeAsync();
+//   return statsigClient;
+// };
+
+// TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -17,3 +17,4 @@
 // };
 
 // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
+// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,3 +1,4 @@
+import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
 
 let statsigClient: StatsigClient;
@@ -14,4 +15,15 @@ export const initStatsig = async () => {
   );
   await statsigClient.initializeAsync();
   return statsigClient;
+};
+
+export const getStatsigConfigPromise = async () => {
+  const client = await initStatsig();
+  return Object.values(StatSigFlags).reduce((acc, gateName) => {
+    const nextGateValue = client.checkGate(gateName);
+    return {
+      ...acc,
+      [gateName]: nextGateValue,
+    };
+  }, {} as StatsigConfigType);
 };

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,4 +1,3 @@
-import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
 
 let statsigClient: StatsigClient;
@@ -15,15 +14,4 @@ export const initStatsig = async () => {
   );
   await statsigClient.initializeAsync();
   return statsigClient;
-};
-
-export const getStatsigConfigPromise = async () => {
-  const client = await initStatsig();
-  return Object.values(StatSigFlags).reduce((acc, gateName) => {
-    const nextGateValue = client.checkGate(gateName);
-    return {
-      ...acc,
-      [gateName]: nextGateValue,
-    };
-  }, {} as StatsigConfigType);
 };


### PR DESCRIPTION
we run into a race condition using hooks where the statsig config isn't loaded yet for a new user, causing weird behavior with abacus' state management where state wasnt being populated (Such as transfer input).

solution for now is to just use the initializeSync method.
this prevents abacus race conditions **but** unfortunately it means that the first time a device loads the page they will always fail a gate. this will make gathering data the first time a little bit slow but it will be fine in the long run as our users won't be clearing their local storage all the time