### PR TITLE
chore(orderbook): update orderbook to not be scrollable

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, type Ref } from 'react';
 
 import { Content, List, Root, Trigger } from '@radix-ui/react-tabs';
 import styled, { css, keyframes } from 'styled-components';
@@ -25,6 +25,7 @@ export type TabItem<TabItemsValue> = {
   subitems?: TabItem<TabItemsValue>[];
   customTrigger?: ReactNode;
   asChild?: boolean;
+  ref?: Ref<HTMLDivElement>;
 };
 
 type ElementProps<TabItemsValue> = {
@@ -126,8 +127,9 @@ export const Tabs = <TabItemsValue extends string>({
 
       {sharedContent ?? (
         <$Stack>
-          {items.map(({ asChild, value: childValue, content, forceMount }) => (
+          {items.map(({ asChild, value: childValue, content, forceMount, ref }) => (
             <$Content
+              ref={ref}
               key={childValue}
               asChild={asChild}
               value={childValue}

--- a/src/constants/orderbook.ts
+++ b/src/constants/orderbook.ts
@@ -13,3 +13,4 @@ export const ORDERBOOK_HEIGHT = 756;
 export const ORDERBOOK_WIDTH = 300;
 export const ORDERBOOK_ROW_HEIGHT = 21;
 export const ORDERBOOK_ROW_PADDING_RIGHT = 8;
+export const ORDERBOOK_HEADER_HEIGHT = 70;

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -101,18 +101,27 @@ export const useDrawOrderbook = ({
 
   // Handle resize, sync to state
   useEffect(() => {
-    if (canvas) {
-      const resizeObserver = new ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.contentBoxSize[0]) {
-            scaleCanvas(entry.contentBoxSize[0].inlineSize, entry.contentBoxSize[0].blockSize);
-          } else {
-            scaleCanvas(entry.contentRect.width, entry.contentRect.height);
-          }
-        });
+    const resizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.contentBoxSize[0]) {
+          scaleCanvas(entry.contentBoxSize[0].inlineSize, entry.contentBoxSize[0].blockSize);
+        } else {
+          scaleCanvas(entry.contentRect.width, entry.contentRect.height);
+        }
       });
+    });
+
+    if (canvas) {
       resizeObserver.observe(canvas);
     }
+
+    return () => {
+      if (canvas) {
+        resizeObserver.unobserve(canvas);
+      } else {
+        resizeObserver.disconnect();
+      }
+    };
   }, [scaleCanvas, canvas]);
 
   const drawBars = useCallback(

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -14,7 +14,7 @@ import { MustBigNumber } from '@/lib/numbers';
 import { safeAssign } from '@/lib/objectHelpers';
 import { orEmptyRecord } from '@/lib/typeUtils';
 
-export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: number }) => {
+export const useCalculateOrderbookData = ({ rowsPerSide }: { rowsPerSide: number }) => {
   const orderbook = useAppSelector(getCurrentMarketOrderbook, shallowEqual);
 
   const subaccountOrderSizeBySideAndPrice = orEmptyRecord(
@@ -37,7 +37,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
             row
           )
       )
-      .slice(0, maxRowsPerSide);
+      .slice(0, rowsPerSide);
 
     const bids: Array<PerpetualMarketOrderbookLevel | undefined> = (
       orderbook?.bids?.toArray() ?? []
@@ -54,7 +54,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
             row
           )
       )
-      .slice(0, maxRowsPerSide);
+      .slice(0, rowsPerSide);
 
     const spread = orderbook?.spread;
     const spreadPercent = orderbook?.spreadPercent;
@@ -73,7 +73,7 @@ export const useCalculateOrderbookData = ({ maxRowsPerSide }: { maxRowsPerSide: 
       hasOrderbook: !!orderbook,
       currentGrouping: orderbook?.grouping,
     };
-  }, [maxRowsPerSide, orderbook, subaccountOrderSizeBySideAndPrice]);
+  }, [rowsPerSide, orderbook, subaccountOrderSizeBySideAndPrice]);
 };
 
 export const useOrderbookValuesForDepthChart = () => {

--- a/src/pages/trade/VerticalPanel.tsx
+++ b/src/pages/trade/VerticalPanel.tsx
@@ -38,19 +38,27 @@ export const VerticalPanel = ({ tradeLayout }: { tradeLayout: TradeLayouts }) =>
   }, []);
 
   useEffect(() => {
-    if (canvasOrderbook) {
-      const resizeObserver = new ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.contentBoxSize[0]) {
-            calculateNumRows(entry.contentBoxSize[0].blockSize);
-          } else {
-            calculateNumRows(entry.contentRect.height);
-          }
-        });
+    const resizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.contentBoxSize[0]) {
+          calculateNumRows(entry.contentBoxSize[0].blockSize);
+        } else {
+          calculateNumRows(entry.contentRect.height);
+        }
       });
