### PR TITLE
chore(analytics): add fromDialogType to NavigateDialog events

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -128,6 +128,7 @@ export const AnalyticsEvents = unionize(
     }>(),
     NavigateDialog: ofType<{
       type: DialogTypesTypes;
+      fromDialogType?: DialogTypesTypes;
     }>(),
     NavigateDialogClose: ofType<{
       type: DialogTypesTypes;

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -158,17 +158,27 @@ export const useAnalytics = () => {
     DialogTypesTypes | undefined
   >();
 
-  useEffect(() => {
-    if (activeDialog?.type) {
-      track(AnalyticsEvents.NavigateDialog({ type: activeDialog.type }));
-    }
+  useEffect(
+    () => {
+      if (activeDialog?.type) {
+        track(
+          AnalyticsEvents.NavigateDialog({
+            type: activeDialog.type,
+            fromDialogType: previousActiveDialogType,
+          })
+        );
+      }
 
-    if (previousActiveDialogType) {
-      track(AnalyticsEvents.NavigateDialogClose({ type: previousActiveDialogType }));
-    }
+      if (previousActiveDialogType) {
+        track(AnalyticsEvents.NavigateDialogClose({ type: previousActiveDialogType }));
+      }
 
-    setPreviousActiveDialogType(activeDialog?.type);
-  }, [activeDialog]);
+      setPreviousActiveDialogType(activeDialog?.type);
+    },
+    // This effect should only trigger on updates to the current active dialog, not previousActiveDialogType
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeDialog]
+  );
 
   // AnalyticsEvent.NavigateExternal
   useEffect(() => {


### PR DESCRIPTION
`fromDialogType` is undefined when the dialog is not opened from an existing open dialog

https://github.com/user-attachments/assets/8a3741f4-a07c-4ab0-94da-5c34780b94c5


