### PR TITLE
fix(compliance): during close only, check for close position form for place orders

### DIFF
--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -370,3 +370,11 @@ export type PerpetualMarketOrderbookLevel = OrderbookLine & {
   mine: number | undefined;
   key: string;
 };
+
+export enum AbacusInputTypes {
+  AdjustIsolatedMargin = 'adjustIsolatedMargin',
+  ClosePosition = 'closePosition',
+  Transfer = 'transfer',
+  Trade = 'trade',
+  TriggerOrders = 'triggerOrders',
+}

--- a/src/state/inputsSelectors.ts
+++ b/src/state/inputsSelectors.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { shallowEqual } from 'react-redux';
 
+import { AbacusInputTypes } from '@/constants/abacus';
 import { EMPTY_ARR } from '@/constants/objects';
 
 import { type RootState } from './_store';
@@ -60,7 +61,7 @@ export const getCurrentInput = (state: RootState) => state.inputs.current;
  */
 export const getTradeInputErrors = (state: RootState) => {
   const currentInput = state.inputs.current;
-  return currentInput === 'trade' ? getInputErrors(state) : EMPTY_ARR;
+  return currentInput === AbacusInputTypes.Trade ? getInputErrors(state) : EMPTY_ARR;
 };
 
 /**
@@ -69,7 +70,7 @@ export const getTradeInputErrors = (state: RootState) => {
  */
 export const getClosePositionInputErrors = (state: RootState) => {
   const currentInput = state.inputs.current;
-  return currentInput === 'closePosition' ? getInputErrors(state) : EMPTY_ARR;
+  return currentInput === AbacusInputTypes.ClosePosition ? getInputErrors(state) : EMPTY_ARR;
 };
 
 /**
@@ -90,7 +91,7 @@ export const getTransferInputs = (state: RootState) => state.inputs.transferInpu
  */
 export const getTriggerOrdersInputErrors = (state: RootState) => {
   const currentInput = state.inputs.current;
-  return currentInput === 'triggerOrders' ? getInputErrors(state) : EMPTY_ARR;
+  return currentInput === AbacusInputTypes.TriggerOrders ? getInputErrors(state) : EMPTY_ARR;
 };
 
 /**

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
 import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 
-import { Nullable, type PerpetualMarketOrderbookLevel } from '@/constants/abacus';
+import { AbacusInputTypes, Nullable, type PerpetualMarketOrderbookLevel } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 import { SMALL_USD_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { ORDERBOOK_MAX_ROWS_PER_SIDE, ORDERBOOK_ROW_HEIGHT } from '@/constants/orderbook';
@@ -118,7 +118,7 @@ export const CanvasOrderbook = forwardRef(
     const dispatch = useAppDispatch();
     const onRowAction = useCallback(
       (price: Nullable<number>) => {
-        if (currentInput === 'trade' && price) {
+        if (currentInput === AbacusInputTypes.Trade && price) {
           // avoid scientific notation for when converting small number to string
           dispatch(
             setTradeFormInputs({

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -5,6 +5,7 @@ import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 
 import {
+  AbacusInputTypes,
   ComplianceStatus,
   ErrorType,
   TradeInputErrorAction,
@@ -112,7 +113,7 @@ export const TradeForm = ({
 
   const hasInputErrors =
     !!tradeErrors?.some((error: ValidationError) => error.type !== ErrorType.warning) ||
-    currentInput !== 'trade';
+    currentInput !== AbacusInputTypes.Trade;
 
   const { getNotificationPreferenceForType } = useNotifications();
 

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -1,7 +1,7 @@
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
-import { AbacusMarginMode, type TradeInputSummary } from '@/constants/abacus';
+import { AbacusInputTypes, AbacusMarginMode, type TradeInputSummary } from '@/constants/abacus';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
@@ -83,8 +83,13 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const hasMissingData = subaccountNumber === undefined;
 
+  const closeOnlyTradingUnavailable =
+    complianceState === ComplianceStates.CLOSE_ONLY &&
+    selectedTradeType !== TradeTypes.MARKET &&
+    currentInput !== AbacusInputTypes.ClosePosition;
+
   const tradingUnavailable =
-    (complianceState === ComplianceStates.CLOSE_ONLY && selectedTradeType !== TradeTypes.MARKET) ||
+    closeOnlyTradingUnavailable ||
     complianceState === ComplianceStates.READ_ONLY ||
     connectionError === ConnectionErrorType.CHAIN_DISRUPTION;
 
@@ -92,7 +97,7 @@ export const PlaceOrderButtonAndReceipt = ({
     canAccountTrade &&
     !hasMissingData &&
     !hasValidationErrors &&
-    currentInput !== 'transfer' &&
+    currentInput !== AbacusInputTypes.Transfer &&
     !tradingUnavailable;
 
   const { fee, price: expectedPrice, reward } = summary ?? {};


### PR DESCRIPTION
During close position, the `selectedTradeType` is not correctly set to `MARKET` by abacus, instead the `MARKET` type is hardcoded when a close position order is placed.

During close only we are checking for `selectedTradeType` which is inaccurate, so we want to check for the current input type to see if it is also `closePosition`