### PR TITLE
chore: add user geo as user property [OTE-667]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -46,12 +46,16 @@ export const AnalyticsUserProperties = unionize(
   {
     // Referrer
     CustomDomainReferrer: ofType<string | null>(),
+
     // Environment
     Locale: ofType<SupportedLocales>(),
     Breakpoint: ofType<
       'MOBILE' | 'TABLET' | 'DESKTOP_SMALL' | 'DESKTOP_MEDIUM' | 'DESKTOP_LARGE' | 'UNSUPPORTED'
     >(),
     Version: ofType<string | null>(),
+
+    // Location
+    Geo: ofType<string | null>(),
 
     // StatSigFlags
     StatsigFlags: ofType<{ [key in StatSigFlags]?: boolean }>(),
@@ -73,6 +77,7 @@ export const AnalyticsUserProperties = unionize(
 
 export const AnalyticsUserPropertyLoggableTypes = {
   Locale: 'selectedLocale',
+  Geo: 'geo',
   Breakpoint: 'breakpoint',
   Version: 'version',
   StatsigFlags: 'statsigFlags',

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -11,7 +11,7 @@ import {
 import { DialogTypesTypes } from '@/constants/dialogs';
 
 import { calculateOnboardingStep } from '@/state/accountCalculators';
-import { getOnboardingState, getSubaccountId } from '@/state/accountSelectors';
+import { getGeo, getOnboardingState, getSubaccountId } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getActiveDialog } from '@/state/dialogsSelectors';
 import { getInputTradeData } from '@/state/inputsSelectors';
@@ -49,6 +49,12 @@ export const useAnalytics = () => {
           : breakpointMatches.isDesktopLarge
             ? 'DESKTOP_LARGE'
             : 'UNSUPPORTED';
+
+  // AnalyticsUserProperty.Geo
+  const geo = useAppSelector(getGeo) ?? undefined;
+  useEffect(() => {
+    identify(AnalyticsUserProperties.Geo(geo ?? null));
+  }, [geo]);
 
   useEffect(() => {
     identify(AnalyticsUserProperties.CustomDomainReferrer(document.referrer));


### PR DESCRIPTION
adds geo as a user property. enables analytics to track various things such as whether or not users are part of restricted geos

https://dydx-team.slack.com/archives/C06ETDBE370/p1722353625082109