+    });
 
+    if (canvasOrderbook) {
       resizeObserver.observe(canvasOrderbook);
     }
+
+    return () => {
+      if (canvasOrderbook) {
+        resizeObserver.unobserve(canvasOrderbook);
+      } else {
+        resizeObserver.disconnect();
+      }
+    };
   }, [calculateNumRows, canvasOrderbook]);
 
   return (

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -33,7 +33,7 @@ import { OrderbookControls } from './OrderbookControls';
 import { OrderbookMiddleRow, OrderbookRow } from './OrderbookRow';
 
 type ElementProps = {
-  maxRowsPerSide?: number;
+  rowsPerSide?: number;
   layout?: 'vertical' | 'horizontal';
 };
 
@@ -48,13 +48,13 @@ export const CanvasOrderbook = forwardRef(
       histogramSide = 'right',
       hideHeader = false,
       layout = 'vertical',
-      maxRowsPerSide = ORDERBOOK_MAX_ROWS_PER_SIDE,
+      rowsPerSide = ORDERBOOK_MAX_ROWS_PER_SIDE,
     }: ElementProps & StyleProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
     const { asks, bids, hasOrderbook, histogramRange, currentGrouping } = useCalculateOrderbookData(
       {
-        maxRowsPerSide,
+        rowsPerSide,
       }
     );
 
@@ -66,12 +66,12 @@ export const CanvasOrderbook = forwardRef(
     const { tickSizeDecimals = USD_DECIMALS } = currentMarketConfig ?? {};
 
     /**
-     * Slice asks and bids to maxRowsPerSide using empty rows
+     * Slice asks and bids to rowsPerSide using empty rows
      */
     const { asksSlice, bidsSlice } = useMemo(() => {
       const emptyAskRows =
-        asks.length < maxRowsPerSide
-          ? new Array<undefined>(maxRowsPerSide - asks.length).fill(undefined)
+        asks.length < rowsPerSide
+          ? new Array<undefined>(rowsPerSide - asks.length).fill(undefined)
           : [];
 
       const newAsksSlice: Array<PerpetualMarketOrderbookLevel | undefined> = [
@@ -80,8 +80,8 @@ export const CanvasOrderbook = forwardRef(
       ];
 
       const emptyBidRows =
-        bids.length < maxRowsPerSide
-          ? new Array<undefined>(maxRowsPerSide - bids.length).fill(undefined)
+        bids.length < rowsPerSide
+          ? new Array<undefined>(rowsPerSide - bids.length).fill(undefined)
           : [];
       const newBidsSlice: Array<PerpetualMarketOrderbookLevel | undefined> = [
         ...bids,
@@ -92,7 +92,7 @@ export const CanvasOrderbook = forwardRef(
         asksSlice: layout === 'horizontal' ? newAsksSlice : newAsksSlice.reverse(),
         bidsSlice: newBidsSlice,
       };
-    }, [asks, bids, layout, maxRowsPerSide]);
+    }, [asks, bids, layout, rowsPerSide]);
 
     const orderbookRef = useRef<HTMLDivElement>(null);
     useCenterOrderbook({
@@ -151,7 +151,7 @@ export const CanvasOrderbook = forwardRef(
     const usdTag = <Tag>USD</Tag>;
     const assetTag = id ? <Tag>{id}</Tag> : undefined;
     const asksOrderbook = (
-      <$OrderbookSideContainer $side="asks" $rows={maxRowsPerSide}>
+      <$OrderbookSideContainer $side="asks" $rows={rowsPerSide}>
         <$HoverRows $bottom={layout !== 'horizontal'}>
           {[...asksSlice].reverse().map((row: PerpetualMarketOrderbookLevel | undefined, idx) =>
             row ? (
@@ -173,7 +173,7 @@ export const CanvasOrderbook = forwardRef(
       </$OrderbookSideContainer>
     );
     const bidsOrderbook = (
-      <$OrderbookSideContainer $side="bids" $rows={maxRowsPerSide}>
+      <$OrderbookSideContainer $side="bids" $rows={rowsPerSide}>
         <$HoverRows>
           {bidsSlice.map((row: PerpetualMarketOrderbookLevel | undefined, idx) =>
             row ? (

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -207,6 +207,7 @@ export const TradeForm = ({
             fallback: errorParams.errorMessage ?? '',
           })
         );
+        setCurrentStep?.(MobilePlaceOrderSteps.PlaceOrderFailed);
       },
       onSuccess: (placeOrderPayload?: Nullable<HumanReadablePlaceOrderPayload>) => {
         setUnIndexedClientId(placeOrderPayload?.clientId);

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -207,7 +207,6 @@ export const TradeForm = ({
             fallback: errorParams.errorMessage ?? '',
           })
         );
-        setCurrentStep?.(MobilePlaceOrderSteps.PlaceOrderFailed);
       },
       onSuccess: (placeOrderPayload?: Nullable<HumanReadablePlaceOrderPayload>) => {
         setUnIndexedClientId(placeOrderPayload?.clientId);
@@ -240,7 +239,7 @@ export const TradeForm = ({
 
   const orderbookAndInputs = (
     <$OrderbookAndInputs showOrderbook={showOrderbook}>
-      {isTablet && showOrderbook && <$Orderbook maxRowsPerSide={5} hideHeader />}
+      {isTablet && showOrderbook && <$Orderbook rowsPerSide={5} hideHeader />}
       <$InputsColumn>
         <TradeFormInputs />
         <TradeSizeInputs />
@@ -330,7 +329,7 @@ const $TradeForm = styled.form`
 
   /* Rules */
   --orderbox-column-width: 180px;
-  --orderbook-width: calc(var(--orderbox-column-width) + var(--tradeBox-content-paddingLeft));
+  --orderbox-gap: 1rem;
 
   min-height: 100%;
   isolation: isolate;
@@ -370,7 +369,7 @@ const $TopActionsRow = styled.div`
 
   @media ${breakpoints.tablet} {
     grid-auto-columns: var(--orderbox-column-width) 1fr;
-    gap: var(--form-input-gap);
+    gap: var(--orderbox-gap);
   }
 `;
 const $OrderbookButtons = styled.div`
@@ -415,9 +414,8 @@ const $OrderbookAndInputs = styled.div<{ showOrderbook: boolean }>`
     ${({ showOrderbook }) =>
       showOrderbook
         ? css`
-            grid-auto-columns: var(--orderbook-width) 1fr;
-            gap: var(--form-input-gap);
-            margin-left: calc(-1 * var(--tradeBox-content-paddingLeft));
+            grid-auto-columns: var(--orderbox-column-width) 1fr;
+            gap: var(--orderbox-gap);
           `
         : css`
             grid-auto-columns: 1fr;
@@ -426,8 +424,6 @@ const $OrderbookAndInputs = styled.div<{ showOrderbook: boolean }>`
   }
 `;
 const $Orderbook = styled(CanvasOrderbook)`
-  width: 100%;
-
   @media ${breakpoints.notTablet} {
     display: none;
   }


### PR DESCRIPTION
try #2 which is 100x simpler than my last thing I was trying cuz I think my brain was non functional the first round

Goal: To make the orderbook not scrollable (fixed height-ish) while still maintaining the reponsiveness of the screen sizing:

We still want the orderbook to grow when the height of the screen grows
We still want the whole page to fit on any (reasonably sized) screen without scrolling
We want the orderbook to be just large enough to show x rows, centered such that the price row is in the middle

Solution: 
1. Calculate the approximate size of the div of the canvas orderbook
2. Calculate the number of rows we can render in this div
3. Recalculate when browser or div resizes (latter happens without browser resizing if we just zoom in/out) using resizeObserver

EDIT: used resizeObserver and things work way better now

### Unrelated polish included in this PR
- Fix orderbook on TradeForm mobile view (changes [here](https://github.com/dydxprotocol/v4-web/pull/846/files#diff-d95dc79cacd2138b69b882229b2d2d2424c28e1ea3949a240daf18ed0c6877feL207))

| before | after | 
| ---- | ---- |
| <img width="623" alt="Screenshot 2024-07-23 at 5 58 46 PM" src="https://github.com/user-attachments/assets/025597c2-d97e-421c-af05-c5c385c96b67"> | <img width="681" alt="Screenshot 2024-07-23 at 5 59 16 PM" src="https://github.com/user-attachments/assets/bd0cde93-d047-495d-81c2-e4522203c05e"> |



https://github.com/user-attachments/assets/5a27db49-df36-46fe-af6a-ed8ee21380f7


https://github.com/user-attachments/assets/d74980b2-24fc-4c4b-9a62-f0fc2b5fcaff




### Things I did not do in this PR
- Add a 50x resolution (we currently have 0.1, 1, 10, 100) - happy to do so in follow up if we get feedback but didn't seem super necessary rn


<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `forms/TradeForm`
  * Changes to make orderbook look better on mobile view
* `views/CanvasOrderbook`
  * Rename `maxRowsPerSide` to `rowsPerSide`

## Components

* `VerticalPanel`
  * Bulk of the logic
  * Adds a ref to the `canvasOrderbook` tab and use `resizeObserver` off of that to calculate the number of rows we can render without scrolling


## Constants/Types

* `constants/orderbook.ts`
  * Add approximate pixel height of orderbook header for calculations on how many rows we can render

## Hooks

* `hooks/useDrawOrderbook`
  * Not really any changes, just wrapped everything in `useCallback` and fixed up the `useEffect` dependencies
  * Updated `windowResize` listener to `resizeObserver`

* `hooks/useCalculateOrderbookData`
  * Rename `maxRowsPerSide` to `rowsPerSide`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
