### PR TITLE
fix: fetch balance without switch network

### DIFF
--- a/src/hooks/useAccountBalance.ts
+++ b/src/hooks/useAccountBalance.ts
@@ -73,10 +73,12 @@ export const useAccountBalance = ({
         ...tokenContract,
         functionName: 'balanceOf',
         args: [evmAddress ?? '0x'],
+        chainId: typeof chainId === 'number' ? chainId : undefined,
       } as const,
       {
         ...tokenContract,
         functionName: 'decimals',
+        chainId: typeof chainId === 'number' ? chainId : undefined,
       } as const,
     ],
     query: {


### PR DESCRIPTION
There was bug where the user can not see their token balance unless they switched network first. Fix this by passing in the chainId to `useReadContracts`

https://github.com/user-attachments/assets/d268661d-ce6c-4bbb-b71a-d530f38f26a7

