### PR TITLE
fix: fix missing tab borders, update inputs padding

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -43,6 +43,7 @@ type StyleProps = {
   side?: 'top' | 'bottom';
   withBorders?: boolean;
   withTransitions?: boolean;
+  withUnderline?: boolean;
   className?: string;
 };
 
@@ -59,6 +60,7 @@ export const Tabs = <TabItemsValue extends string>({
   fullWidthTabs,
   side = 'top',
   withBorders = true,
+  withUnderline = false,
   withTransitions = true,
   disabled = false,
   className,
@@ -75,6 +77,7 @@ export const Tabs = <TabItemsValue extends string>({
                 key={item.value}
                 value={item.value}
                 $withBorders={withBorders}
+                $withUnderline={withUnderline}
                 disabled={disabled}
               >
                 {item.label}
@@ -90,7 +93,9 @@ export const Tabs = <TabItemsValue extends string>({
               onValueChange={onValueChange}
               align="end"
               $isActive={item.subitems.some((subitem) => subitem.value === value)}
-              slotTrigger={<$DropdownTabTrigger value={value ?? ''} />}
+              slotTrigger={
+                <$DropdownTabTrigger value={value ?? ''} $withUnderline={withUnderline} />
+              }
               disabled={disabled}
             >
               {item.label}
@@ -149,11 +154,16 @@ const tabTriggerStyle = css`
   font: var(--trigger-font, var(--font-base-book));
   color: var(--trigger-textColor);
   background-color: var(--trigger-backgroundColor);
-  box-shadow: inset 0 calc(var(--trigger-underline-size) * -1) 0 var(--trigger-active-textColor);
 
   &[data-state='active'] {
     color: var(--trigger-active-textColor);
     background-color: var(--trigger-active-backgroundColor);
+  }
+`;
+
+const tabTriggerUnderlineStyle = css`
+  box-shadow: inset 0 calc(var(--trigger-underline-size) * -1) 0 var(--trigger-active-textColor);
+  &[data-state='active'] {
     box-shadow: inset 0 calc(var(--trigger-active-underline-size) * -1) 0
       var(--trigger-active-textColor);
   }
@@ -248,14 +258,20 @@ const $List = styled(List)<{ $fullWidthTabs?: boolean; $withBorders?: boolean }>
         `}
 `;
 
-const $Trigger = styled(Trigger)<{ $withBorders?: boolean }>`
+const $Trigger = styled(Trigger)<{ $withBorders?: boolean; $withUnderline?: boolean }>`
+  ${tabTriggerStyle}
+
   ${({ $withBorders }) =>
     $withBorders &&
     css`
       ${layoutMixins.withOuterBorder}
     `}
 
-  ${tabTriggerStyle}
+  ${({ $withUnderline }) =>
+    $withUnderline &&
+    css`
+      ${tabTriggerUnderlineStyle}
+    `}
 `;
 
 const $Stack = styled.div`
@@ -308,12 +324,18 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
   }
 `;
 
-const $DropdownTabTrigger = styled(Trigger)`
+const $DropdownTabTrigger = styled(Trigger)<{ $withUnderline?: boolean }>`
   ${tabTriggerStyle}
   gap: 1ch;
 
   height: 100%;
   width: 100%;
+
+  ${({ $withUnderline }) =>
+    $withUnderline &&
+    css`
+      ${tabTriggerUnderlineStyle}
+    `}
 `;
 
 const dropdownSelectMenuType = getSimpleStyledOutputType(

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -48,6 +48,6 @@
   --form-input-gap: 0.625rem;
   --form-input-height: 3rem;
   --form-input-height-mobile: 3.5rem;
-  --form-input-paddingY: 0.375rem;
+  --form-input-paddingY: 0.25rem;
   --form-input-paddingX: 0.625rem;
 }

--- a/src/styles/formMixins.ts
+++ b/src/styles/formMixins.ts
@@ -37,6 +37,7 @@ export const formMixins = {
 
     height: var(--input-height);
     min-height: var(--input-height);
+    max-height: var(--input-height);
 
     background-color: var(--input-backgroundColor);
     border: var(--border-width) solid var(--input-borderColor);
@@ -158,11 +159,11 @@ export const formMixins = {
 
   transfersForm: css`
     ${() => inputsColumn}
-    --form-input-gap: 1.25rem;
+    --form-input-gap: 1rem;
     --form-input-height: 3.5rem;
     --form-input-height-mobile: 4rem;
     --form-input-paddingY: 0.5rem;
-    --form-input-paddingX: 1rem;
+    --form-input-paddingX: 0.75rem;
 
     height: 100%;
 
@@ -177,11 +178,11 @@ export const formMixins = {
 
   stakingForm: css`
     ${() => inputsColumn}
-    --form-input-gap: 1.25rem;
+    --form-input-gap: 1rem;
     --form-input-height: 3.5rem;
     --form-input-height-mobile: 4rem;
     --form-input-paddingY: 0.5rem;
-    --form-input-paddingX: 1rem;
+    --form-input-paddingX: 0.75rem;
 
     --withReceipt-backgroundColor: var(--color-layer-2);
 

--- a/src/views/TradeBoxOrderView.tsx
+++ b/src/views/TradeBoxOrderView.tsx
@@ -56,6 +56,7 @@ export const TradeBoxOrderView = () => {
             <TradeForm />
           </$Container>
         }
+        withUnderline
       />
     </$TradeBoxOrderViewContainer>
   );

--- a/src/views/forms/AdjustTargetLeverageForm.tsx
+++ b/src/views/forms/AdjustTargetLeverageForm.tsx
@@ -155,6 +155,7 @@ const $Description = styled.div`
 const $InputContainer = styled.div`
   ${formMixins.inputContainer}
   --input-height: 3.5rem;
+  --form-input-paddingY: 0.33rem;
 
   padding: var(--form-input-paddingY) var(--form-input-paddingX);
 
@@ -168,8 +169,6 @@ const $WithLabel = styled(WithLabel)`
 `;
 
 const $LeverageSlider = styled(Slider)`
-  margin-top: 0.25rem;
-
   --slider-track-background: linear-gradient(
     90deg,
     var(--color-layer-7) 0%,

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -143,7 +143,7 @@ export const MarketLeverageInput = ({
             </>
           }
         >
-          <$LeverageSlider
+          <LeverageSlider
             leverage={currentLeverage}
             leverageInputValue={getSignedLeverage(leverageInputValue)}
             maxLeverage={maxLeverage}
@@ -188,10 +188,6 @@ const $InputContainer = styled.div`
 
 const $WithLabel = styled(WithLabel)`
   ${formMixins.inputLabel}
-`;
-
-const $LeverageSlider = styled(LeverageSlider)`
-  margin-top: 0.25rem;
 `;
 
 const $InnerInputContainer = styled.div`


### PR DESCRIPTION
- add back missing borders in tabs
- reduce padding (esp vertical) for trade form inputs to get more real estate
- better vertical alignment in transfers inputs
before:
<img width="1369" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/1920830b-ae7e-44c4-bf7a-da6c0ab2c6b0">
after:
<img width="1374" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/88574dce-59b6-4a85-99fa-5486214720dd">

before:
<img width="325" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/1bf5feaa-f6fa-437d-82e5-9ed97a8e4ff6">
after:
<img width="324" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/4162420c-3866-4130-aa8c-2849bc4afc3e">

before:
<img width="651" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/2dfaf946-1eaa-4d15-97b5-56e28baafa84">
after:
<img width="602" alt="image" src="https://github.com/dydxprotocol/v4-web/assets/9400120/66de988a-6112-4e85-9df3-284bf2f67740">

