### PR TITLE
feat(add-filter): Prediction Market filter

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -3,22 +3,14 @@ import '@/polyfills';
 import { useEffect, useState } from 'react';
 
 import '@/index.css';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { GrazProvider } from 'graz';
+import { QueryClient } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import styled from 'styled-components';
-import { WagmiProvider } from 'wagmi';
 
 import { SupportedLocales } from '@/constants/localization';
 
-import { AccountsProvider } from '@/hooks/useAccounts';
 import { AppThemeAndColorModeProvider } from '@/hooks/useAppThemeAndColorMode';
-import { DialogAreaProvider } from '@/hooks/useDialogArea';
-import { DydxProvider } from '@/hooks/useDydxClient';
 import { LocaleProvider } from '@/hooks/useLocaleSeparators';
-import { PotentialMarketsProvider } from '@/hooks/usePotentialMarkets';
-import { RestrictionProvider } from '@/hooks/useRestrictions';
-import { SubaccountProvider } from '@/hooks/useSubaccount';
 
 import { GlobalStyle } from '@/styles/globalStyle';
 
@@ -34,8 +26,6 @@ import {
 } from '@/state/configs';
 import { setLocaleLoaded, setSelectedLocale } from '@/state/localization';
 
-import { config } from '@/lib/wagmi';
-
 import './ladle.css';
 
 const queryClient = new QueryClient();
@@ -47,19 +37,7 @@ const wrapProvider = (Component: React.ComponentType<any>, props?: any) => {
   );
 };
 
-const providers = [
-  wrapProvider(QueryClientProvider, { client: queryClient }),
-  wrapProvider(GrazProvider),
-  wrapProvider(WagmiProvider, { config }),
-  wrapProvider(LocaleProvider),
-  wrapProvider(RestrictionProvider),
-  wrapProvider(DydxProvider),
-  wrapProvider(AccountsProvider),
-  wrapProvider(SubaccountProvider),
-  wrapProvider(DialogAreaProvider),
-  wrapProvider(PotentialMarketsProvider),
-  wrapProvider(AppThemeAndColorModeProvider),
-];
+const providers = [wrapProvider(LocaleProvider), wrapProvider(AppThemeAndColorModeProvider)];
 
 export const StoryWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState(AppTheme.Classic);

--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -1,6 +1,6 @@
 import type { Story } from '@ladle/react';
 
-import { Tag, TagSign, TagSize, TagType } from '@/components/Tag';
+import { NewTag, Tag, TagSign, TagSize, TagType } from '@/components/Tag';
 
 import { StoryWrapper } from '.ladle/components';
 
