### PR TITLE
chore: update staking notification expiration date

### DIFF
--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -280,7 +280,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
       const conditionalOrdersExpirationDate = new Date('2024-06-01T23:59:59');
       const fokDeprecationExpirationDate = new Date('2024-07-01T23:59:59');
       const isolatedMarginLiveExpirationDate = new Date('2024-07-12T23:59:59');
-      const stakingLiveExpirationDate = new Date('2024-08-24T23:59:59');
+      const stakingLiveExpirationDate = new Date('2024-07-24T23:59:59');
 
       const { isolatedMarginLearnMore } = useURLConfigs();
 


### PR DESCRIPTION
pulls out change from https://github.com/dydxprotocol/v4-web/pull/809 which is going out later than I expected. Context is when I originally wrote this code, I couldn't count // notification should only last a month, and I accidentally set it to 2 months

will rebase that PR once this gets in