### PR TITLE
fix: fee tier market share percentage should show 1 decimal

### DIFF
--- a/src/pages/portfolio/Fees.tsx
+++ b/src/pages/portfolio/Fees.tsx
@@ -27,6 +27,8 @@ import { getFeeTiers } from '@/state/configsSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
 
+const MARKET_SHARE_PERCENTAGE_FRACTION_DIGITS = 1;
+
 const EQUALITY_SYMBOL_MAP = {
   '>=': '≥',
   '<=': '≤',
@@ -61,7 +63,11 @@ export const Fees = () => {
               {isAdditional && stringGetter({ key: STRING_KEYS.AND })}{' '}
               {stringGetter({ key: STRING_KEYS.EXCHANGE_MARKET_SHARE })}{' '}
               <$Highlighted>{'>'}</$Highlighted>{' '}
-              <$HighlightOutput type={OutputType.Percent} value={totalShare} fractionDigits={0} />
+              <$HighlightOutput
+                type={OutputType.Percent}
+                value={totalShare}
+                fractionDigits={MARKET_SHARE_PERCENTAGE_FRACTION_DIGITS}
+              />
             </$AdditionalConditionsText>
           )}
           {!!makerShare && (
@@ -69,7 +75,11 @@ export const Fees = () => {
               {isAdditional && stringGetter({ key: STRING_KEYS.AND })}{' '}
               {stringGetter({ key: STRING_KEYS.MAKER_MARKET_SHARE })}{' '}
               <$Highlighted>{'>'}</$Highlighted>{' '}
-              <$HighlightOutput type={OutputType.Percent} value={makerShare} fractionDigits={0} />
+              <$HighlightOutput
+                type={OutputType.Percent}
+                value={makerShare}
+                fractionDigits={MARKET_SHARE_PERCENTAGE_FRACTION_DIGITS}
+              />
             </$AdditionalConditionsText>
           )}
         </$AdditionalConditions>


### PR DESCRIPTION
before:
<img width="559" alt="image" src="https://github.com/user-attachments/assets/c9d01e9a-4b77-4956-9095-103439d224c1">

after:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/eb9f0c7a-1985-43db-a8da-461adc879c7c">
