### PR TITLE
chore: suppress data from hotjar [OTE-524]

### DIFF
--- a/src/views/dialogs/MnemonicExportDialog.tsx
+++ b/src/views/dialogs/MnemonicExportDialog.tsx
@@ -99,7 +99,11 @@ export const MnemonicExportDialog = ({ setIsOpen }: DialogProps<MnemonicExportDi
         </$RevealControls>
         <WithReceipt
           slotReceipt={
-            <$WordList isShowing={isShowing} onClick={() => setIsShowing(!isShowing)}>
+            <$WordList
+              data-hj-suppress
+              isShowing={isShowing}
+              onClick={() => setIsShowing(!isShowing)}
+            >
               <$List>
                 {mnemonic?.split(' ').map((word: string, i: number) => (
                   // eslint-disable-next-line react/no-array-index-key

--- a/src/views/dialogs/MobileSignInDialog.tsx
+++ b/src/views/dialogs/MobileSignInDialog.tsx
@@ -98,7 +98,7 @@ export const MobileSignInDialog = ({ setIsOpen }: DialogProps<MobileSignInDialog
     ),
     [MobileSignInState.Scanning]: (
       <>
-        <p>
+        <p data-hj-suppress>
           {stringGetter({
             key: STRING_KEYS.WHILE_ONBOARDING,
             params: {


### PR DESCRIPTION
Suppress the following data from hotjar
- wordlist for recovery phrase
- qrcode + encryption key for mobile login

For `privy email + phone number`:
- privy only has an email input (unless i'm missing something?)
- we don't have any control over the privy modal, deployers will just have to [update their hotjar settings to not record on email inputs](https://help.hotjar.com/hc/en-us/articles/115012439167-How-to-Suppress-Text-Images-Videos-and-User-Input-from-Collected-Data#site-wide)