### PR TITLE
feat: warning for high fees [OTE-621]

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.8.54",
+    "@dydxprotocol/v4-abacus": "1.8.63",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.163",
     "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.8.63",
     "@dydxprotocol/v4-client-js": "^1.1.27",
-    "@dydxprotocol/v4-localization": "^1.1.163",
+    "@dydxprotocol/v4-localization": "^1.1.164",
     "@ethersproject/providers": "^5.7.2",
     "@hugocxl/react-to-image": "^0.0.9",
     "@js-joda/core": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,19 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.8.54
-    version: 1.8.54
+    specifier: 1.8.63
+    version: 1.8.63
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
   '@dydxprotocol/v4-localization':
+<<<<<<< HEAD
     specifier: ^1.1.163
     version: 1.1.163
+=======
+    specifier: ^1.1.16
+    version: 1.1.164
+>>>>>>> e28e885b (bump packages and update abacus imports)
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -3203,8 +3208,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dydxprotocol/v4-abacus@1.8.54:
-    resolution: {integrity: sha512-kG+FMK5mnLo4vhc2jhuofr0WKpfBfzkCWBtrhGaajH/QZTSlbCz60c5JYOjDM32wn0IPTJlC9hghnrg27YeZDA==}
+  /@dydxprotocol/v4-abacus@1.8.63:
+    resolution: {integrity: sha512-JxyWfOnLJYaZX08/Upa+J996kZjcemrnroubL9ly0staMpobDudkeRlXc5k5t2WwQzAJyTbx7dqOTztmVmJ6Mw==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5
@@ -3239,8 +3244,13 @@ packages:
       - utf-8-validate
     dev: false
 
+<<<<<<< HEAD
   /@dydxprotocol/v4-localization@1.1.163:
     resolution: {integrity: sha512-ewyuJ6AXshDhV/kmf+ZOIBNsemMSAFOd6JbhkkWK+SipwUUzBaAQoulL6daxf7mi4a8H1yu4G75aeWmpcOqLCw==}
+=======
+  /@dydxprotocol/v4-localization@1.1.164:
+    resolution: {integrity: sha512-qModKXbxuxto6iDhNtzpnLPw4qopbkO5aDAjoUu1CF763ipJFLjwsrij1aaI8ivAhwzJAnKE8n51vrWryFmwNQ==}
+>>>>>>> e28e885b (bump packages and update abacus imports)
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,13 +36,8 @@ dependencies:
     specifier: ^1.1.27
     version: 1.1.27
   '@dydxprotocol/v4-localization':
-<<<<<<< HEAD
-    specifier: ^1.1.163
-    version: 1.1.163
-=======
-    specifier: ^1.1.16
+    specifier: ^1.1.164
     version: 1.1.164
->>>>>>> e28e885b (bump packages and update abacus imports)
   '@ethersproject/providers':
     specifier: ^5.7.2
     version: 5.7.2
@@ -3244,13 +3239,8 @@ packages:
       - utf-8-validate
     dev: false
 
-<<<<<<< HEAD
-  /@dydxprotocol/v4-localization@1.1.163:
-    resolution: {integrity: sha512-ewyuJ6AXshDhV/kmf+ZOIBNsemMSAFOd6JbhkkWK+SipwUUzBaAQoulL6daxf7mi4a8H1yu4G75aeWmpcOqLCw==}
-=======
   /@dydxprotocol/v4-localization@1.1.164:
     resolution: {integrity: sha512-qModKXbxuxto6iDhNtzpnLPw4qopbkO5aDAjoUu1CF763ipJFLjwsrij1aaI8ivAhwzJAnKE8n51vrWryFmwNQ==}
->>>>>>> e28e885b (bump packages and update abacus imports)
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:
@@ -15228,7 +15218,6 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
-    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}

--- a/src/constants/__test__/cctp.spec.ts
+++ b/src/constants/__test__/cctp.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getLowestFeeChainNames,
+  getMapOfHighestFeeTokensByChainId,
   getMapOfLowestFeeTokensByChainId,
   getMapOfLowestFeeTokensByDenom,
 } from '@/constants/cctp';
