### PR TITLE
feat: round USD values in position size to 2 decimals [CT-992]

### DIFF
--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -191,7 +191,7 @@ const getPositionsTableColumnDef = ({
         getCellValue: (row) => row.notionalTotal?.current,
         label: stringGetter({ key: STRING_KEYS.SIZE }),
         hideOnBreakpoint: MediaQueryKeys.isMobile,
-        renderCell: ({ assetId, size, notionalTotal, tickSizeDecimals, stepSizeDecimals }) => (
+        renderCell: ({ assetId, size, notionalTotal, stepSizeDecimals }) => (
           <TableCell stacked>
             <$OutputSigned
               type={OutputType.Asset}
@@ -201,11 +201,7 @@ const getPositionsTableColumnDef = ({
               sign={getNumberSign(size?.current)}
               fractionDigits={stepSizeDecimals}
             />
-            <Output
-              type={OutputType.Fiat}
-              value={notionalTotal?.current}
-              fractionDigits={tickSizeDecimals}
-            />
+            <Output type={OutputType.Fiat} value={notionalTotal?.current} />
           </TableCell>
         ),
       },


### PR DESCRIPTION
This PR updates the USD value of position sizing in trade/portfolio position tables to be 2 decimals.

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/347e1e1b-0367-40ed-a3fd-b9cd0a12e4cb">
