### PR TITLE
chore: update layout + padding on trade

### DIFF
--- a/src/components/PortfolioCard.tsx
+++ b/src/components/PortfolioCard.tsx
@@ -45,7 +45,7 @@ const $PortfolioCard = styled.div`
   min-width: 14rem;
   background-color: var(--color-layer-3);
   overflow: hidden;
-  padding: 0.75rem 0;
+  padding: 0.625rem 0;
   padding-bottom: 0.5rem;
   border-radius: 0.625rem;
 `;
@@ -64,7 +64,7 @@ const $MarketRow = styled.div`
 const $MarginRow = styled.div`
   ${layoutMixins.spacedRow}
   padding: 0 0.625rem;
-  margin-top: 0.625rem;
+  margin-top: 0.5rem;
 `;
 
 const $MarginLabel = styled.span`

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,15 @@
+import { STRING_KEYS } from './localization';
+
+export type ErrorParams =
+  | {
+      errorStringKey: string;
+      errorMessage?: string;
+    }
+  | {
+      errorStringKey?: string;
+      errorMessage: string;
+    };
+
+export const DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS = {
+  errorStringKey: STRING_KEYS.SOMETHING_WENT_WRONG,
+};

--- a/src/constants/orderbook.ts
+++ b/src/constants/orderbook.ts
@@ -9,7 +9,7 @@ export const ORDERBOOK_ANIMATION_DURATION = 100;
  * @note ORDERBOOK_ROW_HEIGHT should be a divisor of ORDERBOOK_HEIGHT so that we do not have a partial row at the bottom
  * @note To change the Orderbook width, --orderbook-trades-width and ORDERBOOK_WIDTH must be changed to the same value
  */
-export const ORDERBOOK_HEIGHT = 800;
+export const ORDERBOOK_HEIGHT = 792;
 export const ORDERBOOK_WIDTH = 300;
-export const ORDERBOOK_ROW_HEIGHT = 24;
+export const ORDERBOOK_ROW_HEIGHT = 22;
 export const ORDERBOOK_ROW_PADDING_RIGHT = 8;

--- a/src/constants/orderbook.ts
+++ b/src/constants/orderbook.ts
@@ -9,7 +9,7 @@ export const ORDERBOOK_ANIMATION_DURATION = 100;
  * @note ORDERBOOK_ROW_HEIGHT should be a divisor of ORDERBOOK_HEIGHT so that we do not have a partial row at the bottom
  * @note To change the Orderbook width, --orderbook-trades-width and ORDERBOOK_WIDTH must be changed to the same value
  */
-export const ORDERBOOK_HEIGHT = 792;
+export const ORDERBOOK_HEIGHT = 756;
 export const ORDERBOOK_WIDTH = 300;
-export const ORDERBOOK_ROW_HEIGHT = 22;
+export const ORDERBOOK_ROW_HEIGHT = 21;
 export const ORDERBOOK_ROW_PADDING_RIGHT = 8;

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -580,7 +580,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
             id: NotificationType.ApiError,
           });
         }
