### PR TITLE
chore: change pnl card to use fiat instead of percent [OTE-511]

### DIFF
--- a/src/constants/dialogs.ts
+++ b/src/constants/dialogs.ts
@@ -58,7 +58,7 @@ export type SharePNLAnalyticsDialogProps = {
   leverage: Nullable<number>;
   oraclePrice: Nullable<number>;
   entryPrice: Nullable<number>;
-  unrealizedPnlPercent: Nullable<number>;
+  unrealizedPnl: Nullable<number>;
   side: Nullable<AbacusPositionSides>;
   sideLabel: Nullable<string>;
 };

--- a/src/lib/abacus/logger.ts
+++ b/src/lib/abacus/logger.ts
@@ -9,7 +9,10 @@ class AbacusLogger implements Omit<AbacusLoggingProtocol, '__doNotUseOrImplement
   }
 
   e(tag: string, message: string) {
-    if (import.meta.env.VITE_ENABLE_ABACUS_LOGGING) {
+    if (
+      import.meta.env.VITE_ENABLE_ABACUS_LOGGING ||
+      import.meta.env.VITE_ABACUS_LOG_LEVEL === 'error'
+    ) {
       console.error(`${tag}: ${message}`);
     }
   }

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -48,7 +48,7 @@ export const SharePNLAnalyticsDialog = ({
   leverage,
   oraclePrice,
   entryPrice,
-  unrealizedPnlPercent,
+  unrealizedPnl,
   setIsOpen,
 }: DialogProps<SharePNLAnalyticsDialogProps>) => {
   const stringGetter = useStringGetter();
@@ -89,7 +89,7 @@ export const SharePNLAnalyticsDialog = ({
     }
   }, [side]);
 
-  const unrealizedPnlIsNegative = MustBigNumber(unrealizedPnlPercent).isNegative();
+  const unrealizedPnlIsNegative = MustBigNumber(unrealizedPnl).isNegative();
 
   const [assetLeft, assetRight] = marketId.split('-');
 
@@ -116,8 +116,8 @@ export const SharePNLAnalyticsDialog = ({
 
           <$HighlightOutput
             isNegative={unrealizedPnlIsNegative}
-            type={OutputType.Percent}
-            value={unrealizedPnlPercent}
+            type={OutputType.Fiat}
+            value={unrealizedPnl}
             showSign={ShowSign.None}
             slotLeft={
               <DiffArrow

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -114,7 +114,7 @@ export const SharePNLAnalyticsDialog = ({
 
           <$HighlightOutput
             isNegative={unrealizedPnlIsNegative}
-            type={OutputType.Fiat}
+            type={OutputType.CompactFiat}
             value={unrealizedPnl}
             showSign={ShowSign.Both}
           />

--- a/src/views/dialogs/SharePNLAnalyticsDialog.tsx
+++ b/src/views/dialogs/SharePNLAnalyticsDialog.tsx
@@ -7,7 +7,6 @@ import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction } from '@/constants/buttons';
 import { DialogProps, SharePNLAnalyticsDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
-import { NumberSign } from '@/constants/numbers';
 import { PositionSide } from '@/constants/trade';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -18,7 +17,6 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Dialog } from '@/components/Dialog';
-import { DiffArrow } from '@/components/DiffArrow';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType, ShowSign } from '@/components/Output';
 import { QrCode } from '@/components/QrCode';
@@ -118,13 +116,7 @@ export const SharePNLAnalyticsDialog = ({
             isNegative={unrealizedPnlIsNegative}
             type={OutputType.Fiat}
             value={unrealizedPnl}
-            showSign={ShowSign.None}
-            slotLeft={
-              <DiffArrow
-                direction={unrealizedPnlIsNegative ? 'down' : 'up'}
-                sign={unrealizedPnlIsNegative ? NumberSign.Negative : NumberSign.Positive}
-              />
-            }
+            showSign={ShowSign.Both}
           />
 
           <$Logo />

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -364,7 +364,7 @@ const getPositionsTableColumnDef = ({
           oraclePrice,
           entryPrice,
           takeProfitOrders,
-          unrealizedPnlPercent,
+          unrealizedPnl,
           resources,
         }) => (
           <PositionsActionsCell
@@ -374,7 +374,7 @@ const getPositionsTableColumnDef = ({
             leverage={leverage.current}
             oraclePrice={oraclePrice}
             entryPrice={entryPrice.current}
-            unrealizedPnlPercent={unrealizedPnlPercent?.current}
+            unrealizedPnl={unrealizedPnl?.current}
             sideLabel={
               resources.sideStringKey?.current &&
               stringGetter({ key: resources.sideStringKey?.current })

--- a/src/views/tables/PositionsTable/PositionsActionsCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsActionsCell.tsx
@@ -29,7 +29,7 @@ type ElementProps = {
   leverage: Nullable<number>;
   oraclePrice: Nullable<number>;
   entryPrice: Nullable<number>;
-  unrealizedPnlPercent: Nullable<number>;
+  unrealizedPnl: Nullable<number>;
   side: Nullable<AbacusPositionSides>;
   sideLabel: Nullable<string>;
   stopLossOrders: SubaccountOrder[];
@@ -45,7 +45,7 @@ export const PositionsActionsCell = ({
   leverage,
   oraclePrice,
   entryPrice,
-  unrealizedPnlPercent,
+  unrealizedPnl,
   side,
   sideLabel,
   stopLossOrders,
@@ -101,7 +101,7 @@ export const PositionsActionsCell = ({
           leverage,
           oraclePrice,
           entryPrice,
-          unrealizedPnlPercent,
+          unrealizedPnl,
           side,
           sideLabel,
         })


### PR DESCRIPTION
Old Card (Percent):
<img width="539" alt="Screenshot 2024-07-17 at 3 27 06 PM" src="https://github.com/user-attachments/assets/790b7516-fb96-447c-8926-96eae5ff59ee">



New Card (Dollar amount):
<img width="541" alt="Screenshot 2024-07-17 at 3 25 17 PM" src="https://github.com/user-attachments/assets/36c93d45-ba59-463c-a02a-44a8d7cfd65a">

