### PR TITLE
chore(incentives): remove season 5 notification distribution flag

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -312,7 +312,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -351,7 +350,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -392,7 +390,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -433,7 +430,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -472,7 +468,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -512,7 +507,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": true
          }
       },
@@ -564,7 +558,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -604,7 +597,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -652,7 +644,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -692,7 +683,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -733,7 +723,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -773,7 +762,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -814,7 +802,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -855,7 +842,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -896,7 +882,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       },
@@ -937,7 +922,6 @@
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false,
-            "seasonFiveIncentivesDistributed": false,
             "isOhlcEnabled": false
          }
       }

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -217,7 +217,6 @@ export enum ReleaseUpdateNotificationIds {
 
 // Incentives Season
 export enum IncentivesDistributedNotificationIds {
-  IncentivesDistributedS4 = 'incentives-distributed-s4',
   IncentivesDistributedS5 = 'incentives-distributed-s5',
 }
 
@@ -228,10 +227,8 @@ export const INCENTIVES_SEASON_NOTIFICATION_ID = ReleaseUpdateNotificationIds.In
 export function getSeasonRewardDistributionNumber(seasonId: IncentivesDistributedNotificationIds) {
   switch (seasonId) {
     case IncentivesDistributedNotificationIds.IncentivesDistributedS5:
-      return 5;
-    case IncentivesDistributedNotificationIds.IncentivesDistributedS4:
     default:
-      return 4;
+      return 5;
   }
 }
 

--- a/src/hooks/useEnvFeatures.ts
+++ b/src/hooks/useEnvFeatures.ts
@@ -11,7 +11,6 @@ export interface EnvironmentFeatures {
   CCTPDepositOnly: boolean;
   isSlTpEnabled: boolean;
   isSlTpLimitOrdersEnabled: boolean;
-  seasonFiveIncentivesDistributed: boolean;
   isOhlcEnabled: boolean;
 }
 

--- a/src/hooks/useIncentivesSeason.ts
+++ b/src/hooks/useIncentivesSeason.ts
@@ -3,15 +3,11 @@ import {
   IncentivesDistributedNotificationIds,
 } from '@/constants/notifications';
 
-import { useEnvFeatures } from '@/hooks/useEnvFeatures';
-
 export const useIncentivesSeason = () => {
-  const { seasonFiveIncentivesDistributed } = useEnvFeatures();
-
-  const incentivesDistributedSeasonId = seasonFiveIncentivesDistributed
-    ? IncentivesDistributedNotificationIds.IncentivesDistributedS5
-    : IncentivesDistributedNotificationIds.IncentivesDistributedS4;
-
+  // Add an env flag here for easy development + release of reward distribution notifications
+  // Example: https://github.com/dydxprotocol/v4-web/pull/809
+  const incentivesDistributedSeasonId =
+    IncentivesDistributedNotificationIds.IncentivesDistributedS5;
   const rewardDistributionSeasonNumber = getSeasonRewardDistributionNumber(
     incentivesDistributedSeasonId
   );


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
Removes `seasonFiveIncentivesDistributed` flag (I'd like to remove these flags as soon as they're not needed so merging the `env.json` is less confusing for others).

 
Testing:
- built locally, small modification to show even if rewards = 0 just for testing
<img width="287" alt="Screenshot 2024-08-05 at 11 53 12 AM" src="https://github.com/user-attachments/assets/ba064212-4dcd-445d-ab1c-15d0063f6f8c">


<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->


## Constants/Types

* `constants/notifications.ts`
  * Remove `IncentivesDistributedNotificationIds.IncentivesDistributedS4`  (no longer used) 

## Hooks

* `hooks/useEnvFeatures`
  * remove `seasonFiveIncentivesDistributed` from `EnvironmentFeatures`

* `hooks/useIncentivesSeason`
  * remove check of `seasonFiveIncentivesDistributed` (assume is true)
  * add comment referencing how to easily update again for subsequent seasons

## Configs

* `env.json`
  * Remove `seasonFiveIncentivesDistributed`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
