### PR TITLE
chore(orderbook): remove size gradient from orderbook

### DIFF
--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -103,18 +103,16 @@ export const useDrawOrderbook = ({
   }, [canvas]);
 
   const drawBars = ({
-    barType,
     ctx,
-    depthOrSizeValue,
-    gradientMultiplier,
+    value,
+    gradientMultiplier = 1.3,
     histogramAccentColor,
     histogramSide: inHistogramSide,
     rekt,
   }: {
-    barType: 'depth' | 'size';
     ctx: CanvasRenderingContext2D;
-    depthOrSizeValue: number;
-    gradientMultiplier: number;
+    value: number;
+    gradientMultiplier?: number;
     histogramAccentColor: string;
     histogramSide: 'left' | 'right';
     rekt: Rekt;
@@ -122,9 +120,9 @@ export const useDrawOrderbook = ({
     const { x1, x2, y1, y2 } = rekt;
 
     // X values
-    const maxHistogramBarWidth = x2 - x1 - (barType === 'size' ? 8 : 2);
-    const barWidth = depthOrSizeValue
-      ? Math.min((depthOrSizeValue / histogramRange) * maxHistogramBarWidth, maxHistogramBarWidth)
+    const maxHistogramBarWidth = x2 - x1 - 2;
+    const barWidth = value
+      ? Math.min((value / histogramRange) * maxHistogramBarWidth, maxHistogramBarWidth)
       : 0;
 
     const { gradient, bar } = getHistogramXValues({
@@ -294,26 +292,13 @@ export const useDrawOrderbook = ({
     // Depth Bar
     if (depth) {
       drawBars({
-        barType: 'depth',
         ctx,
-        depthOrSizeValue: depth,
-        gradientMultiplier: 1.3,
+        value: depth,
         histogramAccentColor,
         histogramSide,
         rekt,
       });
     }
-
-    // Size Bar
-    drawBars({
-      barType: 'size',
-      ctx,
-      depthOrSizeValue: size,
-      gradientMultiplier: 5,
-      histogramAccentColor,
-      histogramSide,
-      rekt,
-    });
 
     if (mine && mine > 0) {
       drawMineCircle({ ctx, rekt });

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -48,6 +48,8 @@ enum OrderbookRowAnimationType {
   NONE,
 }
 
+const GRADIENT_MULTIPLIER = 1.3;
+
 export type Rekt = { x1: number; x2: number; y1: number; y2: number };
 
 export const useDrawOrderbook = ({
@@ -105,7 +107,7 @@ export const useDrawOrderbook = ({
   const drawBars = ({
     ctx,
     value,
-    gradientMultiplier = 1.3,
+    gradientMultiplier = GRADIENT_MULTIPLIER,
     histogramAccentColor,
     histogramSide: inHistogramSide,
     rekt,


### PR DESCRIPTION
Chatted with product [here](https://dydx-team.slack.com/archives/C06EMK1746T/p1721407912354539?thread_ts=1720204777.641659&cid=C06EMK1746T); we want to remove the size bar in our orderbook gradients and only keep the depth bar.

Could've further simplified the drawBars function but thought it might be nice to keep the `gradientMultiplier` configuration in case we want to tweak it in the future 🤷‍♀️ 
- I don't feel strongly so happy to just convert the `1.3` to a constant at the top of the file if others think that's better 

| before | after |
| ---- | ---- |
| <img width="314" alt="Screenshot 2024-07-23 at 2 12 32 PM" src="https://github.com/user-attachments/assets/fe03b3bc-7aad-463d-80ad-97e86942f3b5"> | <img width="323" alt="Screenshot 2024-07-23 at 2 12 25 PM" src="https://github.com/user-attachments/assets/59d3fda5-1e54-45fb-aeed-e18a2d454c7d"> |
