### PR TITLE
fix: navigation to markets in cmd+k menu

### DIFF
--- a/src/views/menus/useGlobalCommands.tsx
+++ b/src/views/menus/useGlobalCommands.tsx
@@ -29,10 +29,6 @@ enum LayoutItems {
   setAlternativeLayout = 'SetAlternativeLayout',
 }
 
-enum NavItems {
-  NavigateToMarket = 'NavigateToMarket',
-}
-
 export const useGlobalCommands = (): MenuConfig<string, string> => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -148,21 +144,15 @@ export const useGlobalCommands = (): MenuConfig<string, string> => {
     //   ],
     // },
     {
-      group: 'navigation',
-      groupLabel: 'Navigation',
-      items: [
-        {
-          value: NavItems.NavigateToMarket,
-          label: 'Navigate to Market',
-          subitems: joinedPerpetualMarketsAndAssets.map(({ market, name, id }) => ({
-            value: market ?? '',
-            slotBefore: <AssetIcon symbol={id} />,
-            label: name ?? '',
-            tag: id,
-            onSelect: () => navigate(`${AppRoute.Trade}/${market}`),
-          })),
-        },
-      ],
+      group: 'markets',
+      groupLabel: 'Markets',
+      items: joinedPerpetualMarketsAndAssets.map(({ market, name, id }) => ({
+        value: market ?? '',
+        slotBefore: <AssetIcon symbol={id} />,
+        label: name ?? '',
+        tag: id,
+        onSelect: () => navigate(`${AppRoute.Trade}/${market}`),
+      })),
     },
   ];
 };


### PR DESCRIPTION
Navigation to markets using `cmd+k` was broken before. Allow for much easier transition to any market via the `cmd+k` menu. Works for ticker or name, for example "TRX" or "TRON" both work for Tron.