### PR TITLE
fix: markets page nits

### DIFF
--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -82,7 +82,8 @@ const $MarketsStats = styled.section`
 const $Section = styled.div`
   background: var(--color-layer-3);
   border-radius: 0.625rem;
-  align-content: center;
+  display: grid;
+  grid-template-rows: auto 1fr;
 `;
 const $RecentlyListed = styled.h4`
   display: flex;
@@ -97,7 +98,7 @@ const $NewTag = styled(Tag)`
 const $ToggleGroupContainer = styled.div`
   ${layoutMixins.row}
   position: absolute;
-  top: -0.25rem;
+  top: 1rem;
   right: 1rem;
   z-index: 2;
 
@@ -118,7 +119,7 @@ const $SectionHeader = styled.div`
   ${layoutMixins.row}
   position: relative;
 
-  padding: 0 1.25rem 1.25rem;
+  padding: 1.25rem;
   gap: 0.25rem;
 
   & h4 {

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -19,6 +19,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { tradeViewMixins } from '@/styles/tradeViewMixins';
 
 import { Button } from '@/components/Button';
+import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Output, OutputType } from '@/components/Output';
 import { Table, type ColumnDef } from '@/components/Table';
 import { AssetTableCell } from '@/components/Table/AssetTableCell';
@@ -116,7 +117,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               columnKey: 'priceChange24HChart',
               label: stringGetter({ key: STRING_KEYS.LAST_24H }),
               renderCell: ({ line, priceChange24HPercent }) => (
-                <div style={{ width: 50, height: 50 }}>
+                <$SparklineChartContainer>
                   <SparklineChart
                     data={(line?.toArray() ?? []).map((datum, index) => ({
                       x: index + 1,
@@ -126,7 +127,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                     yAccessor={(datum) => datum.y}
                     positive={MustBigNumber(priceChange24HPercent).gt(0)}
                   />
-                </div>
+                </$SparklineChartContainer>
               ),
               allowsSorting: false,
             },
@@ -240,16 +241,18 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                   <p>{stringGetter({ key: STRING_KEYS.ADD_DETAILS_TO_LAUNCH_MARKET })}</p>
                 )}
               </>
-            ) : (
+            ) : searchFilter ? (
               <>
                 <h2>
                   {stringGetter({
                     key: STRING_KEYS.QUERY_NOT_FOUND,
-                    params: { QUERY: searchFilter ?? '' },
+                    params: { QUERY: searchFilter },
                   })}
                 </h2>
                 <p>{stringGetter({ key: STRING_KEYS.MARKET_SEARCH_DOES_NOT_EXIST_YET })}</p>
               </>
+            ) : (
+              <LoadingSpace id="markets-table" />
             )}
 
             {hasPotentialMarketsData && (
@@ -287,6 +290,9 @@ const $Toolbar = styled(Toolbar)`
 
 const $Table = styled(Table)`
   ${tradeViewMixins.horizontalTable}
+  tbody {
+    --tableCell-padding: 1rem 0;
+  }
 
   @media ${breakpoints.tablet} {
     table {
@@ -335,4 +341,9 @@ const $MarketNotFound = styled.div`
     font: var(--font-medium-book);
     font-weight: 500;
   }
+`;
+
+const $SparklineChartContainer = styled.div`
+  width: 3rem;
+  height: 2rem;
 `;


### PR DESCRIPTION
better loading state since markets page is now the default landing
before:
<img width="1800" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/95a96b2a-c685-49c2-bbc1-b52bd8ad7ea2">
after:
<img width="1800" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/5f516fdc-a0af-47f0-a731-747b6d057f10">


also updated padding a little since the sparklines feel too tall / too little padding:
before:
<img width="1306" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/f02d51eb-3217-4ea1-b67a-ff6918dbd5b0">
after:
<img width="1337" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/eb6d8122-6fd9-4fed-beca-4c45a77ba95f">
