### PR TITLE
chore: regulatory override EU locale detection and default to English

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -1,4 +1,5 @@
 import { StatSigFlags } from '@/types/statsig';
+import { SupportedLocale } from '@dydxprotocol/v4-localization';
 import { RecordOf, TagsOf, UnionOf, ofType, unionize } from 'unionize';
 
 import type { AbacusApiStatus, HumanReadablePlaceOrderPayload } from './abacus';
@@ -100,6 +101,11 @@ export const AnalyticsEvents = unionize(
       blockHeight?: number;
       indexerBlockHeight?: number;
       trailingBlocks?: number;
+    }>(),
+    SwitchedLanguageToEULanguage: ofType<{
+      previousLocale: SupportedLocale;
+      newLocale: SupportedLocale;
+      browserLanguage?: string;
     }>(),
 
     // Export CSV

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -4,6 +4,7 @@ import {
   LOCALE_DATA,
   NOTIFICATIONS,
   NOTIFICATIONS_STRING_KEYS,
+  SupportedLocale,
   TOOLTIPS,
   WARNINGS_STRING_KEYS,
 } from '@dydxprotocol/v4-localization';
@@ -87,6 +88,13 @@ export const SUPPORTED_LOCALE_BASE_TAGS = {
   [SupportedLocales.ES]: 'es',
   [SupportedLocales.DE]: 'de',
 };
+
+export const EU_LOCALES: SupportedLocale[] = [
+  SupportedLocales.DE,
+  SupportedLocales.PT,
+  SupportedLocales.ES,
+  SupportedLocales.FR,
+];
 
 export const SUPPORTED_BASE_TAGS_LOCALE_MAPPING = Object.fromEntries(
   Object.entries(SUPPORTED_LOCALE_BASE_TAGS).map(([locale, baseTag]) => [baseTag, locale])

--- a/src/state/localization.ts
+++ b/src/state/localization.ts
@@ -41,7 +41,11 @@ export const localizationSlice = createSlice({
       const newLocale = action.payload.locale;
 
       // regulatory: track manual switching to EU language and whether it's their browser language / switching from English
-      if (!action.payload.isAutoDetect && EU_LOCALES.includes(newLocale)) {
+      if (
+        newLocale !== previousLocale &&
+        !action.payload.isAutoDetect &&
+        EU_LOCALES.includes(newLocale)
+      ) {
         track(
           AnalyticsEvents.SwitchedLanguageToEULanguage({
             previousLocale,

--- a/src/state/localization.ts
+++ b/src/state/localization.ts
@@ -1,7 +1,10 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
-import { EN_LOCALE_DATA, LocaleData, SupportedLocales } from '@/constants/localization';
+import { AnalyticsEvents } from '@/constants/analytics';
+import { EN_LOCALE_DATA, EU_LOCALES, LocaleData, SupportedLocales } from '@/constants/localization';
+
+import { track } from '@/lib/analytics';
 
 export interface LocalizationState {
   isLocaleLoaded: boolean;
@@ -33,10 +36,26 @@ export const localizationSlice = createSlice({
     setSelectedLocale: (
       state,
       action: PayloadAction<{ locale: SupportedLocales; isAutoDetect?: boolean }>
-    ) => ({
-      ...state,
-      selectedLocale: action.payload.locale,
-    }),
+    ) => {
+      const previousLocale = state.selectedLocale;
+      const newLocale = action.payload.locale;
+
+      // regulatory: track manual switching to EU language and whether it's their browser language / switching from English
+      if (!action.payload.isAutoDetect && EU_LOCALES.includes(newLocale)) {
+        track(
+          AnalyticsEvents.SwitchedLanguageToEULanguage({
+            previousLocale,
+            newLocale,
+            browserLanguage: globalThis.navigator?.language,
+          })
+        );
+      }
+
+      return {
+        ...state,
+        selectedLocale: newLocale,
+      };
+    },
   },
 });
 

--- a/src/state/localizationMiddleware.ts
+++ b/src/state/localizationMiddleware.ts
@@ -8,6 +8,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 
 import { LocalStorageKey } from '@/constants/localStorage';
 import {
+  EU_LOCALES,
   SUPPORTED_BASE_TAGS_LOCALE_MAPPING,
   SupportedLocales,
   type LocaleData,
@@ -57,12 +58,15 @@ export default (store: any) => (next: any) => async (action: PayloadAction<any>)
       } else if (globalThis.navigator?.language) {
         const browserLanguageBaseTag = globalThis.navigator.language.split('-')[0].toLowerCase();
 
-        const locale = (SUPPORTED_BASE_TAGS_LOCALE_MAPPING[browserLanguageBaseTag] ??
-          SUPPORTED_BASE_TAGS_LOCALE_MAPPING[SupportedLocales.EN]) as SupportedLocales;
+        let locale = (SUPPORTED_BASE_TAGS_LOCALE_MAPPING[browserLanguageBaseTag] ??
+          SupportedLocales.EN) as SupportedLocales;
 
-        if (locale) {
-          store.dispatch(setSelectedLocale({ locale, isAutoDetect: true }));
+        // regulatory: do not default to browser language if it's an EU language, default to English instead
+        if (EU_LOCALES.includes(locale)) {
+          locale = SupportedLocales.EN;
         }
+
+        store.dispatch(setSelectedLocale({ locale, isAutoDetect: true }));
       }
       break;
     }


### PR DESCRIPTION
when detected browser language is one of DE, PT, ES or FR, do not default to that language but override it to just use english.

add amplitude tracking when trader switched their language to one of those languages, with metadata including which language they switched from, and their current browser language.