### PR TITLE
chore: inject google tag manager script [OTE-632]

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           pnpm run build
           pnpm run build:inject-amplitude
+          pnpm run build:inject-google-tag-manager
           pnpm run build:inject-hotjar
           pnpm run build:inject-bugsnag
           pnpm run build:inject-statuspage

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Set environment variables via `.env`.
 - `VITE_TOKEN_MIGRATION_URI` (optional): The URL of the token migration website.
 - `AMPLITUDE_API_KEY` (optional): Amplitude API key for enabling Amplitude; used with `pnpm run build:inject-amplitude`.
 - `AMPLITUDE_SERVER_URL` (optional): Custom Amplitude server URL
+- `GOOGLE_TAG_MANAGER_CONTAINER_ID` (optional): Id for a google tag manager container; used with `pnpm run build:inject-google-tag-manager`.
 - `HOTJAR_SITE_ID`, `HOTJAR_VERSION` (optional): used for enabling Hotjar tracking; used with `pnpm run build:inject-hotjar`
 - `BUGSNAG_API_KEY` (optional): API key for enabling Bugsnag; used with `pnpm run build:inject-bugsnag`.
 - `IOS_APP_ID` (optional): iOS app ID used for enabling deep linking to the iOS app; used with `pnpm run build:inject-app-deeplinks`.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "pnpm run build:set-last-commit-and-tag && pnpm run build:generate-entry-points && tsc && vite build",
     "build:inject-app-deeplinks": "sh scripts/inject-app-deeplinks.sh",
     "build:inject-amplitude": "node scripts/inject-amplitude.js",
+    "build:inject-google-tag-manager": "node scripts/inject-google-tag-manager.js",
     "build:inject-hotjar": "node scripts/inject-hotjar.js",
     "build:inject-bugsnag": "node scripts/inject-bugsnag.js",
     "build:inject-analytics": "node scripts/inject-amplitude.js && node scripts/inject-hotjar.js && node scripts/inject-bugsnag.js",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,60 +1,82 @@
 ## App Integrations
+
 ### Amplitude
+
 Analytics service used to collect data to help the dYdX Product team make informed product decisions.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. Amplitude account with API key.
 2. Add API key in Github > Secrets and Variables > Actions as `AMPLITUDE_API_KEY`
 3. In your deploy scripts add `pnpm run build:inject-amplitude` after your pnpm build / vite build command.
 
 ### Hotjar
+
 User behavior tracking service used to help the dYdX Product team make informed product decisions.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. Hotjar account with Site Id and Hotjar version.
 2. Add Site Id and Hotjar version in Github > Secrets and Variables > Actions as `HOTJAR_SITE_ID` and `HOTJAR_VERSION`
 3. In your deploy scripts add `pnpm run build:inject-hotjar` after your pnpm build / vite build command.
 
 ### Bugsnag
+
 Error handling service used to collect handled/unhandled errors within the app. The information collected is used to help debug and alert the engineering team of crashes/unhandled errors within the app to improve stability.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. Bugsnag account with API key.
 2. Add API key in Github > Secrets and Variables > Actions as `BUGSNAG_API_KEY`
 3. In your deploy scripts add `pnpm run build:inject-bugsnag` after your pnpm build / vite build command.
 4. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-amplitude && pnpm run build:inject-bugsnag`
 
+### Google Tag Manager
+
+Tag management service that allows you to manage and deploy marketing tags on the website without having to modify and deploy code. Supports tags such as Google Analytics, Adwords conversions, etc. Used for marketing, analytics, and personalization.
+
+<b>To use with dydxprotocol/v4-web:</b>
+
+1. Follow the instructions on google's docs: https://support.google.com/tagmanager/answer/14842164?hl=en&ref_topic=15191151&sjid=3001289320793576310-NA#
+2. In your deploy scripts add `pnpm run build:inject-google-tag-manager` after your pnpm build / vite build command.
+
 ### StatusPage
+
 Service used to inform users of any status updates to our platform. These status updates are manually set and updated by the On Call engineers.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. StatusPage account and script URI
 2. Add API key in Github > Secrets and Variables > Actions as `STATUS_PAGE_SCRIPT_URI`
 3. In your deploy scripts add `pnpm run build:inject-statuspage` after your pnpm build / vite build command.
 4. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-amplitude && pnpm run build:inject-statuspage`
 
 ### Intercom
+
 Service used for live customer support (chat/inbox) as well as home for Help Articles.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. Create Intercom account
 2. In Intercom UI