@@ -283,6 +284,29 @@ describe('getMapOfLowestFeeTokensByChainId', () => {
           chainId: '42161',
           tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
           name: 'arbitrum',
+        },
+      ],
+    });
+  });
+});
+
+describe('getMapOfHighestFeeTokensByChainId', () => {
+  it('deposits squid - should be an empty map', () => {
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.deposit, false)).toEqual({});
+  });
+  it('deposits skip - should be an empty map', () => {
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.deposit, true)).toEqual({});
+  });
+  it('withdrawals squid - should be an empty map', () => {
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.withdrawal, false)).toEqual({});
+  });
+  it('withdrawals skip - should be a map with one property: ethereum chain id', () => {
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.withdrawal, true)).toEqual({
+      1: [
+        {
+          chainId: '1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          name: 'Ethereum',
         },
       ],
     });

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -116,36 +116,39 @@ export const ErrorType = Abacus.exchange.dydx.abacus.output.input.ErrorType;
 
 // ------ Wallet ------ //
 export type Wallet = Abacus.exchange.dydx.abacus.output.Wallet;
-export type AccountBalance = Abacus.exchange.dydx.abacus.output.AccountBalance;
-export type StakingDelegation = Abacus.exchange.dydx.abacus.output.StakingDelegation;
-export type UnbondingDelegation = Abacus.exchange.dydx.abacus.output.UnbondingDelegation;
-export type StakingRewards = Abacus.exchange.dydx.abacus.output.StakingRewards;
-export type TradingRewards = Abacus.exchange.dydx.abacus.output.TradingRewards;
-export type HistoricalTradingReward = Abacus.exchange.dydx.abacus.output.HistoricalTradingReward;
+export type AccountBalance = Abacus.exchange.dydx.abacus.output.account.AccountBalance;
+export type StakingDelegation = Abacus.exchange.dydx.abacus.output.account.StakingDelegation;
+export type UnbondingDelegation = Abacus.exchange.dydx.abacus.output.account.UnbondingDelegation;
+export type StakingRewards = Abacus.exchange.dydx.abacus.output.account.StakingRewards;
+export type TradingRewards = Abacus.exchange.dydx.abacus.output.account.TradingRewards;
+export type HistoricalTradingReward =
+  Abacus.exchange.dydx.abacus.output.account.HistoricalTradingReward;
 export const HistoricalTradingRewardsPeriod =
   Abacus.exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod;
 const historicalTradingRewardsPeriod = [...HistoricalTradingRewardsPeriod.values()] as const;
 export type HistoricalTradingRewardsPeriods = (typeof historicalTradingRewardsPeriod)[number];
 
-export type Subaccount = Abacus.exchange.dydx.abacus.output.Subaccount;
-export type SubaccountPosition = Abacus.exchange.dydx.abacus.output.SubaccountPosition;
+export type Subaccount = Abacus.exchange.dydx.abacus.output.account.Subaccount;
+export type SubaccountPosition = Abacus.exchange.dydx.abacus.output.account.SubaccountPosition;
 export type SubaccountPendingPosition =
-  Abacus.exchange.dydx.abacus.output.SubaccountPendingPosition;
-export type SubaccountOrder = Abacus.exchange.dydx.abacus.output.SubaccountOrder;
+  Abacus.exchange.dydx.abacus.output.account.SubaccountPendingPosition;
+export type SubaccountOrder = Abacus.exchange.dydx.abacus.output.account.SubaccountOrder;
 export type OrderStatus = Abacus.exchange.dydx.abacus.output.input.OrderStatus;
 export const AbacusOrderStatus = Abacus.exchange.dydx.abacus.output.input.OrderStatus;
 const abacusOrderStatuses = [...AbacusOrderStatus.values()] as const;
 export type AbacusOrderStatuses = (typeof abacusOrderStatuses)[number];
-export type SubaccountFills = Abacus.exchange.dydx.abacus.output.SubaccountFill[];
-export type SubaccountFill = Abacus.exchange.dydx.abacus.output.SubaccountFill;
-export type SubaccountFundingPayment = Abacus.exchange.dydx.abacus.output.SubaccountFundingPayment;
+export type SubaccountFills = Abacus.exchange.dydx.abacus.output.account.SubaccountFill[];
+export type SubaccountFill = Abacus.exchange.dydx.abacus.output.account.SubaccountFill;
+export type SubaccountFundingPayment =
+  Abacus.exchange.dydx.abacus.output.account.SubaccountFundingPayment;
 export type SubaccountFundingPayments =
