### PR TITLE
chore: manually assign custom domain referrer [OTE-516]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -46,6 +46,8 @@ export const customTrackEvent = <T extends AnalyticsEventTypes>(
 // User properties
 export const AnalyticsUserProperties = unionize(
   {
+    // Referrer
+    CustomDomainReferrer: ofType<string | null>(),
     // Environment
     Locale: ofType<SupportedLocales>(),
     Breakpoint: ofType<

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -11,13 +11,10 @@ import { TransferNotificationTypes } from './notifications';
 import type { TradeTypes } from './trade';
 import type { DydxAddress, EvmAddress, WalletConnectionType, WalletType } from './wallets';
 
-type AnalyticsEventDataWithReferrer<T extends AnalyticsEventTypes> = AnalyticsEventPayloads[T] & {
-  referrer: string;
-};
 export type AnalyticsEventTrackMeta<T extends AnalyticsEventTypes> = {
   detail: {
     eventType: T;
-    eventData: AnalyticsEventDataWithReferrer<T>;
+    eventData: AnalyticsEventPayloads[T];
   };
 };
 export type AnalyticsEventIdentifyMeta<T extends AnalyticsUserPropertyTypes> = {
@@ -78,6 +75,7 @@ export const AnalyticsUserPropertyLoggableTypes = {
   Breakpoint: 'breakpoint',
   Version: 'version',
   StatsigFlags: 'statsigFlags',
+  CustomDomainReferrer: 'customDomainReferrer',
   Network: 'network',
   WalletType: 'walletType',
   WalletConnectionType: 'walletConnectionType',

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -51,6 +51,10 @@ export const useAnalytics = () => {
             : 'UNSUPPORTED';
 
   useEffect(() => {
+    identify(AnalyticsUserProperties.CustomDomainReferrer(document.referrer));
+  }, []);
+
+  useEffect(() => {
     identify(AnalyticsUserProperties.Breakpoint(breakpoint));
   }, [breakpoint]);
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,8 +6,6 @@ import {
   type AnalyticsUserProperty,
 } from '@/constants/analytics';
 
-import { testFlags } from './testFlags';
-
 const DEBUG_ANALYTICS = false;
 
 export const identify = (property: AnalyticsUserProperty) => {
@@ -26,13 +24,12 @@ export const identify = (property: AnalyticsUserProperty) => {
 };
 
 export const track = (event: AnalyticsEvent) => {
-  const eventDataWithReferrer = { ...(event.payload ?? {}), referrer: testFlags.referrer };
   if (DEBUG_ANALYTICS) {
     // eslint-disable-next-line no-console
-    console.log(`[Analytics] ${event.type}`, eventDataWithReferrer);
+    console.log(`[Analytics] ${event.type}`, event.payload);
   }
   const customEvent = customTrackEvent({
-    detail: { eventType: event.type, eventData: eventDataWithReferrer },
+    detail: { eventType: event.type, eventData: event.payload },
   });
 
   globalThis.dispatchEvent(customEvent);


### PR DESCRIPTION
context: https://dydx-team.slack.com/archives/C03JV4VJQ6N/p1716565422932799

manually setting a domain referrer since the one automatically it often returns none.
This will help us know if a domain referrer is simply not being provided or if a race condition/setting is causing amplitude to fail to capture this.

also removes the `referrer` event property for 2 reasons:
1. it tracks utm_source, which amplitude already tracks
2. it has no business being an event property. even if we want to add this back at some point it should be as a user property