### PR TITLE
feat: statsig async initialization [OTE-496]

### DIFF
--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -8,7 +8,7 @@ import { useAppDispatch } from '@/state/appTypes';
 
 import abacusStateManager from '@/lib/abacus';
 import { validateAgainstAvailableEnvironments } from '@/lib/network';
-import { statsigConfigPromise } from '@/lib/statsig';
+import { getStatsigConfigAsync } from '@/lib/statsig';
 
 import { useLocalStorage } from './useLocalStorage';
 
@@ -25,7 +25,7 @@ export const useInitializePage = () => {
   useEffect(() => {
     dispatch(initializeLocalization());
     const start = async () => {
-      const statsigConfig = await statsigConfigPromise();
+      const statsigConfig = await getStatsigConfigAsync();
       abacusStateManager.setStatsigConfigs(statsigConfig);
       abacusStateManager.start({ network: localStorageNetwork });
     };

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -27,7 +27,6 @@ export const useInitializePage = () => {
     const start = async () => {
       const statsigConfig = await statsigConfigPromise();
       abacusStateManager.setStatsigConfigs(statsigConfig);
-      // Set store so (Abacus & v4-Client) classes can getState and dispatch
       abacusStateManager.start({ network: localStorageNetwork });
     };
     start();

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -25,7 +25,9 @@ export const useInitializePage = () => {
 
   useEffect(() => {
     dispatch(initializeLocalization());
+    console.log(statsigConfig);
     abacusStateManager.setStatsigConfigs(statsigConfig);
+    // Set store so (Abacus & v4-Client) classes can getState and dispatch
     abacusStateManager.start({ network: localStorageNetwork });
   }, [dispatch, localStorageNetwork, statsigConfig]);
 };

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -8,9 +8,9 @@ import { useAppDispatch } from '@/state/appTypes';
 
 import abacusStateManager from '@/lib/abacus';
 import { validateAgainstAvailableEnvironments } from '@/lib/network';
+import { statsigConfigPromise } from '@/lib/statsig';
 
 import { useLocalStorage } from './useLocalStorage';
-import { useAllStatsigGateValues } from './useStatsig';
 
 export const useInitializePage = () => {
   const dispatch = useAppDispatch();
@@ -21,13 +21,15 @@ export const useInitializePage = () => {
     defaultValue: DEFAULT_APP_ENVIRONMENT,
     validateFn: validateAgainstAvailableEnvironments,
   });
-  const statsigConfig = useAllStatsigGateValues();
 
   useEffect(() => {
     dispatch(initializeLocalization());
-    console.log(statsigConfig);
-    abacusStateManager.setStatsigConfigs(statsigConfig);
-    // Set store so (Abacus & v4-Client) classes can getState and dispatch
-    abacusStateManager.start({ network: localStorageNetwork });
-  }, [dispatch, localStorageNetwork, statsigConfig]);
+    const start = async () => {
+      const statsigConfig = await statsigConfigPromise();
+      abacusStateManager.setStatsigConfigs(statsigConfig);
+      // Set store so (Abacus & v4-Client) classes can getState and dispatch
+      abacusStateManager.start({ network: localStorageNetwork });
+    };
+    start();
+  }, []);
 };

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
@@ -7,22 +7,33 @@ import {
   useStatsigClient,
 } from '@statsig/react-bindings';
 
-const statsigClient = new StatsigClient(
-  // need to default to empty string or it breaks if no key is supplied
-  import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
-  {},
-  {
-    disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-    disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
-  }
-);
-// TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
-// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
-statsigClient.initializeSync();
+import { initStatsig } from '@/lib/statsig';
+
+// const statsigClient = new StatsigClient(
+//   // need to default to empty string or it breaks if no key is supplied
+//   import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
+//   {},
+//   {
+//     disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+//     disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+//   }
+// );
+// // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
+// // https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
+// statsigClient.initializeSync();
 
 // Once we figure out how to initialize statsig async, this provider will actually have meaning
 // https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
+  const [statsigClient, setStatsigClient] = useState<StatsigClient | null>(null);
+  useEffect(() => {
+    const init = async () => {
+      const client = await initStatsig();
+      setStatsigClient(client);
+    };
+    init();
+  }, []);
+  if (!statsigClient) return <div>{children}</div>;
   return <StatsigProviderInternal client={statsigClient}> {children} </StatsigProviderInternal>;
 };
 

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -9,21 +9,6 @@ import {
 
 import { initStatsig } from '@/lib/statsig';
 
-// const statsigClient = new StatsigClient(
-//   // need to default to empty string or it breaks if no key is supplied
-//   import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
-//   {},
-//   {
-//     disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-//     disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
-//   }
-// );
-// // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
-// // https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
-// statsigClient.initializeSync();
-
-// Once we figure out how to initialize statsig async, this provider will actually have meaning
-// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
   const [statsigClient, setStatsigClient] = useState<StatsigClient | null>(null);
   useEffect(() => {

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -7,13 +7,13 @@ import {
   useStatsigClient,
 } from '@statsig/react-bindings';
 
-import { initStatsig } from '@/lib/statsig';
+import { initStatsigAsync } from '@/lib/statsig';
 
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
   const [statsigClient, setStatsigClient] = useState<StatsigClient | null>(null);
   useEffect(() => {
     const init = async () => {
-      const client = await initStatsig();
+      const client = await initStatsigAsync();
       setStatsigClient(client);
     };
     init();

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,20 +1,20 @@
-// import { StatsigClient } from '@statsig/js-client';
+import { StatsigClient } from '@statsig/js-client';
 
-// let statsigClient: StatsigClient;
+let statsigClient: StatsigClient;
 
-// export const initStatsig = async () => {
-//   if (statsigClient) return statsigClient;
-//   statsigClient = new StatsigClient(
-//     import.meta.env.VITE_STATSIG_CLIENT_KEY,
-//     {},
-//     {
-//       disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-//       disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
-//     }
-//   );
-//   await statsigClient.initializeAsync();
-//   return statsigClient;
-// };
+export const initStatsig = async () => {
+  if (statsigClient) return statsigClient;
+  statsigClient = new StatsigClient(
+    import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
+    { userID: 'test-id' },
+    {
+      disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+      disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+    }
+  );
+  await statsigClient.initializeAsync();
+  return statsigClient;
+};
 
 // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
 // https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,20 +1,37 @@
+import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
 
 let statsigClient: StatsigClient;
+let initPromise: Promise<StatsigClient> | null = null;
 
 export const initStatsig = async () => {
+  if (initPromise) {
+    return initPromise;
+  }
   if (statsigClient) return statsigClient;
-  statsigClient = new StatsigClient(
-    import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
-    { userID: 'test-id' },
-    {
-      disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-      disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
-    }
-  );
-  await statsigClient.initializeAsync();
-  return statsigClient;
+
+  initPromise = (async () => {
+    statsigClient = new StatsigClient(
+      import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
+      { userID: 'test-id' },
+      {
+        disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
+        disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+      }
+    );
+    await statsigClient.initializeAsync();
+    return statsigClient;
+  })();
+  return initPromise;
 };
 
 // TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
 // https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
+
+export const statsigConfigPromise = async () => {
+  const client = await initStatsig();
+  const allGateValues = Object.values(StatSigFlags).reduce((acc, gate) => {
+    return { ...acc, [gate]: client.checkGate(gate) };
+  }, {} as StatsigConfigType);
+  return allGateValues;
+};

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -1,5 +1,8 @@
 import { StatSigFlags, StatsigConfigType } from '@/types/statsig';
 import { StatsigClient } from '@statsig/js-client';
+import { merge } from 'lodash';
+
+import { log } from './telemetry';
 
 let statsigClient: StatsigClient;
 let initPromise: Promise<StatsigClient> | null = null;
@@ -12,7 +15,7 @@ let initPromise: Promise<StatsigClient> | null = null;
  *
  * @returns initPromise: a promise that returns the statsig client only after it is initialized
  */
-export const initStatsig = async () => {
+export const initStatsigAsync = async () => {
   if (initPromise) {
     return initPromise;
   }
@@ -35,14 +38,32 @@ export const initStatsig = async () => {
 
 /**
  *
+ * @param client statsig client to check
+ * @param gateId
+ * @returns
+ */
+const checkGateTyped = (client: StatsigClient, gateId: StatSigFlags) => {
+  return client.checkGate(gateId);
+};
+
+/**
+ *
  * This is used only in useInitializePage to block abacus start on the fully loaded async statsig config.
  * This prevents new users from automatically received a 'false' for all feature gates because they
  * don't have a statsig value cached.
+ *
+ * Try catches in case the statsig init or gatechecks fail.
  */
-export const statsigConfigPromise = async () => {
-  const client = await initStatsig();
-  const allGateValues = Object.values(StatSigFlags).reduce((acc, gate) => {
-    return { ...acc, [gate]: client.checkGate(gate) };
-  }, {} as StatsigConfigType);
-  return allGateValues;
+export const getStatsigConfigAsync = async (): Promise<StatsigConfigType> => {
+  try {
+    const client = await initStatsigAsync();
+    const gateValuesList = Object.values(StatSigFlags).map((gateId) => ({
+      [gateId]: checkGateTyped(client, gateId),
+    }));
+    const statsigConfig = merge({}, ...gateValuesList);
+    return statsigConfig;
+  } catch (err) {
+    log('statsig/statsigConfigPromise', err);
+    return {};
+  }
 };

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -4,6 +4,14 @@ import { StatsigClient } from '@statsig/js-client';
 let statsigClient: StatsigClient;
 let initPromise: Promise<StatsigClient> | null = null;
 
+/**
+ * This method creates a promise and assigns it to the variable initPromise.
+ * If an initPromise has already been generated, it returns the existing promise.
+ * This causes all calls to this function to always return the statsigClient only after
+ * it has retrieved all values from statsig
+ *
+ * @returns initPromise: a promise that returns the statsig client only after it is initialized
+ */
 export const initStatsig = async () => {
   if (initPromise) {
     return initPromise;
@@ -12,6 +20,7 @@ export const initStatsig = async () => {
   initPromise = (async () => {
     statsigClient = new StatsigClient(
       import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
+      // TODO: create a top level settings.ts file to coerce boolean env vars to actual boolean
       import.meta.env.VITE_TEST_USER_ID === 'true' ? { userID: 'test-id' } : {},
       {
         disableLogging: import.meta.env.VITE_DISABLE_STATSIG,

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -24,9 +24,12 @@ export const initStatsig = async () => {
   return initPromise;
 };
 
-// TODO: figure out how to init statsig async so we get configs on the first page load without breaking app state
-// https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
-
+/**
+ *
+ * This is used only in useInitializePage to block abacus start on the fully loaded async statsig config.
+ * This prevents new users from automatically received a 'false' for all feature gates because they
+ * don't have a statsig value cached.
+ */
 export const statsigConfigPromise = async () => {
   const client = await initStatsig();
   const allGateValues = Object.values(StatSigFlags).reduce((acc, gate) => {

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -9,11 +9,10 @@ export const initStatsig = async () => {
     return initPromise;
   }
   if (statsigClient) return statsigClient;
-
   initPromise = (async () => {
     statsigClient = new StatsigClient(
       import.meta.env.VITE_STATSIG_CLIENT_KEY ?? '',
-      { userID: 'test-id' },
+      import.meta.env.VITE_TEST_USER_ID === 'true' ? { userID: 'test-id' } : {},
       {
         disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
         disableStorage: import.meta.env.VITE_DISABLE_STATSIG,

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -38,7 +38,10 @@ export const store = configureStore({
 
   devTools: process.env.NODE_ENV !== 'production',
 });
+
+// Set store so (Abacus & v4-Client) classes can getState and dispatch
 abacusStateManager.setStore(store);
+
 export type RootStore = typeof store;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = RootStore['dispatch'];

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -1,7 +1,5 @@
 import { Middleware, configureStore } from '@reduxjs/toolkit';
 
-// TODO - fix cycle
-// eslint-disable-next-line import/no-cycle
 import abacusStateManager from '@/lib/abacus';
 
 import { accountSlice } from './account';
@@ -40,10 +38,7 @@ export const store = configureStore({
 
   devTools: process.env.NODE_ENV !== 'production',
 });
-
-// Set store so (Abacus & v4-Client) classes can getState and dispatch
 abacusStateManager.setStore(store);
-
 export type RootStore = typeof store;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = RootStore['dispatch'];

--- a/src/types/statsig.ts
+++ b/src/types/statsig.ts
@@ -1,4 +1,4 @@
-export type StatsigConfigType = Record<StatSigFlags, boolean>;
+export type StatsigConfigType = {} | Record<StatSigFlags, boolean>;
 
 export enum StatSigFlags {
   ffSkipMigration = 'ff_skip_migration',


### PR DESCRIPTION
Fixes the issue that was called out in https://github.com/dydxprotocol/v4-web/pull/756

The race condition was not inherent to abacus. 
The condition was that the client is constructed separately from initialization, so we were early returning an uninitalized client. This caused abacus to have split behavior where it would call the squid assets endpoint but use the skip processors.

We fix this problem by instead returning the initialization promise instead

TLDR; I am out of practice with promises. This should not have been that hard to debug 😵 


PS: TODO - think about adding tests for this to make sure we don't break the async functionality in the future 