### PR TITLE
chore(analytics): update cmd k menu to use dialog logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ import { FooterDesktop } from '@/layout/Footer/FooterDesktop';
 import { FooterMobile } from '@/layout/Footer/FooterMobile';
 import { HeaderDesktop } from '@/layout/Header/HeaderDesktop';
 import { NotificationsToastArea } from '@/layout/NotificationsToastArea';
-import { GlobalCommandDialog } from '@/views/dialogs/GlobalCommandDialog';
 
 import { parseLocationHash } from '@/lib/urlUtils';
 import { config, privyConfig } from '@/lib/wagmi';
@@ -42,6 +41,7 @@ import { config, privyConfig } from '@/lib/wagmi';
 import { RestrictionWarning } from './components/RestrictionWarning';
 import { useAnalytics } from './hooks/useAnalytics';
 import { useBreakpoints } from './hooks/useBreakpoints';
+import { useCommandMenu } from './hooks/useCommandMenu';
 import { useInitializePage } from './hooks/useInitializePage';
 import { useShouldShowFooter } from './hooks/useShouldShowFooter';
 import { useTokenConfigs } from './hooks/useTokenConfigs';
@@ -64,6 +64,7 @@ const queryClient = new QueryClient();
 const Content = () => {
   useInitializePage();
   useAnalytics();
+  useCommandMenu();
 
   const { isTablet, isNotTablet } = useBreakpoints();
   const { chainTokenLabel } = useTokenConfigs();
@@ -136,7 +137,6 @@ const Content = () => {
           <DialogManager />
         </$DialogArea>
 
-        <GlobalCommandDialog />
       </$Content>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,6 @@ const Content = () => {
         <$DialogArea ref={dialogAreaRef}>
           <DialogManager />
         </$DialogArea>
-
       </$Content>
     </>
   );

--- a/src/constants/dialogs.ts
+++ b/src/constants/dialogs.ts
@@ -33,6 +33,7 @@ export type ExternalLinkDialogProps = {
 export type ExternalNavStrideDialogProps = {};
 export type FillDetailsDialogProps = { fillId: string };
 export type GeoComplianceDialogProps = {};
+export type GlobalCommandDialogProps = {};
 export type HelpDialogProps = {};
 export type ExternalNavKeplrDialogProps = {};
 export type ManageFundsDialogProps = { selectedTransferType?: string };
@@ -102,6 +103,7 @@ export const DialogTypes = unionize(
     ExternalNavStride: ofType<ExternalNavStrideDialogProps>(),
     FillDetails: ofType<FillDetailsDialogProps>(),
     GeoCompliance: ofType<GeoComplianceDialogProps>(),
+    GlobalCommand: ofType<GlobalCommandDialogProps>(),
     Help: ofType<HelpDialogProps>(),
     ManageFunds: ofType<ManageFundsDialogProps>(),
     MnemonicExport: ofType<MnemonicExportDialogProps>(),

--- a/src/hooks/useCommandMenu.ts
+++ b/src/hooks/useCommandMenu.ts
@@ -1,13 +1,30 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
+
+import { shallowEqual } from 'react-redux';
+
+import { DialogTypes } from '@/constants/dialogs';
+
+import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { closeDialog, openDialog } from '@/state/dialogs';
+import { getActiveDialog } from '@/state/dialogsSelectors';
 
 export const useCommandMenu = () => {
-  const [isCommandMenuOpen, setIsCommandMenuOpen] = useState(false);
+  const dispatch = useAppDispatch();
+  const activeDialog = useAppSelector(getActiveDialog, shallowEqual);
 
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    if (event.key === 'k' && (event.ctrlKey || event.metaKey)) {
-      setIsCommandMenuOpen((isOpen) => !isOpen);
-    }
-  }, []);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'k' && (event.ctrlKey || event.metaKey)) {
+        const isCommandDialogOpen = activeDialog && DialogTypes.is.GlobalCommand(activeDialog);
+        if (isCommandDialogOpen) {
+          dispatch(closeDialog());
+        } else {
+          dispatch(openDialog(DialogTypes.GlobalCommand()));
+        }
+      }
+    },
+    [activeDialog]
+  );
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
@@ -16,14 +33,4 @@ export const useCommandMenu = () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
-
-  const closeCommandMenu = useCallback(() => {
-    setIsCommandMenuOpen(false);
-  }, []);
-
-  return {
-    closeCommandMenu,
-    isCommandMenuOpen,
-    setIsCommandMenuOpen,
-  };
 };

