### PR TITLE
chore: update order status notif to show average fill price when filled

### DIFF
--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -466,6 +466,25 @@ export const getCurrentMarketFills = createAppSelector(
     !currentMarketId ? [] : marketFills[currentMarketId]
 );
 
+const getFillsForOrderId = createAppSelector(
+  [(s, orderId) => orderId, getSubaccountFills],
+  (orderId, fills) => (orderId ? groupBy(fills, 'orderId')[orderId] ?? [] : [])
+);
+
+/**
+ * @returns the average price the order is filled at
+ */
+export const getAverageFillPriceForOrder = () =>
+  createAppSelector([(s, orderId) => getFillsForOrderId(s, orderId)], (fillsForOrderId) => {
+    let total = 0;
+    let totalSize = 0;
+    fillsForOrderId.forEach((fill) => {
+      total += fill.price * fill.size;
+      totalSize += fill.size;
+    });
+    return totalSize > 0 ? total / totalSize : null;
+  });
+
 /**
  * @param state
  * @returns list of transfers for the currently connected subaccount

--- a/src/views/notifications/OrderStatusNotification.tsx
+++ b/src/views/notifications/OrderStatusNotification.tsx
@@ -25,7 +25,11 @@ import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
 // eslint-disable-next-line import/no-cycle
 import { Notification, NotificationProps } from '@/components/Notification';
 
-import { getFillByClientId, getOrderByClientId } from '@/state/accountSelectors';
+import {
+  getAverageFillPriceForOrder,
+  getFillByClientId,
+  getOrderByClientId,
+} from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getMarketData } from '@/state/perpetualsSelectors';
 
@@ -48,6 +52,10 @@ export const OrderStatusNotification = ({
   const order = useParameterizedSelector(getOrderByClientId, localOrder.clientId);
   const fill = useParameterizedSelector(getFillByClientId, localOrder.clientId);
   const marketData = useAppSelector((s) => getMarketData(s, localOrder.marketId), shallowEqual);
+  const averageFillPrice = useParameterizedSelector(
+    getAverageFillPriceForOrder,
+    localOrder.orderId
+  );
 
   const { assetId } = marketData ?? {};
   const { equityTiersLearnMore } = useURLConfigs();
@@ -81,7 +89,7 @@ export const OrderStatusNotification = ({
               tradeType={getTradeType(order.type.rawValue) ?? undefined}
               filledAmount={order.totalFilled}
               assetId={assetId}
-              averagePrice={order.price}
+              averagePrice={averageFillPrice ?? order.price}
               tickSizeDecimals={marketData?.configs?.displayTickSizeDecimals ?? USD_DECIMALS}
             />
           );


### PR DESCRIPTION
order updates don't have fill price info, so we need to calculate it ourselves
abacus fill notif does the same calculation, so we're bringing it the order status notif
- repro steps: place a limit order that cross an orderbook e.g. buy ETH at $5000, observe that the order should be filled at market price e.g. $2600 instead of $5000
- followup: might want to add a field / replace existing price field on orders table, if so will do in a followup

![image](https://github.com/user-attachments/assets/ccc542d2-c9b4-4469-a389-7a288280867f)
