### PR TITLE
fix: CT-1060 only show margin usage error icon when most relevant error is relate to margin usage

### DIFF
--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -67,6 +67,8 @@ export const AccountInfoConnectedState = () => {
     (!!marginUsage?.postOrder && getTradeStateWithDoubleValuesHasDiff(marginUsage)) ||
     (!!freeCollateral?.postOrder && getTradeStateWithDoubleValuesHasDiff(freeCollateral));
 
+  const isAccountMarginUsageError = listOfErrors?.[0] === 'INVALID_NEW_ACCOUNT_MARGIN_USAGE';
+
   const showHeader = !hasDiff && !isTablet;
 
   return (
@@ -124,7 +126,7 @@ export const AccountInfoConnectedState = () => {
           items={[
             {
               key: AccountInfoItem.MarginUsage,
-              hasError: listOfErrors?.includes('INVALID_NEW_ACCOUNT_MARGIN_USAGE'),
+              hasError: isAccountMarginUsageError,
               tooltip: 'cross-margin-usage',
               isPositive: !MustBigNumber(marginUsage?.postOrder).gt(
                 MustBigNumber(marginUsage?.current)


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/d9e44176-3dab-42ba-98d6-345f6e706fcd)

after
![image](https://github.com/user-attachments/assets/b8f3df84-c3af-46ba-90d5-83b0f52c5470)

- when order flips position when reduce only is checked, post order account margin usage isn't calculated so it'll also fail "INVALID_NEW_ACCOUNT_MARGIN_USAGE", which is why there's an error icon next to cross margin usage
- however this is confusing because we don't surface anything on the FE that suggests there's any margin usage being calculated / or why it's invalid. so updating to only surface that error when it's the first validation error (i.e. what we're surfacing in the alert / cta)
- the two errors returned in this condition are 1. "ORDER_WOULD_FLIP_POSITION", 2. margin usage error
- opted to not update abacus logic to skip margin usage error when there's a invalid reduce only state since we should just take advantage of the defined error ordering (i.e. error code)