### PR TITLE
fix: store abacus fill notifs so they are properly stored and not retriggered

### DIFF
--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -41,6 +41,8 @@ export const SingleSessionNotificationTypes = [
   NotificationType.OrderStatus,
 ];
 
+export const SingleSessionAbacusNotificationTypes = ['order', 'blockReward'];
+
 export type NotificationId = string | number;
 
 export type NotificationParams = {

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/constants/notifications';
 
 import { track } from '@/lib/analytics';
+import { isAbacusNotificationSingleSession } from '@/lib/notifications';
 import { renderSvgToDataUrl } from '@/lib/renderSvgToDataUrl';
 
 import { useLocalStorage } from './useLocalStorage';
@@ -77,7 +78,10 @@ const useNotificationsContext = () => {
     // save notifications to localstorage, but filter out single session notifications
     const originalEntries = Object.entries(notifications);
     const filteredEntries = originalEntries.filter(
-      ([, value]) => !SingleSessionNotificationTypes.includes(value.type)
+      ([, value]) =>
+        !SingleSessionNotificationTypes.includes(value.type) ||
+        (value.type === NotificationType.AbacusGenerated &&
+          !isAbacusNotificationSingleSession(value))
     );
 
     const newNotifications = Object.fromEntries(filteredEntries);

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -81,7 +81,7 @@ const useNotificationsContext = () => {
       ([, value]) =>
         !SingleSessionNotificationTypes.includes(value.type) ||
         (value.type === NotificationType.AbacusGenerated &&
-          !isAbacusNotificationSingleSession(value))
+          !isAbacusNotificationSingleSession(value.id))
     );
 
     const newNotifications = Object.fromEntries(filteredEntries);

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,7 @@
+import { AbacusNotification } from '@/constants/abacus';
+import { SingleSessionAbacusNotificationTypes } from '@/constants/notifications';
+
+export const isAbacusNotificationSingleSession = (notification: AbacusNotification) => {
+  const notificationType = notification.id.split(':')[0];
+  return SingleSessionAbacusNotificationTypes.includes(notificationType);
+};

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,7 +1,6 @@
-import { AbacusNotification } from '@/constants/abacus';
 import { SingleSessionAbacusNotificationTypes } from '@/constants/notifications';
 
-export const isAbacusNotificationSingleSession = (notification: AbacusNotification) => {
-  const notificationType = notification.id.split(':')[0];
+export const isAbacusNotificationSingleSession = (notificationId: string) => {
+  const notificationType = notificationId.split(':')[0];
   return SingleSessionAbacusNotificationTypes.includes(notificationType);
 };


### PR DESCRIPTION
issue:
- abacus fill notifications (when a fill is deleveraged/ final settlement, liquidated, offsetting) are being triggered every time user lands on web app
- store them like a non single session notif type so they can be properly seen/hidden/cleared
- not doing this for orders since we don't really fetch order history and they happen much more often (i.e. every fill)

repro'd with https://v4.stage.dydx.exchange/trade/ETH-USD?address=dydx1lagu6a2lkpwqe3ekv0078h5zvxulhsj6rfas42
dydx1lagu6a2lkpwqe3ekv0078h5zvxulhsj6rfas42 has tho notifs