### PR TITLE
feat: bump abacus + error message overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.8.40",
+    "@dydxprotocol/v4-abacus": "1.8.41",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.151",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.8.40
-    version: 1.8.40
+    specifier: 1.8.41
+    version: 1.8.41
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
@@ -3203,8 +3203,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.8.40:
-    resolution: {integrity: sha512-YmWm+8xuMx3wsorhg99OsXANL7t7WO4ic9hLG0wZX9bsCq9zsEvfpRVd+2oTZXX6UaP3iln5XLGWevjyH+3Xmw==}
+  /@dydxprotocol/v4-abacus@1.8.41:
+    resolution: {integrity: sha512-3Vbjfqg2rBmWn2nkRIpaHODBGxKFDAe8E4r9V3MdBUtvEBApUSGbVVD5TG8YJgjFc4TBCk0I7diXXVG47iwezQ==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,5 @@
+import { log } from './telemetry';
+
 /**
  * Error thrown if StatefulOrder includes an error code in it's response.
  */
@@ -13,3 +15,23 @@ export class StatefulOrderError extends Error {
     this.code = response.code;
   }
 }
+
+type RouteErrorCodes = 5;
+
+const routeErrorCodesToMessageOverride = {
+  5: 'This route is not yet supported, please check back soon as we are adding new routes.',
+};
+
+export const getRouteErrorMessageOverride = (
+  routeErrors: string,
+  routeErrorMessage: string | null | undefined
+) => {
+  try {
+    const routeErrorsObj = JSON.parse(routeErrors);
+    const routeErrorCode = routeErrorsObj?.[0]?.code as RouteErrorCodes;
+    return routeErrorCodesToMessageOverride[routeErrorCode] ?? routeErrorMessage;
+  } catch (err) {
+    log('getRouteErrorMessageOverride', err);
+    return routeErrorMessage;
+  }
+};

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -61,6 +61,7 @@ import { getSelectedLocale } from '@/state/localizationSelectors';
 import abacusStateManager from '@/lib/abacus';
 import { validateCosmosAddress } from '@/lib/addressUtils';
 import { track } from '@/lib/analytics';
+import { getRouteErrorMessageOverride } from '@/lib/errors';
 import { MustBigNumber } from '@/lib/numbers';
 import { getNobleChainId } from '@/lib/squid';
 import { log } from '@/lib/telemetry';
@@ -403,20 +404,25 @@ export const WithdrawForm = () => {
       };
 
     if (routeErrors) {
+      const routeErrorMessageOverride = getRouteErrorMessageOverride(
+        routeErrors,
+        routeErrorMessage
+      );
+
       track(
         AnalyticsEvents.RouteError({
           transferType: TransferType.withdrawal.name,
-          errorMessage: routeErrorMessage ?? undefined,
+          errorMessage: routeErrorMessageOverride ?? undefined,
           amount: debouncedAmount,
           chainId: chainIdStr ?? undefined,
           assetId: toToken?.toString(),
         })
       );
       return {
-        errorMessage: routeErrorMessage
+        errorMessage: routeErrorMessageOverride
           ? stringGetter({
               key: STRING_KEYS.SOMETHING_WENT_WRONG_WITH_MESSAGE,
-              params: { ERROR_MESSAGE: routeErrorMessage },
+              params: { ERROR_MESSAGE: routeErrorMessageOverride },
             })
           : stringGetter({ key: STRING_KEYS.SOMETHING_WENT_WRONG }),
       };


### PR DESCRIPTION
This PR does 2 things:
1. Upgrades abacus. This gives us the `no multi tx` flag in the withdrawals route which will prevent the FE from allowing users to attempt a multi tx route (base + polygon CCTP would fall under this category). We want to prevent this because abacus only handles a single tx. this would cause our users' funds to just go into noble and be swept back, or in the worst case scenario be stuck completely and require help from skip to retrieve.


2. Replaces base message of `"no single-tx routes found, to enable multi-tx routes set allow_multi_tx to true"` which would be very confusing to the end user for a more user friendly `'This route is not yet supported, please check back soon as we are adding new routes.'`

Ideally we do the error message overrides in abacus but:
1. it's a bit difficult/annoying to do until we migrate fully off of squid and i'm prioritizing quickly launching web
2. this code should be fully out before mobile is done cutting over
3. this code is mostly just needed for the `base` and `polygon` withdrawal routes for the next few days until we can feel confident we're 100% on skip and can re-add them to the cctp.json.
4. once we're fully released on web, we can remove this code and begin refactoring the error code logic in abacus.
5. ALSO this gives us an opportunity to possibly move onboarding flow off of abacus. we already have some divergent behavior and moving web off of abacus for onboarding will make future updates MUCH easier (skip is mostly designed around their sdk, not api)

<img width="533" alt="image" src="https://github.com/user-attachments/assets/59d72326-4085-4109-a42c-ba52c9ae27c7">
