### PR TITLE
fix: missing hotjar text [OTE-675]

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -184,6 +184,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             autoComplete="off"
             autoCorrect="off"
             data-1p-ignore // prevent 1Password fill
+            data-hj-allow
             {...otherProps}
           />
         )}


### PR DESCRIPTION
adds hotjar text to the NumericFormat input option for the `Input` component.