@@ -37,5 +37,25 @@ TagStory.argTypes = {
     options: [true, false],
     control: { type: 'select' },
     defaultValue: false,
+  },
+};
+
+export const NewTagStory: Story<Parameters<typeof Tag>[0]> = (args) => {
+  return (
+    <StoryWrapper>
+      <NewTag {...args}>NEW</NewTag>
+    </StoryWrapper>
+  );
+};
+
+NewTagStory.args = {
+  isHighlighted: false,
+};
+
+NewTagStory.argTypes = {
+  size: {
+    options: Object.values(TagSize),
+    control: { type: 'select' },
+    defaultValue: TagSize.Small,
   },
 };

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -76,3 +76,9 @@ export const Tag = styled.span<StyleProps>`
       color: var(--color-text-button);
     `}
 `;
+
+export const NewTag = styled(Tag)`
+  background-color: var(--color-accent-faded);
+  color: var(--color-accent);
+  text-transform: uppercase;
+`;

--- a/src/components/ToggleGroup.tsx
+++ b/src/components/ToggleGroup.tsx
@@ -70,6 +70,7 @@ export const ToggleGroup = forwardRefFn(
             >
               {item.slotBefore}
               {item.label}
+              {item.slotAfter}
             </ToggleButton>
           </Item>
         ))}

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -20,6 +20,7 @@ export enum MarketSorting {
 export enum MarketFilters {
   ALL = 'all',
   NEW = 'new',
+  PREDICTION_MARKET = 'Prediction Market',
   LAYER_1 = 'Layer 1',
   LAYER_2 = 'Layer 2',
   DEFI = 'Defi',
@@ -33,7 +34,8 @@ export enum MarketFilters {
 
 export const MARKET_FILTER_LABELS = {
   [MarketFilters.ALL]: STRING_KEYS.ALL,
-  [MarketFilters.NEW]: STRING_KEYS.NEW,
+  [MarketFilters.NEW]: STRING_KEYS.RECENTLY_LISTED,
+  [MarketFilters.PREDICTION_MARKET]: undefined,
   [MarketFilters.LAYER_1]: STRING_KEYS.LAYER_1,
   [MarketFilters.LAYER_2]: STRING_KEYS.LAYER_2,
   [MarketFilters.DEFI]: STRING_KEYS.DEFI,

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -32,19 +32,51 @@ export enum MarketFilters {
   ENT = 'Entertainment',
 }
 
-export const MARKET_FILTER_LABELS = {
-  [MarketFilters.ALL]: STRING_KEYS.ALL,
-  [MarketFilters.NEW]: STRING_KEYS.RECENTLY_LISTED,
-  [MarketFilters.PREDICTION_MARKET]: undefined,
-  [MarketFilters.LAYER_1]: STRING_KEYS.LAYER_1,
-  [MarketFilters.LAYER_2]: STRING_KEYS.LAYER_2,
-  [MarketFilters.DEFI]: STRING_KEYS.DEFI,
-  [MarketFilters.AI]: STRING_KEYS.AI,
-  [MarketFilters.NFT]: STRING_KEYS.NFT,
-  [MarketFilters.GAMING]: STRING_KEYS.GAMING,
-  [MarketFilters.MEME]: STRING_KEYS.MEME,
-  [MarketFilters.RWA]: STRING_KEYS.REAL_WORLD_ASSET_SHORT,
-  [MarketFilters.ENT]: STRING_KEYS.ENTERTAINMENT,
+export const MARKET_FILTER_OPTIONS: Record<
+  MarketFilters,
+  {
+    label?: string;
+    isNew?: boolean;
+  }
+> = {
+  [MarketFilters.ALL]: {
+    label: STRING_KEYS.ALL,
+  },
+  [MarketFilters.NEW]: {
+    label: STRING_KEYS.RECENTLY_LISTED,
+  },
+  [MarketFilters.PREDICTION_MARKET]: {
+    // TODO: (TRA-516): Update string when v4-localization contains stringKey.
+    label: undefined,
+    isNew: true,
+  },
+  [MarketFilters.LAYER_1]: {
+    label: STRING_KEYS.LAYER_1,
+  },
+  [MarketFilters.LAYER_2]: {
+    label: STRING_KEYS.LAYER_2,
+  },
+  [MarketFilters.DEFI]: {
+    label: STRING_KEYS.DEFI,
+  },
+  [MarketFilters.AI]: {
+    label: STRING_KEYS.AI,
+  },
+  [MarketFilters.NFT]: {
+    label: STRING_KEYS.NFT,
+  },
+  [MarketFilters.GAMING]: {
+    label: STRING_KEYS.GAMING,
+  },
+  [MarketFilters.MEME]: {
+    label: STRING_KEYS.MEME,
+  },
+  [MarketFilters.RWA]: {
+    label: STRING_KEYS.REAL_WORLD_ASSET_SHORT,
+  },
+  [MarketFilters.ENT]: {
+    label: STRING_KEYS.ENTERTAINMENT,
+  },
 };
 
 export const DEFAULT_MARKETID = 'ETH-USD';

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { shallowEqual } from 'react-redux';
 
-import { MARKET_FILTER_LABELS, MarketFilters, type MarketData } from '@/constants/markets';
+import { MARKET_FILTER_OPTIONS, MarketFilters, type MarketData } from '@/constants/markets';
 
 import {
   SEVEN_DAY_SPARKLINE_ENTRIES,
@@ -113,7 +113,7 @@ export const useMarketsData = (
     () => [
       MarketFilters.ALL,
       MarketFilters.NEW,
-      ...objectKeys(MARKET_FILTER_LABELS).filter((marketFilter) =>
+      ...objectKeys(MARKET_FILTER_OPTIONS).filter((marketFilter) =>
         markets.some((market) => market.asset?.tags?.toArray().some((tag) => tag === marketFilter))
       ),
     ],

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -19,24 +19,24 @@ import { matchesSearchFilter } from '@/lib/search';
 import { orEmptyRecord } from '@/lib/typeUtils';
 
 const filterFunctions = {
-  [MarketFilters.ALL]: () => true,
-  [MarketFilters.LAYER_1]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Layer 1');
+  [MarketFilters.AI]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('AI');
   },
+  [MarketFilters.ALL]: () => true,
   [MarketFilters.DEFI]: (market: MarketData) => {
     return market.asset.tags?.toArray().includes('Defi');
   },
-  [MarketFilters.LAYER_2]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Layer 2');
-  },
-  [MarketFilters.NFT]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('NFT');
+  [MarketFilters.ENT]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('ENT');
   },
   [MarketFilters.GAMING]: (market: MarketData) => {
     return market.asset.tags?.toArray().includes('Gaming');
   },
-  [MarketFilters.AI]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('AI');
+  [MarketFilters.LAYER_1]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('Layer 1');
+  },
+  [MarketFilters.LAYER_2]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('Layer 2');
   },
   [MarketFilters.MEME]: (market: MarketData) => {
     return market.asset.tags?.toArray().includes('Meme');
@@ -44,8 +44,11 @@ const filterFunctions = {
   [MarketFilters.NEW]: (market: MarketData) => {
     return market.isNew;
   },
-  [MarketFilters.ENT]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('ENT');
+  [MarketFilters.NFT]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('NFT');
+  },
+  [MarketFilters.PREDICTION_MARKET]: (market: MarketData) => {
+    return market.asset.tags?.toArray().includes('Prediction Market');
   },
   [MarketFilters.RWA]: (market: MarketData) => {
     return market.asset.tags?.toArray().includes('RWA');

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -20,7 +20,7 @@ import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { NavigationMenu } from '@/components/NavigationMenu';
 import { VerticalSeparator } from '@/components/Separator';
-import { Tag } from '@/components/Tag';
+import { NewTag } from '@/components/Tag';
 import { MobileDownloadLinks } from '@/views/MobileDownloadLinks';
 import { AccountMenu } from '@/views/menus/AccountMenu';
 import { LanguageSelector } from '@/views/menus/LanguageSelector';
@@ -67,7 +67,7 @@ export const HeaderDesktop = () => {
           label: (
             <>
               {stringGetter({ key: STRING_KEYS.VAULT })}{' '}
-              <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
+              <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
             </>
           ),
           href: AppRoute.Vault,
@@ -273,8 +273,4 @@ const $UnreadIndicator = styled.div`
   height: 0.4375rem;
   border-radius: 50%;
   background-color: var(--color-accent);