-  Abacus.exchange.dydx.abacus.output.SubaccountFundingPayment[];
-export type SubaccountTransfer = Abacus.exchange.dydx.abacus.output.SubaccountTransfer;
-export type SubaccountTransfers = Abacus.exchange.dydx.abacus.output.SubaccountTransfer[];
+  Abacus.exchange.dydx.abacus.output.account.SubaccountFundingPayment[];
+export type SubaccountTransfer = Abacus.exchange.dydx.abacus.output.account.SubaccountTransfer;
+export type SubaccountTransfers = Abacus.exchange.dydx.abacus.output.account.SubaccountTransfer[];
 
 // ------ Historical PnL ------ //
-export type SubAccountHistoricalPNLs = Abacus.exchange.dydx.abacus.output.SubaccountHistoricalPNL[];
+export type SubAccountHistoricalPNLs =
+  Abacus.exchange.dydx.abacus.output.account.SubaccountHistoricalPNL[];
 export const HistoricalPnlPeriod = Abacus.exchange.dydx.abacus.state.manager.HistoricalPnlPeriod;
 const historicalPnlPeriod = [...HistoricalPnlPeriod.values()] as const;
 export type HistoricalPnlPeriods = (typeof historicalPnlPeriod)[number];

--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -196,8 +196,8 @@ export type AbacusOrderSides = Abacus.exchange.dydx.abacus.output.input.OrderSid
 export const AbacusOrderType = Abacus.exchange.dydx.abacus.output.input.OrderType;
 export const AbacusOrderSide = Abacus.exchange.dydx.abacus.output.input.OrderSide;
 
-export const AbacusPositionSide = Abacus.exchange.dydx.abacus.output.PositionSide;
-export type AbacusPositionSides = Abacus.exchange.dydx.abacus.output.PositionSide;
+export const AbacusPositionSide = Abacus.exchange.dydx.abacus.output.account.PositionSide;
+export type AbacusPositionSides = Abacus.exchange.dydx.abacus.output.account.PositionSide;
 
 export const AbacusMarginMode = Abacus.exchange.dydx.abacus.output.input.MarginMode;
 

--- a/src/constants/cctp.ts
+++ b/src/constants/cctp.ts
@@ -18,7 +18,7 @@ const getLowestFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
     ? mainnetChains
     : mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId !== '1' : true));
 
-const getHighFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
+const getHighestFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
   type === TransferType.withdrawal
     ? mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId === '1' : false))
     : [];
@@ -61,7 +61,7 @@ export const getMapOfLowestFeeTokensByChainId = (
 export const getMapOfHighestFeeTokensByChainId = (
   type: NullableTransferType,
   skipEnabled: boolean
-) => getMapOfChainsByChainId(getHighFeeChains(type, skipEnabled));
+) => getMapOfChainsByChainId(getHighestFeeChains(type, skipEnabled));
 
 export const cctpTokensByDenom = cctpTokens.reduce(
   (acc, token) => {

--- a/src/constants/cctp.ts
+++ b/src/constants/cctp.ts
@@ -5,6 +5,7 @@ export type CctpTokenInfo = {
   chainId: string;
   tokenAddress: string;
   name: string;
+  isTestnet?: boolean;
 };
 
 type NullableTransferType = TransferTypeType | undefined | null;
@@ -16,6 +17,11 @@ const getLowestFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
   type === TransferType.deposit
     ? mainnetChains
     : mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId !== '1' : true));
+
+const getHighFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
+  type === TransferType.withdrawal
+    ? mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId === '1' : false))
+    : [];
 
 // move this out if we need it in another module
 const capitalizeNames = (str: string) => str[0].toUpperCase() + str.slice(1);
@@ -35,11 +41,8 @@ export const getMapOfLowestFeeTokensByDenom = (type: NullableTransferType, skipE
     {} as Record<string, CctpTokenInfo[]>
   );
 