-      }, [stringGetter, statusErrorMessage?.body, statusErrorMessage?.title]);
+      }, [stringGetter, statusErrorMessage?.body, statusErrorMessage?.title, hideNotification]);
     },
     useNotificationAction: () => {
       return () => {};

--- a/src/pages/trade/Trade.tsx
+++ b/src/pages/trade/Trade.tsx
@@ -123,7 +123,7 @@ const $TradeLayout = styled.article<{
 
   /* prettier-ignore */
   --layout-alternative-desktopMedium:
-    'Top Inner Side' auto
+    'Vertical Top Side' auto
     'Vertical Inner Side' minmax(0, 1fr)
     'Horizontal Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
     / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);

--- a/src/pages/trade/Trade.tsx
+++ b/src/pages/trade/Trade.tsx
@@ -9,7 +9,6 @@ import { useCurrentMarketId } from '@/hooks/useCurrentMarketId';
 import { usePageTitlePriceUpdates } from '@/hooks/usePageTitlePriceUpdates';
 import { useTradeFormInputs } from '@/hooks/useTradeFormInputs';
 
-import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { DetachedSection } from '@/components/ContentSection';
@@ -97,7 +96,7 @@ const $TradeLayout = styled.article<{
   tradeLayout: TradeLayouts;
   isHorizontalPanelOpen: boolean;
 }>`
-  --horizontalPanel-height: 20.625rem;
+  --horizontalPanel-height: 18rem;
 
   // Constants
   /* prettier-ignore */
@@ -108,38 +107,10 @@ const $TradeLayout = styled.article<{
     / var(--sidebar-width) minmax(0, var(--orderbook-trades-width)) 1fr;
 
   /* prettier-ignore */
-  --layout-default-desktopMedium:
-    'Top Top Top' auto
-    'Side Vertical Inner' minmax(0, 1fr)
-    'Side Horizontal Horizontal' minmax(var(--tabs-height), var(--horizontalPanel-height))
-    / var(--sidebar-width) minmax(0, var(--orderbook-trades-width)) 1fr;
-
-  /* prettier-ignore */
-  --layout-default-desktopLarge:
-    'Top Top Top' auto
-    'Side Vertical Inner' minmax(0, 1fr)
-    'Side Vertical Horizontal' minmax(var(--tabs-height), var(--horizontalPanel-height))
-    / var(--sidebar-width) minmax(0, var(--orderbook-trades-width)) 1fr;
-
-  /* prettier-ignore */
   --layout-alternative:
     'Top Top Top' auto
     'Vertical Inner Side' minmax(0, 1fr)
     'Horizontal Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
-    / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);
-
-  /* prettier-ignore */
-  --layout-alternative-desktopMedium:
-    'Top Top Top' auto
-    'Vertical Inner Side' minmax(0, 1fr)
-    'Horizontal Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
-    / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);
-
-  /* prettier-ignore */
-  --layout-alternative-desktopLarge:
-    'Top Top Top' auto
-    'Vertical Inner Side' minmax(0, 1fr)
-    'Vertical Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
     / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);
 
   // Props/defaults
@@ -148,27 +119,11 @@ const $TradeLayout = styled.article<{
 
   // Variants
 
-  @media ${breakpoints.desktopMedium} {
-    --layout: var(--layout-default-desktopMedium);
-  }
-
-  @media ${breakpoints.desktopLarge} {
-    --horizontalPanel-height: 23.75rem;
-    --layout: var(--layout-default-desktopLarge);
-  }
-
   ${({ tradeLayout }) =>
     ({
       [TradeLayouts.Default]: null,
       [TradeLayouts.Alternative]: css`
         --layout: var(--layout-alternative);
-
-        @media ${breakpoints.desktopMedium} {
-          --layout: var(--layout-alternative-desktopMedium);
-        }
-        @media ${breakpoints.desktopLarge} {
-          --layout: var(--layout-alternative-desktopLarge);
-        }
       `,
       [TradeLayouts.Reverse]: css`
         direction: rtl;

--- a/src/pages/trade/Trade.tsx
+++ b/src/pages/trade/Trade.tsx
@@ -9,6 +9,7 @@ import { useCurrentMarketId } from '@/hooks/useCurrentMarketId';
 import { usePageTitlePriceUpdates } from '@/hooks/usePageTitlePriceUpdates';
 import { useTradeFormInputs } from '@/hooks/useTradeFormInputs';
 
+import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { DetachedSection } from '@/components/ContentSection';
@@ -107,8 +108,22 @@ const $TradeLayout = styled.article<{
     / var(--sidebar-width) minmax(0, var(--orderbook-trades-width)) 1fr;
 
   /* prettier-ignore */
+  --layout-default-desktopMedium:
+    'Side Vertical Top' auto
+    'Side Vertical Inner' minmax(0, 1fr)
+    'Side Horizontal Horizontal' minmax(var(--tabs-height), var(--horizontalPanel-height))
+    / var(--sidebar-width) minmax(0, var(--orderbook-trades-width)) 1fr;
+
+  /* prettier-ignore */
   --layout-alternative:
     'Top Top Top' auto
+    'Vertical Inner Side' minmax(0, 1fr)
+    'Horizontal Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
+    / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);
+
+  /* prettier-ignore */
+  --layout-alternative-desktopMedium:
+    'Top Inner Side' auto
     'Vertical Inner Side' minmax(0, 1fr)
     'Horizontal Horizontal Side' minmax(var(--tabs-height), var(--horizontalPanel-height))
     / minmax(0, var(--orderbook-trades-width)) 1fr var(--sidebar-width);
@@ -118,12 +133,18 @@ const $TradeLayout = styled.article<{
   --layout: var(--layout-default);
 
   // Variants
+  @media ${breakpoints.desktopMedium} {
+    --layout: var(--layout-default-desktopMedium);
+  }
 
   ${({ tradeLayout }) =>
     ({
       [TradeLayouts.Default]: null,
       [TradeLayouts.Alternative]: css`
         --layout: var(--layout-alternative);
+        @media ${breakpoints.desktopMedium} {
+          --layout: var(--layout-alternative-desktopMedium);
+        }
       `,
       [TradeLayouts.Reverse]: css`
         direction: rtl;

--- a/src/pages/trade/UnopenedIsolatedPositions.tsx
+++ b/src/pages/trade/UnopenedIsolatedPositions.tsx
@@ -46,7 +46,7 @@ export const MaybeUnopenedIsolatedPositionsDrawer = ({
     <$UnopenedIsolatedPositionsDrawerContainer className={className} isOpen={isOpen}>
       <$Button onClick={() => setIsOpen(!isOpen)}>
         {stringGetter({ key: STRING_KEYS.UNOPENED_ISOLATED_POSITIONS })}
-        <DropdownIcon iconName={IconName.Caret} isOpen={isOpen} />
+        <$DropdownIcon iconName={IconName.Caret} isOpen={isOpen} />
       </$Button>
 
       {isOpen && (
@@ -123,7 +123,7 @@ const $UnopenedIsolatedPositionsDrawerContainer = styled.div<{ isOpen?: boolean 
 const $Button = styled(Button)`
   position: sticky;
   top: 0;
-  gap: 1rem;
+  gap: 0.75rem;
   backdrop-filter: blur(4px) contrast(1.01);
   background-color: transparent;
   border: none;
@@ -136,4 +136,8 @@ const $Cards = styled.div`
 `;
 const $CardsContainer = styled.div`
   padding: 0 1rem 1rem;
+`;
+
+const $DropdownIcon = styled(DropdownIcon)`
+  font-size: 0.5em;
 `;

--- a/src/pages/trade/UnopenedIsolatedPositions.tsx
+++ b/src/pages/trade/UnopenedIsolatedPositions.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react';
 
 import { shallowEqual } from 'react-redux';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { SubaccountPendingPosition } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
@@ -112,7 +112,13 @@ const UnopenedIsolatedPositionsCards = ({
 const $UnopenedIsolatedPositionsDrawerContainer = styled.div<{ isOpen?: boolean }>`
   overflow: auto;
   border-top: var(--border);
-  ${({ isOpen }) => isOpen && 'height: 100%;'}
+
+  ${({ isOpen }) =>
+    isOpen &&
+    css`
+      min-height: 10rem;
+      height: 100%;
+    `}
 `;
 const $Button = styled(Button)`
   position: sticky;

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -3,9 +3,9 @@
   --default-border-width: 1px;
 
   /* Header + footer constants */
-  --page-header-height: 2.9rem;
+  --page-header-height: 2.75rem;
   --page-header-height-mobile: 4rem;
-  --page-footer-height: 2.25rem;
+  --page-footer-height: 2rem;
   --page-footer-height-mobile: 4.5rem;
 
   /* Sidebar constants */
@@ -16,7 +16,7 @@
   --default-page-content-max-width: 80rem;
 
   /* Trade constants */
-  --market-info-row-height: 3rem;
+  --market-info-row-height: 2.675rem;
   --market-info-row-height-mobile: 4.5rem;
 
   --tabs-height: 2.675rem;

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -19,7 +19,7 @@
   --market-info-row-height: 3rem;
   --market-info-row-height-mobile: 4.5rem;
 
-  --tabs-height: 2.75rem;
+  --tabs-height: 2.675rem;
   --tabs-height-mobile: 3.25rem;
 
   --orderbook-trades-width: 18.75rem;

--- a/src/styles/tradeViewMixins.ts
+++ b/src/styles/tradeViewMixins.ts
@@ -7,7 +7,7 @@ import {
 
 export const tradeViewMixins = {
   horizontalTable: css`
-    --tableCell-padding: 0.25rem 0.25rem;
+    --tableCell-padding: 0.25rem;
     --tableStickyRow-backgroundColor: var(--color-layer-2);
     --tableRow-backgroundColor: var(--color-layer-2);
     font: var(--font-mini-book);

--- a/src/styles/tradeViewMixins.ts
+++ b/src/styles/tradeViewMixins.ts
@@ -7,7 +7,7 @@ import {
 
 export const tradeViewMixins = {
   horizontalTable: css`
-    --tableCell-padding: 0.5rem 0.25rem;
+    --tableCell-padding: 0.25rem 0.25rem;
     --tableStickyRow-backgroundColor: var(--color-layer-2);
     --tableRow-backgroundColor: var(--color-layer-2);
     font: var(--font-mini-book);

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -275,8 +275,7 @@ const $OrderbookContent = styled.div<{ $isLoading?: boolean }>`
 `;
 
 const $Header = styled(OrderbookRow)`
-  height: 2rem;
-  border-bottom: var(--border);
+  height: 1.75rem;
   color: var(--color-text-0);
 `;
 

--- a/src/views/CanvasOrderbook/OrderbookControls.tsx
+++ b/src/views/CanvasOrderbook/OrderbookControls.tsx
@@ -115,7 +115,6 @@ const $OrderbookUnitControl = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 0.5rem;
-  border-bottom: var(--border);
 `;
 
 const $MinusSymbolCenter = styled.span`

--- a/src/views/CanvasOrderbook/OrderbookRow.tsx
+++ b/src/views/CanvasOrderbook/OrderbookRow.tsx
@@ -73,7 +73,7 @@ export const OrderbookMiddleRow = forwardRef<HTMLDivElement, StyleProps & Elemen
   }
 );
 const $OrderbookMiddleRow = styled(OrderbookRow)<{ side?: 'top' | 'bottom' }>`
-  height: 2rem;
+  height: 1.75rem;
   border-top: var(--border);
   border-bottom: var(--border);
 

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -213,6 +213,7 @@ const $ToggleButton = styled(ToggleButton)`
   gap: 1px;
 
   svg {
+    color: var(--color-text-1);
     rotate: 0.25turn;
     margin-top: 2px;
   }


### PR DESCRIPTION
1. reduce horizontal panel (i.e. position table etc.) height on all screen sizes
2. reduce vertical padding on `Tabs` and horizontal tables i.e. positions/orders/fills table
3. a little more height on isolated positions so it doesn't scroll weirdly
4. reduce orderbook row height
5. update orderbook/trade layout to take up more height if laptop size is wide; remove some borders from orderbook since they no longer match up

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/fd306c5e-61ba-4d6b-ba5f-9fed83cbb975">
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/70ef5b1b-3d0f-4698-ad61-b480b4f38351">
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/02455f4e-0dd8-4825-9301-df86aa8a043a">

