### PR TITLE
fix: fix orderbook and trade tab stack

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -289,6 +289,10 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
     pointer-events: none;
   }
 
+  &[data-state='active'] {
+    z-index: 1;
+  }
+
   ${({ $hide }) =>
     $hide &&
     css`

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -195,6 +195,9 @@ const $Root = styled(Root)<{ $side: 'top' | 'bottom'; $withInnerBorder?: boolean
   --stickyArea0-background: var(--color-layer-2);
   --stickyArea0-topGap: var(--border-width);
 
+  --activeTab-zIndex: 1;
+  --stickyHeader-zIndex: calc(var(--activeTab-zIndex) + 1);
+
   ${layoutMixins.contentContainer}
 
   ${({ $side }) =>
@@ -236,6 +239,7 @@ const $Header = styled.header<{ $side: 'top' | 'bottom' }>`
 
   ${layoutMixins.row}
   justify-content: space-between;
+  z-index: var(--stickyHeader-zIndex);
 `;
 
 const $List = styled(List)<{ $fullWidthTabs?: boolean; $withBorders?: boolean }>`
@@ -290,7 +294,7 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
   }
 
   &[data-state='active'] {
-    z-index: 1;
+    z-index: var(--activeTab-zIndex);
   }
 
   ${({ $hide }) =>

--- a/src/views/tables/LiveTrades.tsx
+++ b/src/views/tables/LiveTrades.tsx
@@ -60,15 +60,15 @@ export const LiveTrades = ({ className, histogramSide = 'left' }: StyleProps) =>
   const { decimal: decimalSeparator, group: groupSeparator } = useLocaleSeparators();
   const selectedLocale = useAppSelector(getSelectedLocale);
 
-  const rows = currentMarketLiveTrades
-    .map(({ createdAtMilliseconds, price, size, side }: MarketTrade, idx) => ({
+  const rows = currentMarketLiveTrades.map(
+    ({ createdAtMilliseconds, price, size, side }: MarketTrade, idx) => ({
       key: idx,
       createdAtMilliseconds,
       price,
       side: getSelectedOrderSide(side),
       size,
-    }))
-    .slice(0, 1);
+    })
+  );
 
   const columns = useMemo(() => {
     const timeColumn = {

--- a/src/views/tables/LiveTrades.tsx
+++ b/src/views/tables/LiveTrades.tsx
@@ -60,15 +60,15 @@ export const LiveTrades = ({ className, histogramSide = 'left' }: StyleProps) =>
   const { decimal: decimalSeparator, group: groupSeparator } = useLocaleSeparators();
   const selectedLocale = useAppSelector(getSelectedLocale);
 
-  const rows = currentMarketLiveTrades.map(
-    ({ createdAtMilliseconds, price, size, side }: MarketTrade, idx) => ({
+  const rows = currentMarketLiveTrades
+    .map(({ createdAtMilliseconds, price, size, side }: MarketTrade, idx) => ({
       key: idx,
       createdAtMilliseconds,
       price,
       side: getSelectedOrderSide(side),
       size,
-    })
-  );
+    }))
+    .slice(0, 1);
 
   const columns = useMemo(() => {
     const timeColumn = {
@@ -177,9 +177,10 @@ const $SizeOutput = styled(Output)<StyleProps>`
 
 const liveTradesTableType = getSimpleStyledOutputType(OrderbookTradesTable, {} as StyleProps);
 const $LiveTradesTable = styled(OrderbookTradesTable)<StyleProps>`
+  background: var(--color-layer-2);
+
   tr {
     --histogram-bucket-size: 1;
-    background-color: var(--color-layer-2);
 
     &[data-side=${OrderSide.BUY}] {
       --accent-color: var(--color-positive);


### PR DESCRIPTION
the reason that the orderbook leaked into a short trade tab stack is because we use [forceMount](https://github.com/dydxprotocol/v4-web/blame/main/src/pages/trade/VerticalPanel.tsx#L40) on the orderbook tab for [perf reasons](https://github.com/dydxprotocol/v4-web/pull/227) (along with asChild), but not on the trade tab.
- I tried removing these two attributes but it looked off when switching between the tabs
- instead fixed by giving trade tab a z-index of 1 when active (and updating the sticky header z-index to 2 so that scrolling on the trade tab doesn't go over the tab headers), and setting background on entire table rather than rows

## few trades
- manually slicing to few trades in local branch


https://github.com/user-attachments/assets/8437c287-6e74-47f3-ae12-ef2ee602f580


## many trades


https://github.com/user-attachments/assets/b9c9b683-727c-42fc-9424-33bf8395d194