-Getting started > Set up Messenger > will give you your API Key on Step 2
-Customize Intercom Messenger by adding logo and brand colors
+   Getting started > Set up Messenger > will give you your API Key on Step 2
+   Customize Intercom Messenger by adding logo and brand colors
 3. Add API key in Github > Secrets and Variables > Actions as `INTERCOM_APP_ID`
 4. In your deploy scripts add `pnpm run build:inject-intercom` after your pnpm build / vite build command.
 5. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-amplitude && pnpm run build:inject-intercom`
 
 ### Smartbanner
+
 Smartbanner to show download links to iOS and/or Android native apps on mobile devices.
 
 <b>To use with dydxprotocol/v4-web:</b>
+
 1. iOS app App Store link or Android app Google Play link.
-2. Add configurations in Github > Secrets and Variables > Actions as 
-    `SMARTBANNER_APP_NAME` for app name
-    `SMARTBANNER_ORG_NAME` for organization name
-    `SMARTBANNER_ICON_URL` for icon image
-    `SMARTBANNER_APPSTORE_URL` for iOS App Store link
-    `SMARTBANNER_GOOGLEPLAY_URL` for Android Google Play link
+2. Add configurations in Github > Secrets and Variables > Actions as
+   `SMARTBANNER_APP_NAME` for app name
+   `SMARTBANNER_ORG_NAME` for organization name
+   `SMARTBANNER_ICON_URL` for icon image
+   `SMARTBANNER_APPSTORE_URL` for iOS App Store link
+   `SMARTBANNER_GOOGLEPLAY_URL` for Android Google Play link
 3. In your deploy scripts add `pnpm run build:inject-smartbanner` after your pnpm build / vite build command.
 4. If you are using with the Amplitude deployment scripts, your build command may look like the following: `pnpm build && pnpm run build:inject-smartbanner`

--- a/scripts/inject-google-tag-manager.js
+++ b/scripts/inject-google-tag-manager.js
@@ -22,7 +22,7 @@ async function inject(fileName) {
   const htmlFilePath = path.resolve(projectRoot, `../dist/entry-points/${fileName}`);
   const html = await fs.readFile(htmlFilePath, 'utf-8');
 
-  const googleTagManagerScript = `
+  const googleTagManagerHeadScript = `
           <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -31,16 +31,16 @@ async function inject(fileName) {
         })(window,document,'script','dataLayer','GTM-ABCDEFGH');</script>
         <!-- End Google Tag Manager -->
   `;
-  const injectedHtml = html.replace('</head>', `${googleTagManagerScript}\n</head>`);
+  const injectedHtml = html.replace('</head>', `${googleTagManagerHeadScript}\n</head>`);
 
-  const googleTagManagerScript2 = `
+  const googleTagManagerBodyScript = `
         <!-- Google Tag Manager (noscript) -->
         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${GOOGLE_TAG_MANAGER_CONTAINER_ID}"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
   `;
 
-  const injectedHtml2 = injectedHtml.replace('<body>', `<body>\n${googleTagManagerScript2}`);
+  const injectedHtml2 = injectedHtml.replace('<body>', `<body>\n${googleTagManagerBodyScript}`);
   await fs.writeFile(htmlFilePath, injectedHtml2, 'utf-8');
 
   console.log(`Google Tag Manager scripts successfully injected (${fileName}).`);

--- a/scripts/inject-google-tag-manager.js
+++ b/scripts/inject-google-tag-manager.js
@@ -1,0 +1,47 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const GOOGLE_TAG_MANAGER_CONTAINER_ID = process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID;
+
+const currentPath = fileURLToPath(import.meta.url);
+const projectRoot = path.dirname(currentPath);
+
+if (GOOGLE_TAG_MANAGER_CONTAINER_ID) {
+  try {
+    const files = await fs.readdir('entry-points');
+    files.forEach((file) => {
+      inject(file);
+    });
+  } catch (err) {
+    console.error('Error injecting Google Tag Manager scripts:', err);
+  }
+}
+
+async function inject(fileName) {
+  const htmlFilePath = path.resolve(projectRoot, `../dist/entry-points/${fileName}`);
+  const html = await fs.readFile(htmlFilePath, 'utf-8');
+
+  const googleTagManagerScript = `
+          <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-ABCDEFGH');</script>
+        <!-- End Google Tag Manager -->
+  `;
+  const injectedHtml = html.replace('</head>', `${googleTagManagerScript}\n</head>`);
+
+  const googleTagManagerScript2 = `
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${GOOGLE_TAG_MANAGER_CONTAINER_ID}"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+  `;
+
+  const injectedHtml2 = injectedHtml.replace('<body>', `<body>\n${googleTagManagerScript2}`);
+  await fs.writeFile(htmlFilePath, injectedHtml2, 'utf-8');
+
+  console.log(`Google Tag Manager scripts successfully injected (${fileName}).`);
+}


### PR DESCRIPTION
adds google tag manager script. relies on env var GOOGLE_TAG_MANAGER_CONTAINER_ID.'

followed steps outlined here: https://support.google.com/tagmanager/answer/14847097?hl=en&ref_topic=15191151&sjid=3001289320793576310-NA

Tough to QA this - for build time scripts, env vars need to be injected via github secrets