### PR TITLE
chore: add data hj allow to inputs [OTE-639]

### DIFF
--- a/src/components/ComboboxMenu.tsx
+++ b/src/components/ComboboxMenu.tsx
@@ -73,6 +73,7 @@ export const ComboboxMenu = <
             value={searchValue}
             onValueChange={setSearchValue}
             placeholder={inputPlaceholder}
+            data-hj-allow
           />
         </$Header>
       )}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -140,6 +140,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             value={value ?? undefined}
             // Other
             data-1p-ignore // prevent 1Password fill
+            data-hj-allow
             {...otherProps}
           />
         ) : (


### PR DESCRIPTION
https://dydx-team.slack.com/archives/C06ETDBE370/p1722267871599219

hotjar blocks text input tracking by default. we are enabling it on all available inputs by adding the `data-hj-allow` property on `input` tags

NOTE: we will need to do the same when/if we add textarea tags