### PR TITLE
chore: hide warning icon in place order CTA when missing fields

### DIFF
--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -101,7 +101,7 @@ export const PlaceOrderButtonAndReceipt = ({
 
   const { fee, price: expectedPrice, reward } = summary ?? {};
 
-  // check if required fields are filled and summary has been calculated
+  // approximation for whether inputs are filled by whether summary has been calculated
   const areInputsFilled = fee != null || reward != null;
 
   const renderMarginValue = () => {
@@ -289,7 +289,7 @@ export const PlaceOrderButtonAndReceipt = ({
       type={ButtonType.Submit}
       action={buttonAction}
       slotLeft={
-        showValidatorErrors ? (
+        showValidatorErrors && areInputsFilled ? (
           <Icon iconName={IconName.Warning} tw="text-color-warning" />
         ) : undefined
       }


### PR DESCRIPTION
when fields are filled (e.g. missing amount), don't show warning icon since they are not important error validations

alternative is to introduce another warning level or check error code (starts with REQUIRED) -- but using existing best guess with `areInputsFilled` also work

<img width="375" alt="image" src="https://github.com/user-attachments/assets/29128f35-a76b-4169-ab5d-c3692a60db4b">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/2717cdf8-2c90-4193-a8f6-534a3a26e047">
<img width="409" alt="image" src="https://github.com/user-attachments/assets/adf62332-9376-45e9-a663-a62cdf8fc515">