--- a/src/layout/DialogManager.tsx
+++ b/src/layout/DialogManager.tsx
@@ -17,6 +17,7 @@ import { ExternalLinkDialog } from '@/views/dialogs/ExternalLinkDialog';
 import { ExternalNavKeplrDialog } from '@/views/dialogs/ExternalNavKeplrDialog';
 import { ExternalNavStrideDialog } from '@/views/dialogs/ExternalNavStrideDialog';
 import { GeoComplianceDialog } from '@/views/dialogs/GeoComplianceDialog';
+import { GlobalCommandDialog } from '@/views/dialogs/GlobalCommandDialog';
 import { HelpDialog } from '@/views/dialogs/HelpDialog';
 import { ManageFundsDialog } from '@/views/dialogs/ManageFundsDialog';
 import { MnemonicExportDialog } from '@/views/dialogs/MnemonicExportDialog';
@@ -72,6 +73,7 @@ export const DialogManager = () => {
     ExternalNavStride: (args) => <ExternalNavStrideDialog {...args} {...modalProps} />,
     FillDetails: (args) => <FillDetailsDialog {...args} {...modalProps} />,
     GeoCompliance: (args) => <GeoComplianceDialog {...args} {...modalProps} />,
+    GlobalCommand: (args) => <GlobalCommandDialog {...args} {...modalProps} />,
     Help: (args) => <HelpDialog {...args} {...modalProps} />,
     ExternalNavKeplr: (args) => <ExternalNavKeplrDialog {...args} {...modalProps} />,
     ManageFunds: (args) => <ManageFundsDialog {...args} {...modalProps} />,

--- a/src/views/dialogs/GlobalCommandDialog.tsx
+++ b/src/views/dialogs/GlobalCommandDialog.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
+import { DialogProps, GlobalCommandDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
-import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import breakpoints from '@/styles/breakpoints';
@@ -10,17 +10,16 @@ import breakpoints from '@/styles/breakpoints';
 import { ComboboxDialogMenu } from '@/components/ComboboxDialogMenu';
 import { useGlobalCommands } from '@/views/menus/useGlobalCommands';
 
-export const GlobalCommandDialog = () => {
-  const { isCommandMenuOpen, setIsCommandMenuOpen, closeCommandMenu } = useCommandMenu();
+export const GlobalCommandDialog = ({ setIsOpen }: DialogProps<GlobalCommandDialogProps>) => {
   const stringGetter = useStringGetter();
 
   return (
     <$ComboboxDialogMenu
-      isOpen={isCommandMenuOpen}
-      setIsOpen={setIsCommandMenuOpen}
+      isOpen
+      setIsOpen={setIsOpen}
       title={stringGetter({ key: STRING_KEYS.COMMANDS })}
       items={useGlobalCommands()}
-      onItemSelected={closeCommandMenu}
+      onItemSelected={() => setIsOpen(false)}
       inputPlaceholder={stringGetter({ key: STRING_KEYS.SEARCH })}
       slotEmpty={stringGetter({ key: STRING_KEYS.NO_RESULTS })}
     />


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
To add logging for our cmd k dialog, update `GlobalCommandDialog` to be opened in the same way as our other dialogs (with `dispatch(openDialog)`).

### Followups (separate PR):
- Would ideally like to be able to also record if help / display preferences / etc dialogs are being opened from cmd + k (instead of preferences), will follow up in separate PR for this

<!-- Overall purpose of the PR -->
<img width="465" alt="Screenshot 2024-08-07 at 11 16 09 AM" src="https://github.com/user-attachments/assets/aba88d86-e5aa-4ffb-b41f-dae002a970b7">



---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `GlobalCommandDialog`
  * Remove local state of being open/closed and use `setIsOpen` from `DialogManager`

* `DialogManager`
  * Add `GlobalCommand` dialog navigation

* `App`
  * Instead of always rendering `GlobalCommandDialog` component, simply call `useCommandMenu` hook which attaches event listener for cmd+k

## Constants/Types

* `constants/dialogs.ts`
  * Add `GlobalCommand` dialog type

## Hooks

* `hooks/useCommandMenu`
  * Update to determine if dialog is open by reading from `getActiveDialog` 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
