### PR TITLE
fix: recheck statsig config after wallet connection changes

### DIFF
--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -3,7 +3,6 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { OfflineSigner } from '@cosmjs/proto-signing';
 import { LocalWallet, NOBLE_BECH32_PREFIX, type Subaccount } from '@dydxprotocol/v4-client-js';
 import { usePrivy } from '@privy-io/react-auth';
-import { useStatsigUser } from '@statsig/react-bindings';
 import { AES, enc } from 'crypto-js';
 
 import {
@@ -50,7 +49,6 @@ export const AccountsProvider = ({ ...props }) => (
 export const useAccounts = () => useContext(AccountsContext)!;
 
 const useAccountsContext = () => {
-  const { updateUserSync } = useStatsigUser();
   const dispatch = useAppDispatch();
   const geo = useAppSelector(getGeo);
   const { checkForGeo } = useEnvFeatures();
@@ -248,7 +246,6 @@ const useAccountsContext = () => {
 
   const dydxAddress = useMemo(() => {
     const address = localDydxWallet?.address as DydxAddress | undefined;
-    updateUserSync({ userID: address });
     return address;
   }, [localDydxWallet]);
 

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -3,6 +3,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { OfflineSigner } from '@cosmjs/proto-signing';
 import { LocalWallet, NOBLE_BECH32_PREFIX, type Subaccount } from '@dydxprotocol/v4-client-js';
 import { usePrivy } from '@privy-io/react-auth';
+import { useStatsigUser } from '@statsig/react-bindings';
 import { AES, enc } from 'crypto-js';
 
 import {
@@ -49,6 +50,7 @@ export const AccountsProvider = ({ ...props }) => (
 export const useAccounts = () => useContext(AccountsContext)!;
 
 const useAccountsContext = () => {
+  const { updateUserSync } = useStatsigUser();
   const dispatch = useAppDispatch();
   const geo = useAppSelector(getGeo);
   const { checkForGeo } = useEnvFeatures();
@@ -244,10 +246,11 @@ const useAccountsContext = () => {
 
   const dydxAccounts = useMemo(() => localDydxWallet?.accounts, [localDydxWallet]);
 
-  const dydxAddress = useMemo(
-    () => localDydxWallet?.address as DydxAddress | undefined,
-    [localDydxWallet]
-  );
+  const dydxAddress = useMemo(() => {
+    const address = localDydxWallet?.address as DydxAddress | undefined;
+    updateUserSync({ userID: address });
+    return address;
+  }, [localDydxWallet]);
 
   const nobleAddress = useMemo(() => localNobleWallet?.address, [localNobleWallet]);
 

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -72,7 +72,7 @@ export const useAnalytics = () => {
     }
   }, [latestTag]);
 
-  // AnalyticsUserProperty.StatsigConfigs
+  // AnalyticsUserProperty.StatsigFlags
   useEffect(() => {
     identify(AnalyticsUserProperties.StatsigFlags(statsigConfig));
   }, [statsigConfig]);

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -10,8 +10,12 @@ import {
 
 import { initStatsigAsync } from '@/lib/statsig';
 
+import { useAccounts } from './useAccounts';
+
 export const StatsigProvider = ({ children }: { children: React.ReactNode }) => {
   const [statsigClient, setStatsigClient] = useState<StatsigClient | null>(null);
+  const { updateUserSync } = useStatsigUser();
+  const { dydxAddress } = useAccounts();
   useEffect(() => {
     const init = async () => {
       const client = await initStatsigAsync();
@@ -19,6 +23,13 @@ export const StatsigProvider = ({ children }: { children: React.ReactNode }) => 
     };
     init();
   }, []);
+
+  // TODO: consider moving either updateUser to its own hook, or the react bindings to a separate hook.
+  // we don't want to have the statsigGateValue methods module import from other hooks
+  // because then those hooks will have a circular dependency if they want to use statsig
+  useEffect(() => {
+    updateUserSync({ userID: dydxAddress });
+  });
   if (!statsigClient) return <div>{children}</div>;
   return <StatsigProviderInternal client={statsigClient}> {children} </StatsigProviderInternal>;
 };

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -5,6 +5,7 @@ import { StatsigClient } from '@statsig/js-client';
 import {
   StatsigProvider as StatsigProviderInternal,
   useStatsigClient,
+  useStatsigUser,
 } from '@statsig/react-bindings';
 
 import { initStatsigAsync } from '@/lib/statsig';
@@ -29,10 +30,15 @@ export const useStatsigGateValue = (gate: StatSigFlags) => {
 
 export const useAllStatsigGateValues = () => {
   const { checkGate } = useStatsigClient();
-  const allGateValues = useMemo(() => {
-    return Object.values(StatSigFlags).reduce((acc, gate) => {
-      return { ...acc, [gate]: checkGate(gate) };
-    }, {} as StatsigConfigType);
-  }, []);
+  const { user } = useStatsigUser();
+  const allGateValues = useMemo(
+    () =>
+      Object.values(StatSigFlags).reduce((acc, gate) => {
+        return { ...acc, [gate]: checkGate(gate) };
+      }, {} as StatsigConfigType),
+    // Certain flag values may change once a user connects their wallet.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [user]
+  );
   return allGateValues;
 };


### PR DESCRIPTION
although it doesn't happen yet, we will eventually have feature flags that only affect logged in users.

this means that the statsig config fetch function needs to be reactive to address connection updates.
as we start to index statsig configs off of more user properties, we'll want to continue adding to this logic

right now it's done in a less 'clean' way of importing the `useAccounts` hook into the statsig hook mainly because i want to keep the statsig hooks clean of any dependencies, so any hooks can use them for feature gating. this can be easily refactored if it becomes difficult to understand