### PR TITLE
fix: update staking panel text colors + apr tag

### DIFF
--- a/src/pages/token/rewards/StakingPanel.tsx
+++ b/src/pages/token/rewards/StakingPanel.tsx
@@ -1,5 +1,5 @@
 import { shallowEqual } from 'react-redux';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
@@ -100,9 +100,12 @@ export const StakingPanel = ({ className }: { className?: string }) => {
                   key: STRING_KEYS.UNSTAKED,
                 })}
               </WithTooltip>
-              {stakingApr && <$Tag sign={TagSign.Positive}>{aprText}</$Tag>}
             </$Label>
-            <$BalanceOutput type={OutputType.Asset} value={nativeTokenBalance} />
+            <$BalanceOutput
+              type={OutputType.Asset}
+              value={nativeTokenBalance}
+              isPositive={nativeTokenBalance.gt(0)}
+            />
           </div>
           {showStakingActions && (
             <div>
@@ -123,9 +126,13 @@ export const StakingPanel = ({ className }: { className?: string }) => {
                   key: STRING_KEYS.STAKED,
                 })}
               </WithTooltip>
-              {stakingApr && <$Tag>{aprText}</$Tag>}
+              {stakingApr && <$Tag sign={TagSign.Positive}>{aprText}</$Tag>}
             </$Label>
-            <$BalanceOutput type={OutputType.Asset} value={nativeStakingBalance} />
+            <$BalanceOutput
+              type={OutputType.Asset}
+              value={nativeStakingBalance}
+              isPositive={nativeStakingBalance > 0}
+            />
           </div>
           {showStakingActions && nativeStakingBalance > 0 && (
             <div>
@@ -223,7 +230,15 @@ const $Label = styled.div`
   gap: 0.5rem;
 `;
 
-const $BalanceOutput = styled(Output)`
+const $BalanceOutput = styled(Output)<{ isPositive: boolean }>`
   font-size: var(--fontSize-large);
-  color: var(--color-text-0);
+
+  ${({ isPositive }) =>
+    isPositive
+      ? css`
+          color: var(--color-text-2);
+        `
+      : css`
+          color: var(--color-text-0);
+        `}
 `;


### PR DESCRIPTION
1. Remove the APR badge next to 'Unstaked' and add green APR badge next to 'Staked' (no need to exactly copy Keplr)
2. If the balance is more than 0, the text should be 'Primary' instead of 'Tertiary' to avoid confusion (staking panel)

<img width="423" alt="Screenshot 2024-07-03 at 12 03 41 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/2152abd8-506c-412e-af42-5117e7621ad2">
<img width="459" alt="Screenshot 2024-07-03 at 12 02 42 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/aeb4fa42-acbd-4145-b91f-8905147033f8">
