### PR TITLE
feat: reconnect abacus when app comes back from background -> foreground after 10s

### DIFF
--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -125,6 +125,11 @@ class AbacusStateManager {
     this.stateManager.trade(null, null);
   };
 
+  restart = ({ network }: { network?: DydxNetwork } = {}) => {
+    this.stateManager.readyToConnect = false;
+    this.start({ network });
+  };
+
   // ------ Breakdown ------ //
   disconnectAccount = () => {
     this.stateManager.accountAddress = null;


### PR DESCRIPTION
motivation:
- there are reports of seeing api status error messaging more often (even when indexer/validator are fine) when user has switched tabs and come back after after a while
- we've upped the threshold for showing indexer trailing error and also add logic to remove the error toast when api status is calculated back to normal
- as one more thing to try, we want to add logic to restart abacus when web app comes from background -> foreground, similar to what mobile does

this pr:
- add logic to restart abacus when web app comes back to "foreground" after hidden for 10+ seconds
- restarting abacus = reconnect to indexer/validator endpoints + websocket