### PR TITLE
fix(depthchart): fix x axis of depth chart for prices < 1

### DIFF
--- a/src/views/charts/DepthChart/index.tsx
+++ b/src/views/charts/DepthChart/index.tsx
@@ -28,6 +28,7 @@ import { StringGetterFunction } from '@/constants/localization';
 
 import { useOrderbookValuesForDepthChart } from '@/hooks/Orderbook/useOrderbookValues';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
+import { useLocaleSeparators } from '@/hooks/useLocaleSeparators';
 
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { OutputType, formatNumberOutput } from '@/components/Output';
@@ -52,20 +53,6 @@ const theme = buildChartTheme({
 const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
 const lerp = (percent: number, from: number, to: number) => from + percent * (to - from);
 
-const formatNumber = (n: number, selectedLocale: string, isCompact: boolean = n >= 10000) => {
-  const formattedNumber = Intl.NumberFormat(selectedLocale).format(n);
-
-  const compactNumber = formatNumberOutput(n, OutputType.CompactNumber, {
-    decimalSeparator: undefined,
-    groupSeparator: undefined,
-    selectedLocale,
-  });
-
-  return isCompact && compactNumber.length < formattedNumber.length
-    ? compactNumber
-    : formattedNumber;
-};
-
 export const DepthChart = ({
   onChartClick,
   stringGetter,
@@ -78,6 +65,7 @@ export const DepthChart = ({
   // Context
 
   const { isMobile } = useBreakpoints();
+  const { decimal: decimalSeparator, group: groupSeparator } = useLocaleSeparators();
 
   // Chart data
   const { id = '' } = useAppSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
@@ -159,6 +147,17 @@ export const DepthChart = ({
     [midMarketPrice]
   );
 
+  const formatNumber = useCallback(
+    (n: number) =>
+      formatNumberOutput(n, OutputType.Number, {
+        decimalSeparator,
+        groupSeparator,
+        selectedLocale,
+        fractionDigits: tickSizeDecimals,
+      }),
+    [decimalSeparator, groupSeparator, selectedLocale, tickSizeDecimals]
+  );
+
   // Render conditions
 
   if (!(zoomDomain && midMarketPrice && asks.length && bids.length))
@@ -215,11 +214,7 @@ export const DepthChart = ({
             onPointerMove={(point) => point && setChartPointAtPointer(getChartPoint(point))}
             onPointerPressedChange={(pointerPressed) => setIsPointerPressed(pointerPressed)}
           >
-            <Axis
-              orientation="bottom"
-              numTicks={5}
-              tickFormat={(n) => formatNumber(n, selectedLocale, zoomDomain >= 500)}
-            />
+            <Axis orientation="bottom" numTicks={4} tickFormat={formatNumber} />
 
             <Grid
               numTicks={4}


### PR DESCRIPTION
Updated so that x axis always renders with `tickSizeDecimals` precision
- Had to tweak `numTicks` from `5` -> `4` to make the lowest price markets work (to not have the numbers overlap)
  - I think this is the easiest solution rn 🤔 tho open to other ideas
  

https://github.com/user-attachments/assets/877303ce-b3b8-4f9b-be65-0aaaadda517e



---

## Components

* `DepthChart`
  * Updated number formatting function
  * I'm unsure when zoomDomain is ever > 500 (couldn't make it happen through manual scrolling), solution seems to work for everything from lowest (MOG) to highest price markets (BTC)
