### PR TITLE
fix: fix unstake dialog alignment when single validator staked

### DIFF
--- a/src/views/dialogs/UnstakeDialog.tsx
+++ b/src/views/dialogs/UnstakeDialog.tsx
@@ -33,35 +33,38 @@ export const UnstakeDialog = ({ setIsOpen }: DialogProps<UnstakeDialogProps>) =>
   const dialogProps: {
     [key in StakeFormSteps]: {
       title: string;
-      description: string;
+      description: React.ReactNode;
       slotIcon?: JSX.Element;
     };
   } = {
     [StakeFormSteps.EditInputs]: {
       title: stringGetter({ key: STRING_KEYS.UNSTAKE }),
-      description:
-        currentDelegations?.length === 1
-          ? stringGetter({
-              key: STRING_KEYS.CURRENTLY_STAKING_WITH,
-              params: {
-                VALIDATOR: (
-                  <$ValidatorName
-                    validator={stakingValidators?.[currentDelegations[0].validator]?.[0]}
-                  />
-                ),
-              },
-            })
-          : stringGetter({
-              key: STRING_KEYS.CURRENTLY_STAKING,
-              params: {
-                AMOUNT: (
-                  <$StakedAmount>
-                    {nativeStakingBalance}
-                    <Tag>{chainTokenLabel} </Tag>
-                  </$StakedAmount>
-                ),
-              },
-            }),
+      description: (
+        <$Description>
+          {currentDelegations?.length === 1
+            ? stringGetter({
+                key: STRING_KEYS.CURRENTLY_STAKING_WITH,
+                params: {
+                  VALIDATOR: (
+                    <$ValidatorName
+                      validator={stakingValidators?.[currentDelegations[0].validator]?.[0]}
+                    />
+                  ),
+                },
+              })
+            : stringGetter({
+                key: STRING_KEYS.CURRENTLY_STAKING,
+                params: {
+                  AMOUNT: (
+                    <$StakedAmount>
+                      {nativeStakingBalance}
+                      <Tag>{chainTokenLabel} </Tag>
+                    </$StakedAmount>
+                  ),
+                },
+              })}
+        </$Description>
+      ),
       slotIcon: <AssetIcon symbol={chainTokenLabel} />,
     },
     [StakeFormSteps.PreviewOrder]: {
@@ -85,6 +88,10 @@ export const UnstakeDialog = ({ setIsOpen }: DialogProps<UnstakeDialogProps>) =>
 
 const $Dialog = styled(Dialog)`
   --dialog-content-paddingTop: var(--default-border-width);
+`;
+
+const $Description = styled.div`
+  ${layoutMixins.inlineRow}
 `;
 
 const $StakedAmount = styled.span`


### PR DESCRIPTION
| before | after |
| ---- | ---- |
| <img width="534" alt="Screenshot 2024-07-05 at 1 22 03 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/b3cf3c23-34df-4ac2-8387-209d09a69e78"> | <img width="556" alt="Screenshot 2024-07-05 at 1 19 49 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/3ede5201-9a22-4d1b-a30e-799249d74e7e"> | 

confirm multiple case looks fine still
<img width="540" alt="Screenshot 2024-07-05 at 1 20 12 PM" src="https://github.com/dydxprotocol/v4-web/assets/70078372/c61fbb0c-5c02-4864-9eca-63ad6ab733e8">

