### PR TITLE
fix: share pnl card visuals

### DIFF
--- a/src/icons/logo.tsx
+++ b/src/icons/logo.tsx
@@ -50,8 +50,8 @@ export const LogoIcon = ({ id, className }: LogoIconProps) => {
           y2="46.7483"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor="white" />
-          <stop offset="1" stopColor="white" stopOpacity="0.55" />
+          <stop stopColor={`${fill}`} />
+          <stop offset="1" stopColor={`${fill}`} stopOpacity="0.55" />
         </linearGradient>
         <linearGradient
           id={id ? `${id}_logo_gradient_1` : 'paint1_linear'}
@@ -63,17 +63,6 @@ export const LogoIcon = ({ id, className }: LogoIconProps) => {
         >
           <stop stopColor="#6966FF" />
           <stop offset="1" stopColor="#6966FF" stopOpacity="0.36" />
-        </linearGradient>
-        <linearGradient
-          id={id ? `${id}_logo_gradient_2` : 'paint2_linear'}
-          x1="110"
-          y1="7.27451"
-          x2="144.132"
-          y2="49.0118"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="white" />
-          <stop offset="1" stopColor="white" stopOpacity="0.55" />
         </linearGradient>
       </defs>
     </svg>

--- a/src/icons/logo.tsx
+++ b/src/icons/logo.tsx
@@ -6,8 +6,6 @@ export const LogoIcon = ({ id, className }: LogoIconProps) => {
   const theme = useAppThemeAndColorModeContext();
   const fill = theme.logoFill;
 
-  console.log('xcxc', fill);
-
   return (
     <svg
       width="363"

--- a/src/icons/logo.tsx
+++ b/src/icons/logo.tsx
@@ -6,6 +6,8 @@ export const LogoIcon = ({ id, className }: LogoIconProps) => {
   const theme = useAppThemeAndColorModeContext();
   const fill = theme.logoFill;
 
+  console.log('xcxc', fill);
+
   return (
     <svg
       width="363"
@@ -33,7 +35,7 @@ export const LogoIcon = ({ id, className }: LogoIconProps) => {
       <path d="M169.089 0L91 111.991H115.481L193.495 0H169.089Z" fill={fill} />
       <path
         d="M115.5 0L140 34L126.5 53L90 0H115.5Z"
-        fill={`url(#${id ? `${id}_logo_gradient_2` : 'paint2_linear'})`}
+        fill={`url(#${id ? `${id}_logo_gradient_0` : 'paint0_linear'})`}
       />
       <path
         fillRule="evenodd"

--- a/src/styles/text.css
+++ b/src/styles/text.css
@@ -40,6 +40,7 @@
   --font-base-regular: var(--fontWeight-regular) var(--fontSize-base) var(--fontFamily-base);
   --font-base-book: var(--fontWeight-book) var(--fontSize-base) var(--fontFamily-base);
   --font-base-medium: var(--fontWeight-medium) var(--fontSize-base) var(--fontFamily-base);
+  --font-base-bold: var(--fontWeight-bold) var(--fontSize-base) var(--fontFamily-base);
 
   --font-medium-regular: var(--fontWeight-regular) var(--fontSize-medium) var(--fontFamily-base);
   --font-medium-book: var(--fontWeight-book) var(--fontSize-medium) var(--fontFamily-base);

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { ButtonAction } from '@/constants/buttons';
 import { DialogProps, SharePNLAnalyticsDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
+import { NumberSign } from '@/constants/numbers';
 import { PositionSide } from '@/constants/trade';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -16,6 +17,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Dialog } from '@/components/Dialog';
+import { DiffArrow } from '@/components/DiffArrow';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType, ShowSign } from '@/components/Output';
 import { QrCode } from '@/components/QrCode';
@@ -61,7 +63,12 @@ export const SharePNLAnalyticsDialog = ({
       await copyBlobToClipboard(blob);
 
       triggerTwitterIntent({
-        text: `Check out my ${assetId} position on @dYdX\n\n#dYdX #${assetId}\n[paste image and delete this!]`,
+        text: `${stringGetter({
+          key: STRING_KEYS.TWEET_MARKET_POSITION,
+          params: {
+            MARKET: assetId,
+          },
+        })}\n\n#dYdX #${assetId}\n[${stringGetter({ key: STRING_KEYS.TWEET_PASTE_IMAGE_AND_DELETE_THIS })}]`,
         related: 'dYdX',
       });
 
@@ -111,11 +118,10 @@ export const SharePNLAnalyticsDialog = ({
             value={unrealizedPnlPercent}
             showSign={ShowSign.None}
             slotLeft={
-              !unrealizedPnlIsNegative ? (
-                <$ArrowUpIcon iconName={IconName.Arrow} />
-              ) : (
-                <$ArrowDownIcon iconName={IconName.Arrow} />
-              )
+              <DiffArrow
+                direction={unrealizedPnlIsNegative ? 'down' : 'up'}
+                sign={unrealizedPnlIsNegative ? NumberSign.Negative : NumberSign.Positive}
+              />
             }
           />
 
@@ -150,7 +156,7 @@ export const SharePNLAnalyticsDialog = ({
             options={{
               margin: 0,
               backgroundOptions: {
-                color: 'var(--color-layer-3)',
+                color: 'var(--color-layer-6)',
               },
               imageOptions: {
                 margin: 0,
@@ -219,12 +225,12 @@ const $ShareableCardSide = styled.div`
 const $ShareableCardTitle = styled.div`
   ${layoutMixins.row};
   gap: 0.5rem;
-  font-weight: var(--fontWeight-medium);
   margin-bottom: 0.75rem;
 `;
 
 const $ShareableCardTitleAsset = styled.span`
-  color: var(--color-white);
+  font: var(--font-base-bold);
+  color: var(--color-text-2);
 `;
 
 const $ShareableCardStats = styled.div`
@@ -235,17 +241,14 @@ const $ShareableCardStats = styled.div`
 `;
 
 const $ShareableCardStatLabel = styled.div`
-  font: var(--font-base-medium);
+  font: var(--font-base-bold);
   text-align: right;
+  color: var(--color-text-0);
 `;
 
 const $ShareableCardStatOutput = styled(Output)`
-  font: var(--font-base-medium);
+  font: var(--font-base-bold);
   color: var(--color-text-2);
-
-  * {
-    color: var(--color-text-2);
-  }
 `;
 
 const $AssetIcon = styled(AssetIcon)`
@@ -265,6 +268,8 @@ const $QrCode = styled(QrCode)`
 
 const $HighlightOutput = styled(Output)<{ isNegative?: boolean }>`
   font-size: 2.25rem;
+  font-weight: var(--fontWeight-bold);
+
   color: var(--output-sign-color);
   --secondary-item-color: currentColor;
   --output-sign-color: ${({ isNegative }) =>
@@ -273,18 +278,6 @@ const $HighlightOutput = styled(Output)<{ isNegative?: boolean }>`
         ? `var(--color-negative)`
         : `var(--color-positive)`
       : `var(--color-text-1)`};
-`;
-
-const $ArrowUpIcon = styled(Icon)<{ negative?: boolean }>`
-  font-size: 1.5rem;
-  margin-right: 0.5rem;
-  transform: rotateZ(-90deg);
-`;
-
-const $ArrowDownIcon = styled(Icon)<{ negative?: boolean }>`
-  font-size: 1.5rem;
-  margin-right: 0.5rem;
-  transform: rotateZ(90deg);
 `;
 
 const $Logo = styled(LogoIcon)`

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -156,7 +156,7 @@ export const SharePNLAnalyticsDialog = ({
             options={{
               margin: 0,
               backgroundOptions: {
-                color: 'var(--color-layer-6)',
+                color: 'var(--color-layer-3)',
               },
               imageOptions: {
                 margin: 0,


### PR DESCRIPTION
Basically fix the share pnl card to look good in light/ dark/classic // also tested the twitter clickthrough

| | Light | Dark | Classic |
| ---- | ---- | ---- | ---- | 
| App | <img width="560" alt="Screenshot 2024-07-03 at 3 21 11 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/32de46ce-3b95-44a7-8027-e1e1e4f1bfbb"> | <img width="538" alt="Screenshot 2024-07-03 at 3 21 20 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/65c9a7ae-e578-4144-80f5-b5d72d11fb83"> | <img width="535" alt="Screenshot 2024-07-03 at 3 21 25 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/400c85a0-507c-44bb-86bc-5a7a06042e17"> | <img width="688" alt="Screenshot 2024-07-03 at 3 23 42 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/9941c469-28b4-4c31-a581-a3c30e7f2ea5"> |
| Twitter | <img width="622" alt="Screenshot 2024-07-03 at 4 30 41 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/8a936eef-9343-4c37-9e21-eb9c0a36c158"> | <img width="636" alt="Screenshot 2024-07-03 at 4 31 10 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/96ba2b78-229f-4637-a83b-20da3c331f12"> | <img width="659" alt="Screenshot 2024-07-03 at 4 31 28 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/0bbe3d3b-cba1-4e52-8fe7-29ae2b6c8143"> |

---

<!-- Reorder/delete the following sections accordingly: -->

## Views


* `SharePnlAnalyticsDialog`
  * Localize tweet
  * Replace arrow with existing `DiffArrow`
  * Fix up styling of text

## Styles/Mixins

* `styles/text.css`
  * Add bold font base

## Constants/Types

* `icons/logo.tsx`
  * Fix the svg to properly render in light mode


---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
