### PR TITLE
chore: update min cctp amount

### DIFF
--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -22,6 +22,6 @@ export enum NumberSign {
 
 // Deposit/Withdraw
 export const MAX_CCTP_TRANSFER_AMOUNT = 1_000_000;
-export const MIN_CCTP_TRANSFER_AMOUNT = 10;
+export const MIN_CCTP_TRANSFER_AMOUNT = 11;
 export const MAX_PRICE_IMPACT = 0.02; // 2%
 export const DEFAULT_GAS_LIMIT = 160000;


### PR DESCRIPTION
bump min amount to 11 

context: https://dydx-team.slack.com/archives/C06ETDBE370/p1721406945614009?thread_ts=1721400846.467719&cid=C06ETDBE370

users are seeing their transfers fail because the relayer minimum CCTP amount is slightly higher than the amount they're sending