### PR TITLE
feat(ohlc): enable ohlc for all markets

### DIFF
--- a/src/constants/candles.ts
+++ b/src/constants/candles.ts
@@ -14,6 +14,8 @@ export interface Candle {
   usdVolume: string;
   trades: number;
   startingOpenInterest: string;
+  orderbookMidPriceOpen?: string;
+  orderbookMidPriceClose?: string;
 }
 
 export interface TradingViewBar {

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -47,6 +47,10 @@ class TestFlags {
   get referrer() {
     return this.queryParams.utm_source;
   }
+
+  get ohlc() {
+    return !!this.queryParams.ohlc;
+  }
 }
 
 export const testFlags = new TestFlags();

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -49,6 +49,8 @@ class TestFlags {
   }
 
   get ohlc() {
+    // When enabled, empty (0 trade) candles in markets will show O(pen) H(igh) L(ow) C(lose) data via mid-price.
+    // When disabled, candles will only display OHLC data from historical trades.
     return !!this.queryParams.ohlc;
   }
 }

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -8,6 +8,8 @@ import { Themes } from '@/styles/themes';
 
 import { AppTheme, type AppColorMode } from '@/state/configs';
 
+import { testFlags } from '../testFlags';
+
 export const mapCandle = ({
   startedAt,
   open,
@@ -15,14 +17,28 @@ export const mapCandle = ({
   high,
   low,
   baseTokenVolume,
-}: Candle): TradingViewBar => ({
-  time: new Date(startedAt).getTime(),
-  low: parseFloat(low),
-  high: parseFloat(high),
-  open: parseFloat(open),
-  close: parseFloat(close),
-  volume: Math.ceil(Number(baseTokenVolume)),
-});
+  trades,
+  orderbookMidPriceOpen,
+  orderbookMidPriceClose,
+}: Candle): TradingViewBar => {
+  const isOhlcEnabled = testFlags.ohlc;
+  const hasNoTrades = trades === 0;
+
+  return {
+    time: new Date(startedAt).getTime(),
+    low: parseFloat(low),
+    high: parseFloat(high),
+    open:
+      isOhlcEnabled && hasNoTrades && orderbookMidPriceOpen
+        ? parseFloat(orderbookMidPriceOpen)
+        : parseFloat(open),
+    close:
+      isOhlcEnabled && hasNoTrades && orderbookMidPriceClose
+        ? parseFloat(orderbookMidPriceClose)
+        : parseFloat(close),
+    volume: Math.ceil(Number(baseTokenVolume)),
+  };
+};
 
 export const getSymbol = (marketId: string): TradingViewSymbol => ({
   description: marketId,

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -21,21 +21,19 @@ export const mapCandle = ({
   orderbookMidPriceOpen,
   orderbookMidPriceClose,
 }: Candle): TradingViewBar => {
-  const isOhlcEnabled = testFlags.ohlc;
   const hasNoTrades = trades === 0;
+  const useOhlc = testFlags.ohlc && hasNoTrades && orderbookMidPriceOpen && orderbookMidPriceClose;
 
   return {
     time: new Date(startedAt).getTime(),
-    low: parseFloat(low),
-    high: parseFloat(high),
-    open:
-      isOhlcEnabled && hasNoTrades && orderbookMidPriceOpen
-        ? parseFloat(orderbookMidPriceOpen)
-        : parseFloat(open),
-    close:
-      isOhlcEnabled && hasNoTrades && orderbookMidPriceClose
-        ? parseFloat(orderbookMidPriceClose)
-        : parseFloat(close),
+    low: useOhlc
+      ? Math.min(parseFloat(orderbookMidPriceOpen), parseFloat(orderbookMidPriceClose))
+      : parseFloat(low),
+    high: useOhlc
+      ? Math.max(parseFloat(orderbookMidPriceOpen), parseFloat(orderbookMidPriceClose))
+      : parseFloat(high),
+    open: useOhlc ? parseFloat(orderbookMidPriceOpen) : parseFloat(open),
+    close: useOhlc ? parseFloat(orderbookMidPriceClose) : parseFloat(close),
     volume: Math.ceil(Number(baseTokenVolume)),
   };
 };


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

This change takes in the new `orderbookMidPrice[Open/Close]` data returned from indexer and optionally uses it to render the candles if:
- there are no trades in that candle 
- (to be removed after done testing in a subsequent PR) ohlc is enabled (as a url testing param)

### Notes
- Used a new ohlc url param flag instead of the existing OHLC flag from env.json because checking that requires a hook which is not available in `mapCandle`
- It is intentional that this change does not check if the OHLC toggle is on/off from the chart
  - We'd like to release this change before the OHLC toggle part (because it's sig easier)
- Known bug that we sometimes have trailing decimal points (rip floating point precision) in `orderbookMidPrice[Open/Close]`; BE is working on fixing that 

### Testing
- This one was sort of annoying because 
  - Changes (as of now) are only enabled in staging which is missing a few markets; and we have simulated trades in a lot of em
- Steps for testing:
  - Go to staging (only env with indexer chnages deployed)
  - Go to low volume market - RNDR seemed to be the best one to test on (ty adam) 
    - Found that at one minute resolution, there was a block with 0 trades at 2024-07-26T19:51:00.000Z
  - Find a block that has 0 trades and verify that a candle is rendered when `ohlc=true` in url params, and not otherwise  

| with OHLC enabled | without OHLC enabled | 
| ---- | ---- |
| <img width="1920" alt="Screenshot 2024-07-26 at 2 23 40 PM" src="https://github.com/user-attachments/assets/9004b285-f360-4ba1-a9dd-6d0d84ce839b"> | <img width="811" alt="Screenshot 2024-07-26 at 2 32 33 PM" src="https://github.com/user-attachments/assets/14658033-5286-4a1a-a27a-f51d6074f13e"> | 

---

