### PR TITLE
chore(tradingview): update tradingview chart font to satoshi

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@dydxprotocol/v4-abacus": "1.8.80",
     "@dydxprotocol/v4-client-js": "^1.1.27",
-    "@dydxprotocol/v4-localization": "^1.1.170",
+    "@dydxprotocol/v4-localization": "^1.1.171",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",
     "@hugocxl/react-to-image": "^0.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^1.1.27
     version: 1.1.27
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.170
-    version: 1.1.170
+    specifier: ^1.1.171
+    version: 1.1.171
   '@emotion/is-prop-valid':
     specifier: ^1.3.0
     version: 1.3.0
@@ -3252,8 +3252,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.170:
-    resolution: {integrity: sha512-PNHr59u3X32/cJ/OwacQjGrET/zn8uDPxugm42m60kuEasFOOKPwPKa2D+hVhQWZ7bXycLjF+8l/ToWMrAoRzw==}
+  /@dydxprotocol/v4-localization@1.1.171:
+    resolution: {integrity: sha512-HXx2PNR4NZ1slGuPY3fLZMSHIjfBTX4H3VFcoJ+CZjYt4uB2HJbXzP4IFlYh8DZOYZJKmbsXwEZj0hjC+1Bspw==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -22,6 +22,8 @@ import { getChartLineColors } from '@/lib/tradingView/utils';
 
 import { useStringGetter } from '../useStringGetter';
 
+const CHART_LINE_FONT = 'bold 10px Satoshi';
+
 /**
  * @description Hook to handle drawing chart lines
  */
@@ -71,7 +73,7 @@ export const useChartLines = ({
     [tvWidget]
   );
 
-  const setLineColors = useCallback(
+  const setLineColorsAndFont = useCallback(
     ({ chartLine }: { chartLine: ChartLine }) => {
       const { line, chartLineType } = chartLine;
       const { maybeQuantityColor, borderColor, backgroundColor, textColor, textButtonColor } =
@@ -86,7 +88,9 @@ export const useChartLines = ({
         .setBodyBackgroundColor(backgroundColor)
         .setBodyBorderColor(borderColor)
         .setBodyTextColor(textColor)
-        .setQuantityTextColor(textButtonColor);
+        .setQuantityTextColor(textButtonColor)
+        .setBodyFont(CHART_LINE_FONT)
+        .setQuantityFont(CHART_LINE_FONT);
 
       if (maybeQuantityColor != null) {
         line.setLineColor(maybeQuantityColor).setQuantityBackgroundColor(maybeQuantityColor);
@@ -139,12 +143,12 @@ export const useChartLines = ({
 
         if (positionLine) {
           const chartLine: ChartLine = { line: positionLine, chartLineType };
-          setLineColors({ chartLine });
+          setLineColorsAndFont({ chartLine });
           chartLinesRef.current[key] = chartLine;
         }
       }
     },
-    [setLineColors, tvWidget]
+    [setLineColorsAndFont, tvWidget]
   );
 
   const updatePositionLines = useCallback(() => {
@@ -229,14 +233,14 @@ export const useChartLines = ({
                 line: orderLine,
                 chartLineType: ORDER_SIDES[side.name],
               };
-              setLineColors({ chartLine });
+              setLineColorsAndFont({ chartLine });
               chartLinesRef.current[key] = chartLine;
             }
           }
         }
       }
     );
-  }, [setLineColors, stringGetter, currentMarketOrders, tvWidget]);
+  }, [setLineColorsAndFont, stringGetter, currentMarketOrders, tvWidget]);
 
   const clearChartLines = useCallback(() => {
     Object.values(chartLinesRef.current).forEach(({ line }) => {

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -121,6 +121,7 @@ export const getWidgetOverrides = ({
       'scalesProperties.textColor': theme.textPrimary,
       'scalesProperties.backgroundColor': theme.layer2,
       'scalesProperties.lineColor': theme.layer3,
+      'scalesProperties.fontSize': 12,
     },
     studies_overrides: {
       'volume.volume.color.0': theme.negative,
@@ -143,6 +144,7 @@ export const getWidgetOptions = () => {
     container: 'tv-price-chart',
     library_path: '/tradingview/', // relative to public folder
     custom_css_url: '/tradingview/custom-styles.css',
+    custom_font_family: "'Satoshi', system-ui, -apple-system, Helvetica, Arial, sans-serif",
     autosize: true,
     disabled_features: [
       'header_symbol_search',


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
and pull in localization changes (unrelated).

<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

| Before | After | 
| ---- | ---- |
| <img width="898" alt="Screenshot 2024-08-09 at 1 33 25 PM" src="https://github.com/user-attachments/assets/c683470e-2787-4633-b105-9f5091f779a9"> | <img width="897" alt="Screenshot 2024-08-09 at 1 34 08 PM" src="https://github.com/user-attachments/assets/3bc4db55-db6f-4f8d-9756-f3d1aec05f83"> |


## Functions

* `lib/tradingView/utils.ts`
  * added `custom_font_family`, copied from `--fontFamily-base` in `text.css`
  * add `scalesProperties.fontSize`

## Hooks

* `hooks/useChartLines`
  * set font to Satoshi for lines drawn

## Packages

* `v4-localization`
  * updated: v1.1.170 -> v1.1.171

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
