### PR TITLE
chore: add analytics for share pnl dialog

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -227,6 +227,15 @@ export const AnalyticsEvents = unionize(
       amount?: number;
       validatorAddress?: string;
     }>(),
+
+    // Sharing
+    SharePnlShared: ofType<{
+      asset: string;
+    }>(),
+    SharePnlCopied: ofType<{
+      asset: string;
+    }>(),
+
     Error: ofType<{
       location: string;
       error: Error;

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useToBlob } from '@hugocxl/react-to-image';
 import styled from 'styled-components';
 
+import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction } from '@/constants/buttons';
 import { DialogProps, SharePNLAnalyticsDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -24,6 +25,7 @@ import { Tag, TagSign } from '@/components/Tag';
 import { useAppDispatch } from '@/state/appTypes';
 import { closeDialog } from '@/state/dialogs';
 
+import { track } from '@/lib/analytics';
 import { MustBigNumber } from '@/lib/numbers';
 import { triggerTwitterIntent } from '@/lib/twitter';
 
@@ -166,6 +168,7 @@ export const SharePNLAnalyticsDialog = ({
           action={ButtonAction.Secondary}
           slotLeft={<Icon iconName={IconName.Copy} />}
           onClick={() => {
+            track(AnalyticsEvents.SharePnlCopied({ asset: assetId }));
             convert();
           }}
           state={{
@@ -178,6 +181,7 @@ export const SharePNLAnalyticsDialog = ({
           action={ButtonAction.Primary}
           slotLeft={<Icon iconName={IconName.SocialX} />}
           onClick={() => {
+            track(AnalyticsEvents.SharePnlShared({ asset: assetId }));
             convertShare();
           }}
           state={{


### PR DESCRIPTION
notion reqs [here](https://www.notion.so/dydx/Grants-Share-P-L-Cards-4af7036029ec4a588cd68720ab0774e5#be73475c1b1749b98a1871dc84d728a3). chatted with chris // confirmed that only metadata we want is asset (asset isn't recorded for modal opening since tracking the opening/closing dialogs is done in another way, but I think that's fine. Can double check with Yang once he's back).

<img width="457" alt="Screenshot 2024-07-03 at 4 12 06 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/e021678b-ff62-4760-b0e0-1e6b7287bfef">
<img width="510" alt="Screenshot 2024-07-03 at 4 11 58 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/bf53e891-1b63-4222-b4cf-0d00022ef815">
<img width="548" alt="Screenshot 2024-07-03 at 4 11 47 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/1d5bf47e-88f1-431c-b2e0-4fd7b94a50ca">
