### PR TITLE
chore: Use new URL for Apybara API proxy in testnet

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -299,7 +299,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4dev.dydx.exchange"
          },
          "stakingValidators": [],
@@ -375,7 +375,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "http://dev3-faucet-lb-public-1644791410.us-east-2.elb.amazonaws.com"
          },
          "stakingValidators": [],
@@ -414,7 +414,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4dev4.dydx.exchange"
          },
          "stakingValidators": [],
@@ -620,7 +620,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [
@@ -662,7 +662,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -700,7 +700,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -739,7 +739,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -777,7 +777,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -816,7 +816,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],
@@ -855,7 +855,7 @@
             "skip": "https://api.skip.money",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
             "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "stakingAPR": "https://apybara-proxy-web-testnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
             "faucet": "https://faucet.v4testnet.dydx.exchange"
          },
          "stakingValidators": [],


### PR DESCRIPTION
Use the new API proxy with client-dedicated CORS setup.