### PR TITLE
feat: unsupported transaction error fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.8.54",
     "@dydxprotocol/v4-client-js": "^1.1.27",
-    "@dydxprotocol/v4-localization": "^1.1.159",
+    "@dydxprotocol/v4-localization": "^1.1.160",
     "@ethersproject/providers": "^5.7.2",
     "@hugocxl/react-to-image": "^0.0.9",
     "@js-joda/core": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ dependencies:
     specifier: ^1.1.27
     version: 1.1.27
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.159
+    specifier: ^1.1.160
     version: 1.1.160
   '@ethersproject/providers':
     specifier: ^5.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ dependencies:
     version: 1.1.27
   '@dydxprotocol/v4-localization':
     specifier: ^1.1.159
-    version: 1.1.159
+    version: 1.1.160
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -3239,8 +3239,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.159:
-    resolution: {integrity: sha512-tIjxVXrK8drd9ilm5kNS7n6LR1kqEH45kvi04SiSI+0edDCQ8DbkQxu+68HjDIaFjj4X6Kr4q+gWq2LQjy7+wA==}
+  /@dydxprotocol/v4-localization@1.1.160:
+    resolution: {integrity: sha512-Ry5Fnbph3x8qgbn1hINn0tZBz+Z6N0X/yJ8JVNmAZE/mHKx5u20QW57SZ4hZr7F6yoT3y3RCk/vE3gAjsXk+tw==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -1,4 +1,5 @@
 import { StatsigConfigType } from '@/types/statsig';
+import { Nullable } from '@dydxprotocol/v4-abacus';
 import {
   APP_STRING_KEYS,
   ERRORS_STRING_KEYS,
@@ -52,13 +53,21 @@ export type LocaleData = typeof EN_LOCALE_DATA;
 
 export type StringGetterParams = Record<string, any>;
 
-export type StringGetterFunction = <T extends StringGetterParams>({
-  key,
-  params,
-}: {
-  key: string;
-  params?: T;
-}) => T extends {
+export type StringGetterProps<T extends StringGetterParams> =
+  | {
+      key: string;
+      params?: T;
+      fallback?: string;
+    }
+  | {
+      key?: Nullable<string>;
+      params?: T;
+      fallback: string;
+    };
+
+export type StringGetterFunction = <T extends StringGetterParams>(
+  props: StringGetterProps<T>
+) => T extends {
   [K in keyof T]: T[K] extends string | number ? any : T[K] extends JSX.Element ? any : never;
 }
   ? string

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -2,6 +2,8 @@ import { AlertType } from '@/constants/alerts';
 import { STRING_KEYS } from '@/constants/localization';
 import { TimeUnitShort } from '@/constants/time';
 
+import { ErrorParams } from './errors';
+
 export enum TradeTypes {
   MARKET = 'MARKET',
   LIMIT = 'LIMIT',
@@ -171,11 +173,11 @@ export type LocalPlaceOrderData = {
   orderId?: string;
   orderType: TradeTypes;
   submissionStatus: PlaceOrderStatuses;
-  errorStringKey?: string;
+  errorParams?: ErrorParams;
 };
 
 export type LocalCancelOrderData = {
   orderId: string;
   submissionStatus: CancelOrderStatuses;
-  errorStringKey?: string;
+  errorParams?: ErrorParams;
 };

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -612,7 +612,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 />
               ),
             },
-            [localPlace.submissionStatus, localPlace.errorStringKey],
+            [localPlace.submissionStatus, localPlace.errorParams],
             true
           );
         }
@@ -645,7 +645,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
                 />
               ),
             },
-            [localCancel.submissionStatus, localCancel.errorStringKey],
+            [localCancel.submissionStatus, localCancel.errorParams],
             true
           );
         }

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -41,7 +41,7 @@ import { getBalances } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 
 import abacusStateManager from '@/lib/abacus';
-import { getValidParsingErrorParams } from '@/lib/errors';
+import { getValidErrorParamsFromParsingError } from '@/lib/errors';
 import { isTruthy } from '@/lib/isTruthy';
 import { log } from '@/lib/telemetry';
 import { hashFromTx } from '@/lib/txUtils';
