### PR TITLE
feat(next-clob-pair-id): update new market proposal fetch

### DIFF
--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -143,7 +143,10 @@ export const useNextClobPairId = () => {
 
   const fetchNextClobPairId = useCallback(async () => {
     try {
-      const [governanceProposals, markets] = await Promise.all([requestAllGovernanceProposals(), requestAllPerpetualMarkets()]);
+      const [governanceProposals, markets] = await Promise.all([
+        requestAllGovernanceProposals(),
+        requestAllPerpetualMarkets(),
+      ]);
       return getNextClobPairIdAndTickers({ governanceProposals, markets });
     } catch (error) {
       log('useNextClobPairId/fetchNextClobPairId', error);

--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import {
   MsgCreateClobPair,
@@ -17,6 +17,8 @@ import { useQuery } from '@tanstack/react-query';
 import type { PerpetualMarketResponse } from '@/constants/indexer';
 
 import { useDydxClient } from '@/hooks/useDydxClient';
+
+import { log } from '@/lib/telemetry';
 
 /**
  *
@@ -85,53 +87,85 @@ export const useNextClobPairId = () => {
     staleTime: 10_000,
   });
 
-  const { nextAvailableClobPairId, tickersFromProposals } = useMemo(() => {
-    const idsFromProposals: number[] = [];
-    const newTickersFromProposals: Set<string> = new Set();
+  const getNextClobPairIdAndTickers = useCallback(
+    ({
+      governanceProposals,
+      markets,
+    }: {
+      governanceProposals?: Awaited<ReturnType<typeof requestAllGovernanceProposals>>;
+      markets?: Awaited<ReturnType<typeof requestAllPerpetualMarkets>>;
+    }) => {
+      const idsFromProposals: number[] = [];
+      const newTickersFromProposals: Set<string> = new Set();
 
-    const addIdFromProposal = (id?: number) => {
-      if (id) {
-        idsFromProposals.push(id);
-      }
-    };
-
-    const addTickerFromProposal = (ticker?: string) => {
-      if (ticker) {
-        newTickersFromProposals.add(ticker);
-      }
-    };
-
-    if (allGovProposals && Object.values(allGovProposals.proposals).length > 0) {
-      const proposals = allGovProposals.proposals;
-      proposals.forEach((proposal) => {
-        if (proposal.messages) {
-          proposal.messages.forEach((message) => {
-            decodeMsgForClobPairId(message, addIdFromProposal, addTickerFromProposal);
-          });
+      const addIdFromProposal = (id?: number) => {
+        if (id) {
+          idsFromProposals.push(id);
         }
-      });
-    }
+      };
 
-    if (perpetualMarkets && Object.values(perpetualMarkets).length > 0) {
-      const clobPairIds = Object.values(perpetualMarkets)?.map((perpetualMarket) =>
-        Number((perpetualMarket as PerpetualMarketResponse).clobPairId)
-      );
+      const addTickerFromProposal = (ticker?: string) => {
+        if (ticker) {
+          newTickersFromProposals.add(ticker);
+        }
+      };
 
-      const newNextAvailableClobPairId = Math.max(...[...clobPairIds, ...idsFromProposals]) + 1;
+      if (governanceProposals && Object.values(governanceProposals.proposals).length > 0) {
+        const proposals = governanceProposals.proposals;
+        proposals.forEach((proposal) => {
+          if (proposal.messages) {
+            proposal.messages.forEach((message) => {
+              decodeMsgForClobPairId(message, addIdFromProposal, addTickerFromProposal);
+            });
+          }
+        });
+      }
+
+      if (markets && Object.values(markets).length > 0) {
+        const clobPairIds = Object.values(markets)?.map((perpetualMarket) =>
+          Number((perpetualMarket as PerpetualMarketResponse).clobPairId)
+        );
+
+        const newNextAvailableClobPairId = Math.max(...[...clobPairIds, ...idsFromProposals]) + 1;
+        return {
+          nextAvailableClobPairId: newNextAvailableClobPairId,
+          tickersFromProposals: newTickersFromProposals,
+        };
+      }
+
       return {
-        nextAvailableClobPairId: newNextAvailableClobPairId,
+        nextAvailableClobPairId: undefined,
         tickersFromProposals: newTickersFromProposals,
       };
-    }
+    },
+    []
+  );
 
-    return {
-      nextAvailableClobPairId: undefined,
-      tickersFromProposals: newTickersFromProposals,
-    };
+  const fetchNextClobPairId = useCallback(async () => {
+    try {
+      const governanceProposals = await requestAllGovernanceProposals();
+      const markets = await requestAllPerpetualMarkets();
+      return getNextClobPairIdAndTickers({ governanceProposals, markets });
+    } catch (error) {
+      log('useNextClobPairId/fetchNextClobPairId', error);
+
+      return {
+        nextAvailableClobPairId: undefined,
+        tickersFromProposals: undefined,
+      };
+    }
+  }, [isCompositeClientConnected]);
+
+  const { nextAvailableClobPairId, tickersFromProposals } = useMemo(() => {
+    return getNextClobPairIdAndTickers({
+      governanceProposals: allGovProposals,
+      markets: perpetualMarkets,
+    });
   }, [perpetualMarkets, allGovProposals]);
 
   return {
     allGovProposalsStatus,
+    fetchNextClobPairId,
     perpetualMarketsStatus,
     nextAvailableClobPairId,
     tickersFromProposals,

--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -126,7 +126,7 @@ export const useNextClobPairId = () => {
           Number((perpetualMarket as PerpetualMarketResponse).clobPairId)
         );
 
-        const newNextAvailableClobPairId = Math.max(...[...clobPairIds, ...idsFromProposals]) + 1;
+        const newNextAvailableClobPairId = Math.max(...clobPairIds, ...idsFromProposals) + 1;
         return {
           nextAvailableClobPairId: newNextAvailableClobPairId,
           tickersFromProposals: newTickersFromProposals,

--- a/src/hooks/useNextClobPairId.ts
+++ b/src/hooks/useNextClobPairId.ts
@@ -143,8 +143,7 @@ export const useNextClobPairId = () => {
 
   const fetchNextClobPairId = useCallback(async () => {
     try {
-      const governanceProposals = await requestAllGovernanceProposals();
-      const markets = await requestAllPerpetualMarkets();
+      const [governanceProposals, markets] = await Promise.all([requestAllGovernanceProposals(), requestAllPerpetualMarkets()]);
       return getNextClobPairIdAndTickers({ governanceProposals, markets });
     } catch (error) {
       log('useNextClobPairId/fetchNextClobPairId', error);

--- a/src/views/forms/NewMarketForm/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/NewMarketSelectionStep.tsx
@@ -19,6 +19,7 @@ import {
 import { useAccountBalance } from '@/hooks/useAccountBalance';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useGovernanceVariables } from '@/hooks/useGovernanceVariables';
+import { useNextClobPairId } from '@/hooks/useNextClobPairId';
 import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
@@ -46,7 +47,6 @@ import { MustBigNumber } from '@/lib/numbers';
 
 type NewMarketSelectionStepProps = {
   assetToAdd?: NewMarketProposal;
-  clobPairId?: number;
   setAssetToAdd: (assetToAdd?: NewMarketProposal) => void;
   onConfirmMarket: () => void;
   liquidityTier?: number;
@@ -57,7 +57,6 @@ type NewMarketSelectionStepProps = {
 
 export const NewMarketSelectionStep = ({
   assetToAdd,
-  clobPairId,
   setAssetToAdd,
   onConfirmMarket,
   liquidityTier,
@@ -75,6 +74,7 @@ export const NewMarketSelectionStep = ({
   const { potentialMarkets, liquidityTiers } = usePotentialMarkets();
   const stringGetter = useStringGetter();
   const { newMarketProposal } = useGovernanceVariables();
+  const { nextAvailableClobPairId } = useNextClobPairId();
   const initialDepositAmountBN = MustBigNumber(newMarketProposal.initialDepositAmount).div(
     Number(`1e${chainTokenDecimals}`)
   );
@@ -273,7 +273,7 @@ export const NewMarketSelectionStep = ({
                         openDialog(
                           DialogTypes.NewMarketMessageDetails({
                             assetData: assetToAdd,
-                            clobPairId,
+                            clobPairId: nextAvailableClobPairId,
                             liquidityTier,
                           })
                         )
@@ -319,7 +319,7 @@ export const NewMarketSelectionStep = ({
         ) : (
           <Button
             type={ButtonType.Submit}
-            state={{ isDisabled: !assetToAdd || !liquidityTier === undefined || !clobPairId }}
+            state={{ isDisabled: !assetToAdd || !liquidityTier === undefined }}
             action={ButtonAction.Primary}
           >
             {stringGetter({ key: STRING_KEYS.PREVIEW_MARKET_PROPOSAL })}

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -28,7 +28,7 @@ export const NewMarketForm = () => {
   const [proposalTxHash, setProposalTxHash] = useState<string>();
   const { mintscan: mintscanTxUrl } = useURLConfigs();
 
-  const { nextAvailableClobPairId, tickersFromProposals } = useNextClobPairId();
+  const { tickersFromProposals } = useNextClobPairId();
   const { hasPotentialMarketsData } = usePotentialMarkets();
 
   const tickSizeDecimals = useMemo(() => {
@@ -37,7 +37,7 @@ export const NewMarketForm = () => {
     return Math.abs(p - 3);
   }, [assetToAdd]);
 
-  if (!hasPotentialMarketsData || !nextAvailableClobPairId) {
+  if (!hasPotentialMarketsData) {
     return <$LoadingSpace id="new-market-form" />;
   }
 
@@ -46,11 +46,10 @@ export const NewMarketForm = () => {
   }
 
   if (NewMarketFormStep.PREVIEW === step) {
-    if (assetToAdd && liquidityTier && nextAvailableClobPairId) {
+    if (assetToAdd && liquidityTier) {
       return (
         <NewMarketPreviewStep
           assetData={assetToAdd}
-          clobPairId={nextAvailableClobPairId}
           liquidityTier={liquidityTier}
           onBack={() => setStep(NewMarketFormStep.SELECTION)}
           onSuccess={(hash: string) => {
@@ -65,9 +64,10 @@ export const NewMarketForm = () => {
 
   return (
     <NewMarketSelectionStep
-      onConfirmMarket={() => setStep(NewMarketFormStep.PREVIEW)}
+      onConfirmMarket={() => {
+        setStep(NewMarketFormStep.PREVIEW);
+      }}
       assetToAdd={assetToAdd}
-      clobPairId={nextAvailableClobPairId}
       setAssetToAdd={setAssetToAdd}
       liquidityTier={liquidityTier}
       setLiquidityTier={setLiquidityTier}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Create general function that will calculate next available clobPairId. Add a manual fetch along with the polling fetch to be used onSubmit.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<NewMarketForm>`
 * Remove code that disables form  if `nextAvailableClobPairId` is not populated since it will be fetched right before market proposal.

* `<NewMarketSelectionStep>`
  * Remove `clobPairId` prop and use the contents of hook directly.
  * Remove code that disables continuing to next step if `clobPairId` is not populated since it will be fetched right before market proposal.

* `<NewMarketPreviewStep>`
  * Utilize `fetchNextClobPairId` in `onSubmit`
  * Remove `clobPairId` prop and use the contents of hook directly.

## Hooks

* `hooks/useNextClobPairId`
  * add `getNextClobPairIdAndTickers` to be used in new `fetchNextClobPairId` and existing memo.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
