### PR TITLE
chore: always set selectedLocale and match amplitude language detection

### DIFF
--- a/src/lib/language.ts
+++ b/src/lib/language.ts
@@ -1,0 +1,11 @@
+// matches Amplitude's language detection logic in https://github.com/amplitude/Amplitude-JavaScript/blob/master/src/language.js
+export const getBrowserLanguage = (): string => {
+  const navigator = globalThis.navigator;
+  return (
+    (navigator &&
+      ((navigator.languages && navigator.languages[0]) ||
+        navigator.language ||
+        (navigator as any).userLanguage)) ||
+    ''
+  );
+};

--- a/src/state/localizationMiddleware.ts
+++ b/src/state/localizationMiddleware.ts
@@ -17,6 +17,7 @@ import {
 import { initializeLocalization } from '@/state/app';
 import { setLocaleData, setLocaleLoaded, setSelectedLocale } from '@/state/localization';
 
+import { getBrowserLanguage } from '@/lib/language';
 import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
 
 const getNewLocaleData = ({
@@ -55,8 +56,9 @@ export default (store: any) => (next: any) => async (action: PayloadAction<any>)
 
       if (localStorageLocale) {
         store.dispatch(setSelectedLocale({ locale: localStorageLocale }));
-      } else if (globalThis.navigator?.language) {
-        const browserLanguageBaseTag = globalThis.navigator.language.split('-')[0].toLowerCase();
+      } else {
+        const browserLanguage = getBrowserLanguage();
+        const browserLanguageBaseTag = browserLanguage.split('-')[0].toLowerCase();
 
         let locale = (SUPPORTED_BASE_TAGS_LOCALE_MAPPING[browserLanguageBaseTag] ??
           SupportedLocales.EN) as SupportedLocales;
@@ -68,6 +70,7 @@ export default (store: any) => (next: any) => async (action: PayloadAction<any>)
 
         store.dispatch(setSelectedLocale({ locale, isAutoDetect: true }));
       }
+
       break;
     }
     // @ts-ignore


### PR DESCRIPTION
during locale initialization, we should just always set locale regardless of whether `globalThis.navigator?.language` exists. this will just default to English and won't affect existing behaior.

also update browser language detection logic to match amplitude (since somehow they always have a language property while we seem to miss since `selectedLocale` was empty for many users)