@@ -376,7 +376,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         if (success) {
           onSuccess?.(data);
         } else {
-          onError?.(getValidParsingErrorParams(parsingError));
+          onError?.(getValidErrorParamsFromParsingError(parsingError));
         }
       };
 
@@ -420,7 +420,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         if (success) {
           onSuccess?.(data);
         } else {
-          const errorParams = getValidParsingErrorParams(parsingError);
+          const errorParams = getValidErrorParamsFromParsingError(parsingError);
           onError?.(errorParams);
 
           if (data?.clientId !== undefined) {
@@ -483,7 +483,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
           dispatch(cancelOrderConfirmed(orderId));
           onSuccess?.();
         } else {
-          const errorParams = getValidParsingErrorParams(parsingError);
+          const errorParams = getValidErrorParamsFromParsingError(parsingError);
           dispatch(
             cancelOrderFailed({
               orderId,
@@ -524,7 +524,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
             dispatch(cancelOrderConfirmed(payload.orderId));
           });
         } else {
-          const errorParams = getValidParsingErrorParams(parsingError);
+          const errorParams = getValidErrorParamsFromParsingError(parsingError);
           onError?.(errorParams);
 
           placeOrderPayloads.forEach((payload: HumanReadablePlaceOrderPayload) => {

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -43,7 +43,7 @@ import { placeOrderTimeout } from '@/state/account';
 import { setInitializationError } from '@/state/app';
 
 import { signComplianceSignature } from '../compliance';
-import { StatefulOrderError } from '../errors';
+import { StatefulOrderError, stringifyTransactionError } from '../errors';
 import { bytesToBigInt } from '../numbers';
 import { log } from '../telemetry';
 import { getMintscanTxLink, hashFromTx } from '../txUtils';
@@ -282,10 +282,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       if (error?.name !== 'BroadcastError') {
         log('DydxChainTransactions/placeOrderTransaction', error);
       }
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -318,10 +315,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return encodedTx;
     } catch (error) {
       log('DydxChainTransactions/cancelOrderTransaction', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -350,10 +344,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return JSON.stringify(parsedTx);
     } catch (error) {
       log('DydxChainTransactions/simulateWithdrawTransaction', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -387,10 +378,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return JSON.stringify(parsedTx);
     } catch (error) {
       log('DydxChainTransactions/simulateTransferNativeTokenTransaction', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -433,10 +421,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return JSON.stringify(parsedTx);
     } catch (error) {
       log('DydxChainTransactions/sendNobleIBC', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -482,10 +467,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       });
     } catch (error) {
       log('DydxChainTransactions/withdrawToNobleIBC', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -519,10 +501,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return JSON.stringify(parsedTx);
     } catch (error) {
       log('DydxChainTransactions/cctpWithdraw', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -588,10 +567,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       });
     } catch (error) {
       log('DydxChainTransactions/signComplianceMessage', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -623,10 +599,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       return JSON.stringify(parsedTx);
     } catch (error) {
       log('DydxChainTransactions/subaccountTransfer', error);
-
-      return JSON.stringify({
-        error,
-      });
+      return stringifyTransactionError(error);
     }
   }
 
@@ -695,7 +668,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       }
     } catch (error) {
       try {
-        const serializedError = JSON.stringify(error);
+        const serializedError = stringifyTransactionError(error);
         callback(serializedError);
       } catch (parseError) {
         log('DydxChainTransactions/transaction', parseError);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -45,7 +45,9 @@ const getUntranslatedErrorMessageOrDefaultErrorParams = (errorMessage?: string):
   return DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS;
 };
 
-export const getValidParsingErrorParams = (error?: Nullable<ParsingError>): ErrorParams => {
+export const getValidErrorParamsFromParsingError = (
+  error?: Nullable<ParsingError>
+): ErrorParams => {
   const { stringKey: errorStringKey, message: errorMessage } = error ?? {};
   const defaultErrorParams = getUntranslatedErrorMessageOrDefaultErrorParams(errorMessage);
   if (!errorStringKey) return defaultErrorParams;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,7 @@
+import { Nullable, ParsingError } from '@/constants/abacus';
+import { DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS, ErrorParams } from '@/constants/errors';
+import { STRING_KEY_VALUES } from '@/constants/localization';
+
 import { log } from './telemetry';
 
 /**
@@ -34,4 +38,24 @@ export const getRouteErrorMessageOverride = (
     log('getRouteErrorMessageOverride', err);
     return routeErrorMessage;
   }
+};
+
+const getUntranslatedErrorMessageOrDefaultErrorParams = (errorMessage?: string): ErrorParams => {
+  if (errorMessage && errorMessage !== '') return { errorMessage };
+  return DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS;
+};
+
+export const getValidParsingErrorParams = (error?: Nullable<ParsingError>): ErrorParams => {
+  const { stringKey: errorStringKey, message: errorMessage } = error ?? {};
+  const defaultErrorParams = getUntranslatedErrorMessageOrDefaultErrorParams(errorMessage);
+  if (!errorStringKey) return defaultErrorParams;
+
+  const validErrorStringKey = STRING_KEY_VALUES[errorStringKey];
+  if (!validErrorStringKey) {
+    const err = new Error(`Missing error translation for ${errorStringKey}`);
+    log('errors/MissingParsingErrorTranslation', err, { parsingError: error });
+    return defaultErrorParams;
+  }
+
+  return { errorStringKey: validErrorStringKey };
 };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -59,3 +59,25 @@ export const getValidParsingErrorParams = (error?: Nullable<ParsingError>): Erro
 
   return { errorStringKey: validErrorStringKey };
 };
+
+/**
+ * Abacus parses the stringified error and returns a ParseError.
+ * BroadcastError is parsed with `code`, `codespace`, and `message`, and defaults to show the original error message if untranslated.
+ * Failed Query results (i.e., those starting with "Query failed") are matched via the error message, defaulting to "Unknown query result error".
+ * Unmatched errors will display the actual error message.
+ */
+export const stringifyTransactionError = (error: any): string => {
+  // Check if the error is a broadcast error (i.e., from execution)
+  if (error?.name === 'BroadcastError') {
+    // Return the error as a JSON string
+    return JSON.stringify({ error });
+  }
+
+  // Handle a normal Error (i.e., from query/simulation or other errors)
+  // An Error object is not fully serializable, so we need to extract the message and stack
+  const serializedError: { [key: string]: any } = {
+    message: error.message, // Extract the error message
+  };
+
+  return JSON.stringify({ error: serializedError });
+};

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -20,8 +20,8 @@ import {
   type Wallet,
 } from '@/constants/abacus';
 import { OnboardingGuard, OnboardingState } from '@/constants/account';
+import { DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS, ErrorParams } from '@/constants/errors';
 import { LocalStorageKey } from '@/constants/localStorage';
-import { STRING_KEYS } from '@/constants/localization';
 import {
   CancelOrderStatuses,
   PlaceOrderStatuses,
@@ -321,13 +321,13 @@ export const accountSlice = createSlice({
     },
     placeOrderFailed: (
       state,
-      action: PayloadAction<{ clientId: number; errorStringKey: string }>
+      action: PayloadAction<{ clientId: number; errorParams: ErrorParams }>
     ) => {
       state.localPlaceOrders = state.localPlaceOrders.map((order) =>
         order.clientId === action.payload.clientId
           ? {
               ...order,
-              errorStringKey: action.payload.errorStringKey,
+              errorParams: action.payload.errorParams,
             }
           : order
       );
@@ -339,7 +339,7 @@ export const accountSlice = createSlice({
       if (state.uncommittedOrderClientIds.includes(action.payload)) {
         placeOrderFailed({
           clientId: action.payload,
-          errorStringKey: STRING_KEYS.SOMETHING_WENT_WRONG,
+          errorParams: DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS,
         });
       }
     },
@@ -358,11 +358,11 @@ export const accountSlice = createSlice({
     },
     cancelOrderFailed: (
       state,
-      action: PayloadAction<{ orderId: string; errorStringKey: string }>
+      action: PayloadAction<{ orderId: string; errorParams: ErrorParams }>
     ) => {
       state.localCancelOrders.map((order) =>
         order.orderId === action.payload.orderId
-          ? { ...order, errorStringKey: action.payload.errorStringKey }
+          ? { ...order, errorParams: action.payload.errorParams }
           : order
       );
     },

--- a/src/state/localizationSelectors.ts
+++ b/src/state/localizationSelectors.ts
@@ -42,12 +42,18 @@ export const getStringGetterForLocaleData = (
 ): StringGetterFunction => {
   // @ts-expect-error TODO: formatString return doesn't match StringGetterFunction
   return (props) => {
-    // Fallback to english whenever a key doesn't exist for other languages
     if (isLocaleLoaded) {
-      const formattedString: string =
-        localeData || EN_LOCALE_DATA
-          ? get(localeData, props.key) || get(EN_LOCALE_DATA, props.key)
-          : '';
+      let formattedString = props.fallback ?? '';
+
+      if (localeData || EN_LOCALE_DATA) {
+        if (props.key) {
+          const localeString = get(localeData, props.key);
+          const englishString = get(EN_LOCALE_DATA, props.key);
+
+          // Fallback to english whenever a key doesn't exist for other languages
+          formattedString = localeString || englishString;
+        }
+      }
 
       return formatString(formattedString, props?.params);
     }

--- a/src/views/forms/AdjustIsolatedMarginForm.tsx
+++ b/src/views/forms/AdjustIsolatedMarginForm.tsx
@@ -128,9 +128,12 @@ export const AdjustIsolatedMarginForm = ({
     adjustIsolatedMarginOfPosition({
       onError: (errorParams) => {
         setIsSubmitting(false);
-        if (errorParams?.errorStringKey) {
-          setErrorMessage(stringGetter({ key: errorParams.errorStringKey }));
-        }
+        setErrorMessage(
+          stringGetter({
+            key: errorParams.errorStringKey,
+            fallback: errorParams.errorMessage ?? '',
+          })
+        );
       },
       onSuccess: () => {
         setIsSubmitting(false);

--- a/src/views/forms/CancelAllOrdersInMarketForm.tsx
+++ b/src/views/forms/CancelAllOrdersInMarketForm.tsx
@@ -5,6 +5,7 @@ import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
+import { ErrorParams } from '@/constants/errors';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign } from '@/constants/numbers';
 import { EMPTY_ARR } from '@/constants/objects';
@@ -35,7 +36,7 @@ type CancelAllOrdersInMarketFormProps = {
 type OrderCancelStatus =
   | { type: 'pending' }
   | { type: 'success' }
-  | { type: 'error'; errorKey?: string };
+  | { type: 'error'; errorParams?: ErrorParams };
 
 export const CancelAllOrdersInMarketForm = ({
   marketId,
@@ -75,10 +76,10 @@ export const CancelAllOrdersInMarketForm = ({
         onSuccess: () => {
           setCancellingStatus((old) => ({ ...old, [p.id]: { type: 'success' } }));
         },
-        onError: (errorInfo) => {
+        onError: (errorParams) => {
           setCancellingStatus((old) => ({
             ...old,
-            [p.id]: { type: 'error', errorKey: errorInfo?.errorStringKey ?? undefined },
+            [p.id]: { type: 'error', errorParams },
           }));
         },
       })

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/constants/abacus';
 import { AlertType } from '@/constants/alerts';
 import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
+import { ErrorParams } from '@/constants/errors';
 import { STRING_KEYS } from '@/constants/localization';
 import { NotificationType } from '@/constants/notifications';
 import { TOKEN_DECIMALS } from '@/constants/numbers';
@@ -200,9 +201,12 @@ export const ClosePositionForm = ({
     setClosePositionError(undefined);
 
     closePosition({
-      onError: (errorParams?: { errorStringKey?: Nullable<string> }) => {
+      onError: (errorParams: ErrorParams) => {
         setClosePositionError(
-          stringGetter({ key: errorParams?.errorStringKey ?? STRING_KEYS.SOMETHING_WENT_WRONG })
+          stringGetter({
+            key: errorParams.errorStringKey,
+            fallback: errorParams.errorMessage ?? '',
+          })
         );
         setCurrentStep?.(MobilePlaceOrderSteps.PlaceOrderFailed);
       },

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/constants/abacus';
 import { AlertType } from '@/constants/alerts';
 import { ButtonAction, ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
+import { ErrorParams } from '@/constants/errors';
 import { STRING_KEYS } from '@/constants/localization';
 import { NotificationType } from '@/constants/notifications';
 import { MobilePlaceOrderSteps, ORDER_TYPE_STRINGS, TradeTypes } from '@/constants/trade';
@@ -199,9 +200,12 @@ export const TradeForm = ({
     setPlaceOrderError(undefined);
 
     placeOrder({
-      onError: (errorParams?: { errorStringKey?: Nullable<string> }) => {
+      onError: (errorParams: ErrorParams) => {
         setPlaceOrderError(
-          stringGetter({ key: errorParams?.errorStringKey ?? STRING_KEYS.SOMETHING_WENT_WRONG })
+          stringGetter({
+            key: errorParams.errorStringKey,
+            fallback: errorParams.errorMessage ?? '',
+          })
         );
         setCurrentStep?.(MobilePlaceOrderSteps.PlaceOrderFailed);
       },

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -286,7 +286,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const submitButton = (
     <$Button
-      state={buttonState}
+      state={{}}
       type={ButtonType.Submit}
       action={buttonAction}
       slotLeft={showValidatorErrors ? <$WarningIcon iconName={IconName.Warning} /> : undefined}

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -286,7 +286,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const submitButton = (
     <$Button
-      state={{}}
+      state={buttonState}
       type={ButtonType.Submit}
       action={buttonAction}
       slotLeft={showValidatorErrors ? <$WarningIcon iconName={IconName.Warning} /> : undefined}

--- a/src/views/notifications/OrderCancelNotification.tsx
+++ b/src/views/notifications/OrderCancelNotification.tsx
@@ -59,10 +59,17 @@ export const OrderCancelNotification = ({
     orderStatusIcon = <$OrderStatusIcon status={AbacusOrderStatus.Canceled.rawValue} />;
   }
 
-  if (localCancel.errorStringKey) {
+  if (localCancel.errorParams) {
     orderStatusStringKey = STRING_KEYS.ERROR;
     orderStatusIcon = <$WarningIcon iconName={IconName.Warning} />;
-    customContent = <span>{stringGetter({ key: localCancel.errorStringKey })}</span>;
+    customContent = (
+      <span>
+        {stringGetter({
+          key: localCancel.errorParams.errorStringKey,
+          fallback: localCancel.errorParams.errorMessage ?? '',
+        })}
+      </span>
+    );
   }
 
   return (

--- a/src/views/notifications/OrderStatusNotification.tsx
+++ b/src/views/notifications/OrderStatusNotification.tsx
@@ -97,13 +97,13 @@ export const OrderStatusNotification = ({
       }
       break;
     case PlaceOrderStatuses.Submitted:
-      if (localOrder.errorStringKey) {
+      if (localOrder.errorParams) {
         orderStatusStringKey = STRING_KEYS.ERROR;
         orderStatusIcon = <$WarningIcon iconName={IconName.Warning} />;
         customContent = (
           <span>
             {stringGetter({
-              key: localOrder.errorStringKey,
+              key: localOrder.errorParams.errorStringKey,
               params: {
                 EQUITY_TIER_LEARN_MORE: (
                   <Link href={equityTiersLearnMore} onClick={(e) => e.stopPropagation()} isInline>
@@ -111,6 +111,7 @@ export const OrderStatusNotification = ({
                   </Link>
                 ),
               },
+              fallback: localOrder.errorParams.errorMessage ?? '',
             })}
           </span>
         );


### PR DESCRIPTION
context: it's possible that the stringkey we pass from Abacus might not exist in localization, since we aren't translating protocol errors 1:1. [example](https://github.com/dydxprotocol/v4-abacus/blob/de7b8170aec72008d02dac0656085e7c2c82466e/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt#L17). other than just translating all error codes and catching all possible query results (which is not sustainable), we should fallback to show some error message that is relevant

- correctly serialize transaction errors via `stringifyTransactionError`, because when a normal Error is thrown (e.g. query update failure), JSON.stringify will not work
- update functions that takes in `errorStringKey?: string` to `errorParams?: ErrorParams`, the latter includes a potential error string key and a fallback error message
- update string getter function to take a `fallback` param, so when the string key isn't valid (part of STRING_KEYS), we should explicitly define fallback string. this is kinda optional so open to thoughts!

before, query result failure (e.g. failure during subaccount transfer) will show no error strings. after:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/2d975e48-5615-4238-bcc9-f8e28388ab02">