-export const getMapOfLowestFeeTokensByChainId = (
-  type: NullableTransferType,
-  skipEnabled: boolean
-) =>
-  getLowestFeeChains(type, skipEnabled).reduce(
+const getMapOfChainsByChainId = (chains: CctpTokenInfo[]) =>
+  chains.reduce(
     (acc, token) => {
       if (!acc[token.chainId]) {
         acc[token.chainId] = [];
@@ -49,6 +52,16 @@ export const getMapOfLowestFeeTokensByChainId = (
     },
     {} as Record<string, CctpTokenInfo[]>
   );
+
+export const getMapOfLowestFeeTokensByChainId = (
+  type: NullableTransferType,
+  skipEnabled: boolean
+) => getMapOfChainsByChainId(getLowestFeeChains(type, skipEnabled));
+
+export const getMapOfHighestFeeTokensByChainId = (
+  type: NullableTransferType,
+  skipEnabled: boolean
+) => getMapOfChainsByChainId(getHighFeeChains(type, skipEnabled));
 
 export const cctpTokensByDenom = cctpTokens.reduce(
   (acc, token) => {

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -40,6 +40,7 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 import { isTruthy } from '@/lib/isTruthy';
 import { MustBigNumber } from '@/lib/numbers';
 
+import { RouteWarningMessage } from '../RouteWarningMessage';
 import { SlippageEditor } from '../SlippageEditor';
 
 type ElementProps = {
@@ -105,7 +106,9 @@ export const DepositButtonAndReceipt = ({
     requestPayload,
     depositOptions,
     chain: chainIdStr,
+    warning: routeWarning,
   } = useAppSelector(getTransferInputs, shallowEqual) ?? {};
+
   const { usdcLabel } = useTokenConfigs();
   const isSkipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
 
@@ -250,11 +253,22 @@ export const DepositButtonAndReceipt = ({
     },
   ].filter(isTruthy);
 
+  const [hasAcknowledged, setHasAcknowledged] = useState(false);
+  const requiresAcknowledgement = Boolean(routeWarning && !hasAcknowledged);
+
   const isFormValid =
-    !isDisabled && !isEditingSlippage && connectionError !== ConnectionErrorType.CHAIN_DISRUPTION;
+    !isDisabled &&
+    !isEditingSlippage &&
+    connectionError !== ConnectionErrorType.CHAIN_DISRUPTION &&
+    !requiresAcknowledgement;
 
   return (
     <$WithReceipt slotReceipt={<$Details items={submitButtonReceipt} />}>
+      <RouteWarningMessage
+        hasAcknowledged={hasAcknowledged}
+        setHasAcknowledged={setHasAcknowledged}
+        routeWarningJSON={routeWarning}
+      />
       {!canAccountTrade ? (
         <OnboardingTriggerButton size={ButtonSize.Base} />
       ) : !isConnectedWagmi ? (

--- a/src/views/forms/AccountManagementForms/HighestFeesText.tsx
+++ b/src/views/forms/AccountManagementForms/HighestFeesText.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+export const HighestFeesDecoratorText = () => {
+  const stringGetter = useStringGetter();
+  return (
+    <$Text>
+      {stringGetter({
+        key: STRING_KEYS.HIGH_FEES_IN_GENERAL,
+        params: {
+          HIGH_FEES_IN_GENERAL_HIGHLIGHT_TEXT: (
+            <$RedHighlight>
+              {stringGetter({ key: STRING_KEYS.HIGH_FEES_IN_GENERAL_HIGHLIGHT_TEXT })}
+            </$RedHighlight>
+          ),
+        },
+      })}
+    </$Text>
+  );
+};
+
+const $Text = styled.div`
+  font: var(--font-small-regular);
+  color: var(--color-text-0);
+`;
+
+const $RedHighlight = styled.span`
+  color: var(--color-red);
+`;

--- a/src/views/forms/AccountManagementForms/RouteWarningMessage.tsx
+++ b/src/views/forms/AccountManagementForms/RouteWarningMessage.tsx
@@ -1,0 +1,76 @@
+import { Dispatch, SetStateAction, useMemo } from 'react';
+
+import styled from 'styled-components';
+
+import { AlertType } from '@/constants/alerts';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { AlertMessage } from '@/components/AlertMessage';
+import { Checkbox } from '@/components/Checkbox';
+
+import { log } from '@/lib/telemetry';
+
+type RouteWarningMessageProps = {
+  hasAcknowledged: boolean;
+  setHasAcknowledged: Dispatch<SetStateAction<boolean>>;
+  routeWarningJSON: string | undefined | null;
+};
+/*
+Warning message example:
+{
+  "type": "BAD_PRICE_WARNING",
+  "message": "Difference in USD value of route input and output is large. Input USD value: 52.98 Output USD value: 28.05"
+}
+*/
+
+const getStringKeyFromWarningType = (warningType: string) => {
+  if (warningType === 'BAD_PRICE_WARNING') return STRING_KEYS.ACKNOWLEDGE_WARNING_MESSAGE_HIGH_FEES;
+  return STRING_KEYS.ACKNOWLEDGE_WARNING_MESSAGE_FALLBACK;
+};
+
+export const RouteWarningMessage = ({
+  hasAcknowledged,
+  setHasAcknowledged,
+  routeWarningJSON,
+}: RouteWarningMessageProps) => {
+  const stringGetter = useStringGetter();
+  const { warningMessage, acknowledgementMessageStringKey } = useMemo(() => {
+    if (!routeWarningJSON) return {};
+    try {
+      const warningObject = JSON.parse(routeWarningJSON);
+      return {
+        warningMessage: warningObject.message,
+        acknowledgementMessageStringKey: getStringKeyFromWarningType(warningObject.type),
+      };
+    } catch (err) {
+      log('RouteWarningMessage/warningObject', err);
+      return {};
+    }
+  }, [routeWarningJSON]);
+  if (!warningMessage || !acknowledgementMessageStringKey) {
+    setHasAcknowledged(false);
+    return null;
+  }
+
+  return (
+    <$AlertMessage type={AlertType.Warning}>
+      <Checkbox
+        checked={hasAcknowledged}
+        onCheckedChange={setHasAcknowledged}
+        id="acknowledge-route-warning"
+        label={stringGetter({
+          key: acknowledgementMessageStringKey,
+          params: {
+            WARNING_MESSAGE: warningMessage,
+          },
+        })}
+      />
+    </$AlertMessage>
+  );
+};
+
+const $AlertMessage = styled(AlertMessage)`
+  margin: var(--form-input-paddingY) var(--form-input-paddingX);
+`;

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -28,6 +28,7 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
 
+import { HighestFeesDecoratorText } from './HighestFeesText';
 import { LowestFeesDecoratorText } from './LowestFeesText';
 
 type ElementProps = {
@@ -73,6 +74,11 @@ export const SourceSelectMenu = ({
   // in the description prop (renders below the item label) instead of in the slotAfter
   const feesDecoratorProp = type === TransferType.deposit ? 'slotAfter' : 'description';
 
+  const getFeeDecoratorComponentForChainId = (chainId: string) => {
+    if (lowestFeeTokensByChainId[chainId]) return <LowestFeesDecoratorText />;
+    if (highestFeeTokensByChainId[chainId]) return <HighestFeesDecoratorText />;
+    return null;
+  };
   const chainItems = Object.values(chains)
     .map((chain) => ({
       value: chain.type,
@@ -81,7 +87,7 @@ export const SourceSelectMenu = ({
         onSelect(chain.type, 'chain');
       },
       slotBefore: <$Img src={chain.iconUrl ?? undefined} alt="" />,
-      [feesDecoratorProp]: !!lowestFeeTokensByChainId[chain.type] && <LowestFeesDecoratorText />,
+      [feesDecoratorProp]: getFeeDecoratorComponentForChainId(chain.type),
     }))
     .filter((chain) => {
       // if deposit and CCTPDepositOnly enabled, only return cctp tokens
@@ -105,7 +111,7 @@ export const SourceSelectMenu = ({
       onSelect(exchange.type, 'exchange');
     },
     slotBefore: <$Img src={exchange.iconUrl ?? undefined} alt="" />,
-    [lowestFeesDecoratorProp]: <LowestFeesDecoratorText />,
+    [feesDecoratorProp]: <LowestFeesDecoratorText />,
   }));
 
   const selectedChainOption = chains.find((item) => item.type === selectedChain);

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -5,7 +5,11 @@ import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { TransferType } from '@/constants/abacus';
-import { cctpTokensByChainId, getMapOfLowestFeeTokensByChainId } from '@/constants/cctp';
+import {
+  cctpTokensByChainId,
+  getMapOfHighestFeeTokensByChainId,
+  getMapOfLowestFeeTokensByChainId,
+} from '@/constants/cctp';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
 import { WalletType } from '@/constants/wallets';
@@ -60,9 +64,14 @@ export const SourceSelectMenu = ({
     [type, skipEnabled]
   );
 
+  const highestFeeTokensByChainId = useMemo(
+    () => getMapOfHighestFeeTokensByChainId(type, skipEnabled),
+    [type, skipEnabled]
+  );
+
   // withdrawals SourceSelectMenu is half width size so we must throw the decorator text
   // in the description prop (renders below the item label) instead of in the slotAfter
-  const lowestFeesDecoratorProp = type === TransferType.deposit ? 'slotAfter' : 'description';
+  const feesDecoratorProp = type === TransferType.deposit ? 'slotAfter' : 'description';
 
   const chainItems = Object.values(chains)
     .map((chain) => ({
@@ -72,9 +81,7 @@ export const SourceSelectMenu = ({
         onSelect(chain.type, 'chain');
       },
       slotBefore: <$Img src={chain.iconUrl ?? undefined} alt="" />,
-      [lowestFeesDecoratorProp]: !!lowestFeeTokensByChainId[chain.type] && (
-        <LowestFeesDecoratorText />
-      ),
+      [feesDecoratorProp]: !!lowestFeeTokensByChainId[chain.type] && <LowestFeesDecoratorText />,
     }))
     .filter((chain) => {
       // if deposit and CCTPDepositOnly enabled, only return cctp tokens

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -222,7 +222,7 @@ export const WithdrawButtonAndReceipt = ({
             onCheckedChange={setHasAcknowledged}
             id="acknowledge-secret-phase-risk"
             label={stringGetter({
-              key: STRING_KEYS.WARNING_MESSAGE,
+              key: STRING_KEYS.WITHDRAW_ROUTE_WARNING_MESSAGE,
               params: {
                 WARNING_MESSAGE: warningMessage,
               },


### PR DESCRIPTION
blocked by: https://github.com/dydxprotocol/v4-abacus/pull/540
If we receive a warning from skip from the `msgs_direct` api, we pass that warning onto the user and gate withdrawals until they click a checkbox saying they acknowledge the warning.

The warning we expect to see is typically about transfer fees being very high.
This is designed to prevent users who aren't pay attention to the receipt from losing funds unnecessarily

We also update the copy in the source select dropdown to warn users for high fees on ethereum



### Modal when user attempts a high fee withdrawal:
https://www.loom.com/share/5e388ab7b5f24e3b8ef1896717e39590?sid=41cf5310-6a2e-4ffa-b902-5f65c5c6633f

### Modal when user attempts a high fee deposit:
NOTE: had to mock a route warning since i  couldn't trigger a real one, so excuse the jankiness
https://www.loom.com/share/0eefc97cba4744faa3d2f08a024f7d13?sid=1df2cd7e-43e1-477c-9cd8-15e8d8beedfa

### Modal when user attempts a non high fee withdrawal or deposit **that still has a warning**:
NOTE: had to mock a route warning again for this one
https://www.loom.com/share/30a9bbe878184225909e72d458d64f3f?sid=e9017622-ef1c-4cf7-887b-1962aabaecb7

Modal when user is scrolling through withdrawal options:
https://www.loom.com/share/34c5a6e8e2314b28b9df152e4b774936?sid=aa601491-7c5c-47e1-bd96-ab32b362375f

Modal when user attempts a non-high fee withdrawal or deposit:
https://www.loom.com/share/c0dc91ce845441e5bce6511ddd80d156?sid=02b7855d-3c98-42bd-86ce-f02b8e2214ae