-`;
-const $NewTag = styled(Tag)`
-  color: var(--color-accent);
-  background-color: var(--color-accent-faded);
 `;

--- a/src/pages/token/LaunchIncentivesPanel.tsx
+++ b/src/pages/token/LaunchIncentivesPanel.tsx
@@ -21,7 +21,7 @@ import { Button } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 import { Panel } from '@/components/Panel';
-import { Tag, TagSize } from '@/components/Tag';
+import { NewTag, TagSize } from '@/components/Tag';
 
 import { useAppDispatch } from '@/state/appTypes';
 import { markLaunchIncentivesSeen } from '@/state/configs';
@@ -66,7 +66,7 @@ const LaunchIncentivesTitle = () => {
           FOR_V4: <$ForV4>{stringGetter({ key: STRING_KEYS.FOR_V4 })}</$ForV4>,
         },
       })}
-      <$NewTag size={TagSize.Medium}>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
+      <NewTag size={TagSize.Medium}>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
     </$Title>
   );
 };
@@ -304,9 +304,4 @@ const $ChaosLabsLogo = styled.span`
   align-items: center;
   gap: 0.5em;
   font: var(--font-tiny-medium);
-`;
-
-const $NewTag = styled(Tag)`
-  color: var(--color-accent);
-  background-color: var(--color-accent-faded);
 `;

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
-import { MARKET_FILTER_LABELS, MarketFilters } from '@/constants/markets';
+import { MARKET_FILTER_OPTIONS, MarketFilters } from '@/constants/markets';
 import { AppRoute, MarketsRoute } from '@/constants/routes';
 
 import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
@@ -49,10 +49,8 @@ export const MarketFilter = ({
         <$ToggleGroupContainer $compactLayout={compactLayout}>
           <$ToggleGroup
             items={Object.values(filters).map((value) => ({
-              label: MARKET_FILTER_LABELS[value]
-                ? stringGetter({ key: MARKET_FILTER_LABELS[value] ?? '' })
-                : value,
-              slotAfter: value === MarketFilters.PREDICTION_MARKET && (
+              label: stringGetter({ key: MARKET_FILTER_OPTIONS[value].label, fallback: value }),
+              slotAfter: MARKET_FILTER_OPTIONS[value]?.isNew && (
                 <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
               ),
               value,

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -14,6 +14,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Button } from '@/components/Button';
 import { SearchInput } from '@/components/SearchInput';
+import { NewTag } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 export const MarketFilter = ({
@@ -43,15 +44,24 @@ export const MarketFilter = ({
         placeholder={stringGetter({ key: searchPlaceholderKey })}
         onTextChange={onSearchTextChange}
       />
-      <$ToggleGroupContainer $compactLayout={compactLayout}>
-        <ToggleGroup
-          items={Object.values(filters).map((value) => ({
-            label: stringGetter({ key: MARKET_FILTER_LABELS[value] }),
-            value,
-          }))}
-          value={selectedFilter}
-          onValueChange={onChangeFilter}
-        />
+
+      <$Row>
+        <$ToggleGroupContainer $compactLayout={compactLayout}>
+          <$ToggleGroup
+            items={Object.values(filters).map((value) => ({
+              label: MARKET_FILTER_LABELS[value]
+                ? stringGetter({ key: MARKET_FILTER_LABELS[value] ?? '' })
+                : value,
+              slotAfter: value === MarketFilters.PREDICTION_MARKET && (
+                <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
+              ),
+              value,
+            }))}
+            value={selectedFilter}
+            onValueChange={onChangeFilter}
+          />
+        </$ToggleGroupContainer>
+
         {hasPotentialMarketsData && !hideNewMarketButton && (
           <Button
             onClick={() => navigate(`${AppRoute.Markets}/${MarketsRoute.New}`)}
@@ -60,7 +70,7 @@ export const MarketFilter = ({
             {stringGetter({ key: STRING_KEYS.PROPOSE_NEW_MARKET })}
           </Button>
         )}
-      </$ToggleGroupContainer>
+      </$Row>
     </$MarketFilter>
   );
 };
@@ -84,7 +94,19 @@ const $MarketFilter = styled.div<{ $compactLayout: boolean }>`
 const $ToggleGroupContainer = styled.div<{ $compactLayout: boolean }>`
   ${layoutMixins.row}
   justify-content: space-between;
-  overflow-x: auto;
+  overflow-x: hidden;
+  position: relative;
+  --toggle-group-paddingRight: 0.75rem;
+
+  &:after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: var(--toggle-group-paddingRight);
+    background: linear-gradient(to right, transparent 10%, var(--color-layer-2));
+  }
 
   ${({ $compactLayout }) =>
     $compactLayout &&
@@ -98,4 +120,13 @@ const $ToggleGroupContainer = styled.div<{ $compactLayout: boolean }>`
         --button-font: var(--font-small-book);
       }
     `}
+`;
+
+const $ToggleGroup = styled(ToggleGroup)`
+  overflow-x: auto;
+  padding-right: var(--toggle-group-paddingRight);
+` as typeof ToggleGroup;
+
+const $Row = styled.div`
+  ${layoutMixins.row}
 `;

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -118,6 +118,20 @@ const MarketsDropdownContent = ({ onRowAction }: { onRowAction?: (market: Key) =
     [stringGetter]
   );
 
+  const slotBottom = useMemo(() => {
+    if (filter === MarketFilters.PREDICTION_MARKET) {
+      // TODO: (TRA-516): Localize string when finallized.
+      return (
+        <$Disclaimer>
+          Prediction Markets will settle at $1 if the event occurs as predicted. Otherwise, they
+          will settle at $0.
+        </$Disclaimer>
+      );
+    }
+
+    return null;
+  }, [filter]);
+
   return (
     <>
       <$Toolbar>
@@ -181,6 +195,7 @@ const MarketsDropdownContent = ({ onRowAction }: { onRowAction?: (market: Key) =
             </$MarketNotFound>
           }
         />
+        {slotBottom}
       </$ScrollArea>
     </>
   );
@@ -335,6 +350,12 @@ const $Popover = styled(Popover)`
   &:focus-visible {
     outline: none;
   }
+`;
+
+const $Disclaimer = styled.div`
+  font: var(--font-small-medium);
+  color: var(--color-text-0);
+  padding: 1rem;
 `;
 
 const $Toolbar = styled(Toolbar)`

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -10,7 +10,7 @@ import { useStringGetter } from '@/hooks/useStringGetter';
 import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
 
-import { Tag } from '@/components/Tag';
+import { NewTag } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 import { ExchangeBillboards } from './ExchangeBillboards';
@@ -32,7 +32,7 @@ export const MarketsStats = (props: MarketsStatsProps) => {
         <$SectionHeader>
           <$RecentlyListed>
             {stringGetter({ key: STRING_KEYS.RECENTLY_LISTED })}
-            <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
+            <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
           </$RecentlyListed>
         </$SectionHeader>
         <MarketsCompactTable sorting={MarketSorting.HIGHEST_CLOB_PAIR_ID} />
@@ -40,7 +40,7 @@ export const MarketsStats = (props: MarketsStatsProps) => {
       <$Section>
         <$SectionHeader>
           <h4>{stringGetter({ key: STRING_KEYS.BIGGEST_MOVERS })}</h4>
-          <$NewTag>{stringGetter({ key: STRING_KEYS._24H })}</$NewTag>
+          <NewTag>{stringGetter({ key: STRING_KEYS._24H })}</NewTag>
 
           <$ToggleGroupContainer>
             <ToggleGroup
@@ -79,21 +79,20 @@ const $MarketsStats = styled.section`
     ${layoutMixins.column}
   }
 `;
+
 const $Section = styled.div`
   background: var(--color-layer-3);
   border-radius: 0.625rem;
   display: grid;
   grid-template-rows: auto 1fr;
 `;
+
 const $RecentlyListed = styled.h4`
   display: flex;
   align-items: center;
   gap: 0.375rem;
 `;
-const $NewTag = styled(Tag)`
-  background-color: var(--color-accent-faded);
-  color: var(--color-accent);
-`;
+
 const $ToggleGroupContainer = styled.div`
   ${layoutMixins.row}
   position: absolute;
@@ -114,6 +113,7 @@ const $ToggleGroupContainer = styled.div`
     --button-font: var(--font-mini-book);
   }
 `;
+
 const $SectionHeader = styled.div`
   ${layoutMixins.row}
   position: relative;

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -21,7 +21,7 @@ import { Output, OutputType } from '@/components/Output';
 import { Table, type ColumnDef } from '@/components/Table';
 import { AssetTableCell } from '@/components/Table/AssetTableCell';
 import { TableCell } from '@/components/Table/TableCell';
-import { Tag } from '@/components/Tag';
+import { NewTag } from '@/components/Tag';
 import { TriangleIndicator } from '@/components/TriangleIndicator';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -105,7 +105,7 @@ export const MarketsCompactTable = ({
                 <$DetailsCell>
                   {isNew && (
                     <$RecentlyListed>
-                      <$NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</$NewTag>
+                      <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
                     </$RecentlyListed>
                   )}
                   <Icon iconName={IconName.ChevronRight} />
@@ -315,10 +315,4 @@ const $RecentlyListed = styled.div`
 const $InterestOutput = styled(Output)`
   color: var(--color-text-0);
   font: var(--font-mini-medium);
-`;
-
-const $NewTag = styled(Tag)`
-  background-color: var(--color-accent-faded);
-  color: var(--color-accent);
-  text-transform: uppercase;
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Market Page
<img width="1379" alt="Screen Shot 2024-08-01 at 9 39 32 AM" src="https://github.com/user-attachments/assets/6d8e94dd-7c82-4e68-92da-3ebb8ce2c996">

Market Dropdown
<img width="731" alt="Screen Shot 2024-08-01 at 9 40 00 AM" src="https://github.com/user-attachments/assets/8cad1a09-bb1d-4ebe-b7e5-6b8021aeaf02">

<!-- Overall purpose of the PR -->
Add `Prediction Market` filter to `<MarketFilter>` component.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketFilter>`
  * Add gradient fade to scrollable area so users know it is scrollable.
  * Utilize ToggleGroup.item `slotAfter` to render `<NewTag>` based on `MARKET_FILTER_OPTIONS`

* `<MarketDropdown>`
  * Add disclaimer when on Prediction Market Filter 

* `<Component>`
  * Remove unnecessary providers from base `ladle` component to fix component story environment.

## Components

* New: `<NewTag>`
  * Add NewTag component and story component
  * Update usage in `HeaderDesktop`, `LaunchIncentivesPanel`, `MarketStats`, and `MarketCompactTable`

* `<ToggleGroup>`
  * Add usage of `slotAfter` prop for ToggleGroup.Item

## Constants/Types

* `constants/markets`
  * Update `MARKET_FILTER_LABELS` -> `MARKET_FILTER_OPTIONS` to support `isNew` prop
  * Add Prediction Market to `enum MarketFilters`

## Hooks

* `hooks/useMarketsData`
  * alphabetize filter fn's
  * Add filter fn for Prediction Market

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->

## How to test
1. Checkout branch and run locally.
2. In `public/configs/market.json` add `Prediction Market` to any market's tags array.
3. By doing step 2 The filter should appear in the `<MarketFilter>` component
