### PR TITLE
chore: add support for missing dydx onboarding analytics [OTE-645]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -150,18 +150,6 @@ export const AnalyticsEvents = unionize(
     OnboardingAcknowledgeTermsButtonClick: ofType<{
       agreed: boolean;
     }>(),
-    OnboardingDepositFundsClick: ofType<{
-      chainId: string | undefined;
-      tokenAddress: string | undefined;
-      tokenSymbol: string | undefined;
-      slippage: number | undefined;
-      gasFee: number | undefined;
-      bridgeFee: number | undefined;
-      exchangeRate: number | undefined;
-      estimatedRouteDuration: number | undefined;
-      toAmount: number | undefined;
-      toAmountMin: number | undefined;
-    }>(),
     OnboardingSwitchNetworkClick: ofType<{}>(),
     OnboardingSendRequestClick: ofType<{
       firstAttempt: boolean;
@@ -187,6 +175,18 @@ export const AnalyticsEvents = unionize(
       roundtripMs: number;
       /** URL/IP of node the order was sent to */
       validatorUrl: string;
+    }>(),
+    TransferDepositFundsClick: ofType<{
+      chainId: string | undefined;
+      tokenAddress: string | undefined;
+      tokenSymbol: string | undefined;
+      slippage: number | undefined;
+      gasFee: number | undefined;
+      bridgeFee: number | undefined;
+      exchangeRate: number | undefined;
+      estimatedRouteDuration: number | undefined;
+      toAmount: number | undefined;
+      toAmountMin: number | undefined;
     }>(),
     TransferDeposit: ofType<{
       chainId?: string;

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -144,6 +144,33 @@ export const AnalyticsEvents = unionize(
     DisconnectWallet: ofType<{}>(),
 
     // Onboarding
+    OnboardingDeriveKeysSignatureReceived: ofType<{
+      signatureNumber: number;
+    }>(),
+    OnboardingAcknowledgeTermsButtonClick: ofType<{
+      agreed: boolean;
+    }>(),
+    OnboardingDepositFundsClick: ofType<{
+      chainId: string | undefined;
+      tokenAddress: string | undefined;
+      tokenSymbol: string | undefined;
+      slippage: number | undefined;
+      gasFee: number | undefined;
+      bridgeFee: number | undefined;
+      exchangeRate: number | undefined;
+      estimatedRouteDuration: number | undefined;
+      toAmount: number | undefined;
+      toAmountMin: number | undefined;
+    }>(),
+    OnboardingSwitchNetworkClick: ofType<{}>(),
+    OnboardingSendRequestClick: ofType<{
+      firstAttempt: boolean;
+    }>(),
+    OnboardingTriggerClick: ofType<{
+      // if onboarding state is Disconnected, then user clicked "Connect Wallet"
+      // if onboarding state is WalletConnected, then user clicked "Recover Keys"
+      state: OnboardingState;
+    }>(),
     OnboardingStepChanged: ofType<{
       state: OnboardingState;
       step?: OnboardingSteps;

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -187,6 +187,7 @@ export const AnalyticsEvents = unionize(
       estimatedRouteDuration: number | undefined;
       toAmount: number | undefined;
       toAmountMin: number | undefined;
+      depositCTAString: string;
     }>(),
     TransferDeposit: ofType<{
       chainId?: string;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -24,7 +24,7 @@ export const identify = (property: AnalyticsUserProperty) => {
 };
 
 export const track = (event: AnalyticsEvent) => {
-  if (DEBUG_ANALYTICS) {
+  if (DEBUG_ANALYTICS || import.meta.env.VITE_LOG_TRACK_EVENTS === 'true') {
     // eslint-disable-next-line no-console
     console.log(`[Analytics] ${event.type}`, event.payload);
   }

--- a/src/views/dialogs/AcknowledgeTermsDialog.tsx
+++ b/src/views/dialogs/AcknowledgeTermsDialog.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import tw from 'twin.macro';
 
+import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction } from '@/constants/buttons';
 import { AcknowledgeTermsDialogProps, DialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -17,6 +18,8 @@ import { Dialog } from '@/components/Dialog';
 import { Link } from '@/components/Link';
 import { TermsOfUseLink } from '@/components/TermsOfUseLink';
 
+import { track } from '@/lib/analytics';
+
 export const AcknowledgeTermsDialog = ({ setIsOpen }: DialogProps<AcknowledgeTermsDialogProps>) => {
   const stringGetter = useStringGetter();
   const { saveHasAcknowledgedTerms } = useAccounts();
@@ -24,10 +27,20 @@ export const AcknowledgeTermsDialog = ({ setIsOpen }: DialogProps<AcknowledgeTer
   const onAcknowledgement = () => {
     saveHasAcknowledgedTerms(true);
     setIsOpen(false);
+    track(
+      AnalyticsEvents.OnboardingAcknowledgeTermsButtonClick({
+        agreed: true,
+      })
+    );
   };
 
   const onClose = () => {
     setIsOpen(false);
+    track(
+      AnalyticsEvents.OnboardingAcknowledgeTermsButtonClick({
+        agreed: false,
+      })
+    );
   };
 
   return (

--- a/src/views/dialogs/OnboardingTriggerButton.tsx
+++ b/src/views/dialogs/OnboardingTriggerButton.tsx
@@ -1,4 +1,5 @@
 import { OnboardingState } from '@/constants/account';
+import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction, ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -12,6 +13,8 @@ import { getOnboardingState } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { forceOpenDialog } from '@/state/dialogs';
 
+import { track } from '@/lib/analytics';
+
 type StyleProps = {
   className?: string;
   size?: ButtonSize;
@@ -20,6 +23,14 @@ type StyleProps = {
 export const OnboardingTriggerButton = ({ className, size = ButtonSize.Small }: StyleProps) => {
   const stringGetter = useStringGetter();
   const dispatch = useAppDispatch();
+  const openOnboardingDialog = () => {
+    track(
+      AnalyticsEvents.OnboardingTriggerClick({
+        state: onboardingState,
+      })
+    );
+    dispatch(forceOpenDialog(DialogTypes.Onboarding()));
+  };
   const { disableConnectButton } = useComplianceState();
 
   const onboardingState = useAppSelector(getOnboardingState);
@@ -32,7 +43,7 @@ export const OnboardingTriggerButton = ({ className, size = ButtonSize.Small }: 
       state={{
         isDisabled: disableConnectButton,
       }}
-      onClick={() => dispatch(forceOpenDialog(DialogTypes.Onboarding()))}
+      onClick={openOnboardingDialog}
     >
       {
         {

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -291,6 +291,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
           estimatedRouteDuration: summary?.estimatedRouteDuration || undefined,
           toAmount: summary?.toAmount || undefined,
           toAmountMin: summary?.toAmountMin || undefined,
+          depositCTAString,
         })
       );
       try {

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -280,7 +280,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
   const onSubmit = useCallback(
     async (e: FormEvent) => {
       track(
-        AnalyticsEvents.OnboardingDepositFundsClick({
+        AnalyticsEvents.TransferDepositFundsClick({
           chainId: chainIdStr || undefined,
           tokenAddress: sourceToken?.address || undefined,
           tokenSymbol: sourceToken?.symbol || undefined,

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -281,16 +281,16 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
     async (e: FormEvent) => {
       track(
         AnalyticsEvents.TransferDepositFundsClick({
-          chainId: chainIdStr || undefined,
-          tokenAddress: sourceToken?.address || undefined,
-          tokenSymbol: sourceToken?.symbol || undefined,
-          slippage: slippage || undefined,
-          gasFee: summary?.gasFee || undefined,
-          bridgeFee: summary?.bridgeFee || undefined,
-          exchangeRate: summary?.exchangeRate || undefined,
-          estimatedRouteDuration: summary?.estimatedRouteDuration || undefined,
-          toAmount: summary?.toAmount || undefined,
-          toAmountMin: summary?.toAmountMin || undefined,
+          chainId: chainIdStr ?? undefined,
+          tokenAddress: sourceToken?.address ?? undefined,
+          tokenSymbol: sourceToken?.symbol ?? undefined,
+          slippage: slippage ?? undefined,
+          gasFee: summary?.gasFee ?? undefined,
+          bridgeFee: summary?.bridgeFee ?? undefined,
+          exchangeRate: summary?.exchangeRate ?? undefined,
+          estimatedRouteDuration: summary?.estimatedRouteDuration ?? undefined,
+          toAmount: summary?.toAmount ?? undefined,
+          toAmountMin: summary?.toAmountMin ?? undefined,
           depositCTAString,
         })
       );

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -279,6 +279,20 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
 
   const onSubmit = useCallback(
     async (e: FormEvent) => {
+      track(
+        AnalyticsEvents.OnboardingDepositFundsClick({
+          chainId: chainIdStr || undefined,
+          tokenAddress: sourceToken?.address || undefined,
+          tokenSymbol: sourceToken?.symbol || undefined,
+          slippage: slippage || undefined,
+          gasFee: summary?.gasFee || undefined,
+          bridgeFee: summary?.bridgeFee || undefined,
+          exchangeRate: summary?.exchangeRate || undefined,
+          estimatedRouteDuration: summary?.estimatedRouteDuration || undefined,
+          toAmount: summary?.toAmount || undefined,
+          toAmountMin: summary?.toAmountMin || undefined,
+        })
+      );
       try {
         e.preventDefault();
 


### PR DESCRIPTION
According to the doc: https://www.notion.so/dydx/v4-conversion-funnel-events-32465e38f3704b4f973d586f3da7c2da#b3f64fb5942f41a8b9a73e0958a2e5ff

Clicked "Connect Wallet": `OnboardingTriggerClick`
Clicked "Send Request": `OnboardingSendRequestClick`
  - also flags first attempt, because failures will result in the `Try Again` button instead. We can track if users are getting there
  
Clicked “Sign” (first time): `OnboardingDeriveKeysSignatureReceived`
  - has a `signatureNumber` property to track whether it's the first or second signature. Opted to not use a `firstAttempt` flag since users are not attempting but may potentially (in the future) have N number of signatures they need to sign

Clicked “Sign” (second time): Same as above
Clicked “I agree”: `OnboardingAcknowledgeTermsButtonClick`
  - has `agreed` property to track whether or not they agreed or canceled to leave the modal
  - not sure if we're going to use this since it doesn't seem like we use this dialog anymore?

Clicked “Deposit funds”: `TransferDepositFundsClick`
  - behaves similarly to `TransferDeposit` except it tracks upon click instead of upon success
  - also added depositCTAString property so we know if the transfer deposit was due to an `acknowledge and deposit` submit or a regular deposit