### PR TITLE
chore(network-selector): disable network-selector if only 1 network

### DIFF
--- a/src/components/DropdownSelectMenu.tsx
+++ b/src/components/DropdownSelectMenu.tsx
@@ -31,6 +31,7 @@ type ElementProps<MenuItemValue extends string> = {
 
 type StyleProps = {
   align?: 'center' | 'start' | 'end';
+  hideIcon?: boolean;
   sideOffset?: number;
   className?: string;
 };
@@ -51,6 +52,7 @@ export const DropdownSelectMenu = <MenuItemValue extends string>({
     );
   })(),
   align = 'start',
+  hideIcon,
   sideOffset = 1,
   className,
 
@@ -59,9 +61,11 @@ export const DropdownSelectMenu = <MenuItemValue extends string>({
   const triggerContent = (
     <>
       {children}
-      <$DropdownIcon aria-hidden="true">
-        <Icon iconName={IconName.Triangle} aria-hidden="true" />
-      </$DropdownIcon>
+      {!hideIcon && (
+        <$DropdownIcon aria-hidden="true">
+          <Icon iconName={IconName.Triangle} aria-hidden="true" />
+        </$DropdownIcon>
+      )}
     </>
   );
 

--- a/src/hooks/useSelectedNetwork.ts
+++ b/src/hooks/useSelectedNetwork.ts
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useWallets } from '@privy-io/react-auth';
 
 import { LocalStorageKey } from '@/constants/localStorage';
-import { DEFAULT_APP_ENVIRONMENT, DydxNetwork } from '@/constants/networks';
+import { AVAILABLE_ENVIRONMENTS, DEFAULT_APP_ENVIRONMENT, DydxNetwork } from '@/constants/networks';
 
 import { setSelectedNetwork } from '@/state/app';
 import { getSelectedNetwork } from '@/state/appSelectors';
@@ -43,6 +43,13 @@ export const useSelectedNetwork = (): {
     },
     [dispatch, disconnect, setLocalStorageNetwork, chainId]
   );
+
+  // Ensure the selected network is valid
+  useEffect(() => {
+    if (!AVAILABLE_ENVIRONMENTS.environments.includes(selectedNetwork)) {
+      switchNetwork(DEFAULT_APP_ENVIRONMENT);
+    }
+  }, [selectedNetwork, switchNetwork]);
 
   return { switchNetwork, selectedNetwork };
 };

--- a/src/views/menus/NetworkSelectMenu.tsx
+++ b/src/views/menus/NetworkSelectMenu.tsx
@@ -19,6 +19,8 @@ export const NetworkSelectMenu = ({ align, sideOffset }: StyleProps) => {
 
   return (
     <$DropdownSelectMenu
+      disabled={networks.length <= 1}
+      hideIcon
       items={networks}
       value={selectedNetwork}
       onValueChange={switchNetwork}
@@ -27,15 +29,24 @@ export const NetworkSelectMenu = ({ align, sideOffset }: StyleProps) => {
     />
   );
 };
+
 const $DropdownSelectMenu = styled(DropdownSelectMenu)`
   ${headerMixins.dropdownTrigger}
 
   width: max-content;
 
   & > span:first-of-type {
-    ${layoutMixins.textOverflow}
+    display: inline-block;
     max-width: 5.625rem;
     min-width: 0;
     white-space: nowrap;
+  }
+
+  &:not(:disabled) > span:first-of-type {
+    ${layoutMixins.textOverflow}
+  }
+
+  &:disabled {
+    cursor: default;
   }
 ` as typeof DropdownSelectMenu;


### PR DESCRIPTION
<!-- Overall purpose of the PR -->
Disable the NetworkSelectMenu and hide the dropdown icon when there is only one supported network.
---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<NetworkSelectMenu>`
  * disable the dropdown if 1 available environment

## Components

* `<DropdownSelectMenu>`
  * Introduce prop to hide the caret icon

## Hooks

* `hooks/useSelectedNetwork`
  * add side-effect to set your network to the default if the `selectedNetwork` from localStorage is invalid. (Necessary to add the side effect because the dropdown will be disabled)

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
