### PR TITLE
feat: add ability to hide + unhide notification based on condition other than user action

### DIFF
--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -108,6 +108,9 @@ export enum NotificationStatus {
   /** Toast or NotificationsMenu item interacted with or dismissed. "Seen" in NotificationsMenu. */
   Seen,
 
+  /** Toast or NotificationsMenu item marked as hidden by non-user action. Can be unhidden since it's not explicitly cleared by user. */
+  Hidden,
+
   /** Notification marked for deletion. Hidden in NotificationsMenu. */
   Cleared,
 }

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -43,6 +43,11 @@ export const SingleSessionNotificationTypes = [
 
 export type NotificationId = string | number;
 
+export type NotificationParams = {
+  type: NotificationType;
+  id: NotificationId;
+};
+
 export type NotificationTypeConfig<
   NotificationIdType extends NotificationId = string,
   NotificationUpdateKey = any,
@@ -69,8 +74,19 @@ export type NotificationTypeConfig<
        * @param true (default): Notification initialized with status NotificationStatus.Triggered
        * @param false: Notification initialized with status NotificationStatus.Cleared
        */
-      isNew?: boolean
+      isNew?: boolean,
+
+      /**
+       * @param false (default): Notification should not be retriggered if it's been seen/cleared/hidden
+       * @param true:  Notification should be retriggered if status was NotificationStatus.Hidden
+       */
+      shouldUnhide?: boolean
     ) => void;
+
+    /**
+     * Hide (mark clear) a notification based on condition other than user action
+     */
+    hideNotification: ({ type, id }: NotificationParams) => void;
 
     lastUpdated: number;
   }) => void;

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -581,9 +581,10 @@ export const notificationTypes: NotificationTypeConfig[] = [
             },
             [],
             true,
-            true
+            true // unhide on new error (i.e. normal -> not normal api status)
           );
         } else {
+          // hide/expire existing notification if no error
           hideNotification({
             type: NotificationType.ApiError,
             id: NotificationType.ApiError,

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -558,7 +558,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
   },
   {
     type: NotificationType.ApiError,
-    useTrigger: ({ trigger }) => {
+    useTrigger: ({ trigger, hideNotification }) => {
       const stringGetter = useStringGetter();
       const { statusErrorMessage } = useApiState();
       const { statusPage } = useURLConfigs();
@@ -579,8 +579,15 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 <Link href={statusPage}>{stringGetter({ key: STRING_KEYS.STATUS_PAGE })} →</Link>
               ),
             },
-            []
+            [],
+            true,
+            true
           );
+        } else {
+          hideNotification({
+            type: NotificationType.ApiError,
+            id: NotificationType.ApiError,
+          });
         }
       }, [stringGetter, statusErrorMessage?.body, statusErrorMessage?.title]);
     },

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -129,7 +129,7 @@ const useNotificationsContext = () => {
     [getKey]
   );
 
-  const { markUnseen, markSeen, markCleared } = useMemo(
+  const { markUnseen, markSeen, markHidden, markCleared } = useMemo(
     () => ({
       markUnseen: (notification: Notification) => {
         if (notification.status < NotificationStatus.Unseen) {
@@ -139,6 +139,11 @@ const useNotificationsContext = () => {
       markSeen: (notification: Notification) => {
         if (notification.status < NotificationStatus.Seen) {
           updateStatus(notification, NotificationStatus.Seen);
+        }
+      },
+      markHidden: (notification: Notification) => {
+        if (notification.status < NotificationStatus.Hidden) {
+          updateStatus(notification, NotificationStatus.Hidden);
         }
       },
       markCleared: (notification: Notification) => {
@@ -154,9 +159,9 @@ const useNotificationsContext = () => {
     ({ type, id }: NotificationParams) => {
       const key = getKey({ type, id });
       const { [key]: notif } = notifications;
-      if (notif) markCleared(notif);
+      if (notif) markHidden(notif);
     },
-    [notifications, markCleared, getKey]
+    [notifications, markHidden, getKey]
   );
 
   const markAllCleared = useCallback(() => {
@@ -195,9 +200,9 @@ const useNotificationsContext = () => {
 
               thisNotification.updateKey = updateKey;
               updateStatus(thisNotification, NotificationStatus.Updated);
-            } else if (shouldUnhide && notification.status === NotificationStatus.Cleared) {
+            } else if (shouldUnhide && notification.status === NotificationStatus.Hidden) {
               const thisNotification = notifications[key];
-              updateStatus(thisNotification, NotificationStatus.Triggered);
+              updateStatus(thisNotification, NotificationStatus.Updated);
             }
           } else {
             // Notification is disabled - remove it


### PR DESCRIPTION
motivation: when api status goes from error to back to normal, the status notification/toast still persists until user closes it. if the api status (e.g. indexer trailing error) is inaccurate / temporary (e.g. network slowness), it will have the illusion that exchange is still down even tho it's back to normal. therefore we want to introduce a way to remove an existing notification (without toast duration) based on condition other than user dismissing it.

this pr introduces two new things:
1. `hideNotification` function: when api status is normal, we want to hide toast if it exists. this will mark the notification as `hidden`
2. `hidden` notification status, one "step" before `cleared` i.e. if notif is cleared it cannot be marked back to hidden, but otherwise a notif can be marked as hidden by code logic other than user action
3. `shouldUnhide` in the `trigger` function, when set to true, a `hidden` notification will be marked back to `updated` if has not been cleared by a user

cant upload vid here, pls check review channel :3