### PR TITLE
chore: hide diff state for account available balance when its negative

### DIFF
--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 
@@ -63,19 +61,16 @@ export const AccountInfoConnectedState = () => {
   const { freeCollateral: availableBalance, marginUsage } = subAccount ?? {};
   const portfolioValue = subAccount?.equity;
 
-  const hasDiff =
-    !!availableBalance?.postOrder && getTradeStateWithDoubleValuesHasDiff(availableBalance);
+  const isPostOrderBalanceNegative =
+    isNumber(availableBalance?.postOrder) && MustBigNumber(availableBalance?.postOrder).lt(0);
 
-  const showHeader = !hasDiff && !isTablet;
+  // Do not show diff state if there is no postOrder balance or if it is negative
+  const showDiff =
+    !!availableBalance?.postOrder &&
+    getTradeStateWithDoubleValuesHasDiff(availableBalance) &&
+    !isPostOrderBalanceNegative;
 
-  const isPostOrderTradeStateNegative = useCallback(
-    (tradeStateValue: Nullable<TradeState<number>>) => {
-      return (
-        isNumber(tradeStateValue?.postOrder) && MustBigNumber(tradeStateValue?.postOrder).lt(0)
-      );
-    },
-    []
-  );
+  const showHeader = !showDiff && !isTablet;
 
   return (
     <$ConnectedAccountInfoContainer $showHeader={showHeader}>
@@ -143,7 +138,8 @@ export const AccountInfoConnectedState = () => {
             },
             {
               key: AccountInfoItem.AvailableBalance,
-              hasError: isPostOrderTradeStateNegative(availableBalance),
+              hasError: isPostOrderBalanceNegative,
+              hideDiff: isPostOrderBalanceNegative,
               isPositive: MustBigNumber(availableBalance?.postOrder).gt(
                 MustBigNumber(availableBalance?.current)
               ),


### PR DESCRIPTION
hide diff state when available balance is going to be negative
before:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/fc9fcd72-acf7-4d52-8248-584239ecee12">
after:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/fe2e0dfd-92b0-4390-a2ba-a8bd7fd431ce">
