### PR TITLE
feat: evm swap deposits [OTE-700]

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.8.85",
+    "@dydxprotocol/v4-abacus": "1.8.89",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.174",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.8.85
-    version: 1.8.85
+    specifier: 1.8.89
+    version: 1.8.89
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
@@ -3216,8 +3216,8 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  /@dydxprotocol/v4-abacus@1.8.85:
-    resolution: {integrity: sha512-AuV1q2vIzEE/SWTw4L3/B9lncFrolngfQdT0vLEL5je70QJtNQr+Joei61kKarsTPWkc0FlfV4MeORWtF2bOBQ==}
+  /@dydxprotocol/v4-abacus@1.8.89:
+    resolution: {integrity: sha512-2M6iE1oDzzbccP3/Zi53eQhyj3wOLddg9zzYqss7Of9JuKp4ajoRpeNJEFqSziHiOdrW0vWhD3BOw+yEOmQ/Jg==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -34,6 +34,5 @@ export const useAllStatsigGateValues = () => {
       return { ...acc, [gate]: checkGate(gate) };
     }, {} as StatsigConfigType);
   }, []);
-
   return allGateValues;
 };

--- a/src/lib/__test__/index.spec.ts
+++ b/src/lib/__test__/index.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { StatsigConfig } from '../../constants/abacus'
+import { StatSigFlags } from "../../types/statsig"
+import abacusStateManager from "../abacus"
+
+describe('setStatsigConfigs', () => {
+    it('only sets properties that exist in the kotlin object', () => {
+        abacusStateManager.setStatsigConfigs({
+            [StatSigFlags.ffEnableEvmSwaps]: true,
+            'nonexistent_flag': true,
+        })
+        expect(StatsigConfig.ff_enable_evm_swaps).toBe(true)
+        // @ts-ignore
+        expect(StatsigConfig.nonexistent_flag).toBeUndefined()
+    })
+})

--- a/src/lib/__test__/index.spec.ts
+++ b/src/lib/__test__/index.spec.ts
@@ -1,16 +1,18 @@
-import { describe, expect, it } from "vitest"
-import { StatsigConfig } from '../../constants/abacus'
-import { StatSigFlags } from "../../types/statsig"
-import abacusStateManager from "../abacus"
+import { describe, expect, it } from 'vitest';
+
+import { StatsigConfig } from '../../constants/abacus';
+import { StatSigFlags } from '../../types/statsig';
+import abacusStateManager from '../abacus';
 
 describe('setStatsigConfigs', () => {
-    it('only sets properties that exist in the kotlin object', () => {
-        abacusStateManager.setStatsigConfigs({
-            [StatSigFlags.ffEnableEvmSwaps]: true,
-            'nonexistent_flag': true,
-        })
-        expect(StatsigConfig.ff_enable_evm_swaps).toBe(true)
-        // @ts-ignore
-        expect(StatsigConfig.nonexistent_flag).toBeUndefined()
-    })
-})
+  it('only sets properties that exist in the kotlin object', () => {
+    abacusStateManager.setStatsigConfigs({
+      [StatSigFlags.ffEnableEvmSwaps]: true,
+      // @ts-ignore
+      nonexistent_flag: true,
+    });
+    expect(StatsigConfig.ff_enable_evm_swaps).toBe(true);
+    // @ts-ignore
+    expect(StatsigConfig.nonexistent_flag).toBeUndefined();
+  });
+});

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -456,6 +456,7 @@ class AbacusStateManager {
       // This filters out any feature flags in the enum that are not part of the
       // kotlin statsig config object
       if (k in StatsigConfig) {
+        // @ts-ignore
         StatsigConfig[k] = v;
       }
     });

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -446,16 +446,19 @@ class AbacusStateManager {
   /**
    *
    * Updates Abacus' global StatsigConfig object.
-   * You must destructure the new flag you want to use from the config and set
-   * the relevant property on the StatsigConfig object.
+   * You must define the property in abacus first, and then add to the enum.
    *
-   * TODO: establish standardized naming conventions between
-   * statsig FF name and boolean propery in abacus StatsigConfig
-   * https://linear.app/dydx/project/feature-experimentation-6853beb333d7/overview
    */
   setStatsigConfigs = (statsigConfig: { [key in StatSigFlags]?: boolean }) => {
-    const { [StatSigFlags.ffSkipMigration]: useSkip = false } = statsigConfig;
+    const { [StatSigFlags.ffSkipMigration]: useSkip = false, ...rest } = statsigConfig;
     StatsigConfig.useSkip = useSkip;
+    Object.entries(rest).forEach(([k, v]) => {
+      // This filters out any feature flags in the enum that are not part of the
+      // kotlin statsig config object
+      if (k in StatsigConfig) {
+        StatsigConfig[k] = v;
+      }
+    });
   };
 }
 

--- a/src/types/statsig.ts
+++ b/src/types/statsig.ts
@@ -1,6 +1,12 @@
 export type StatsigConfigType = Record<StatSigFlags, boolean>;
 
+/**
+ * !README!:
+ * If you are using a flag in abacus, you must add it to the abacus
+ * StatsigConfig object first! Otherwise it won't be set in the StatsigConfig object
+ */
 export enum StatSigFlags {
   ffSkipMigration = 'ff_skip_migration',
   ffShowPredictionMarketsUi = 'ff_show_prediction_markets_ui',
+  ffEnableEvmSwaps = 'ff_enable_evm_swaps',
 }


### PR DESCRIPTION
enable evm swap deposits by piping in the new `ff_enable_evm_swaps` feature gate

also automatically adds new statsig flags to the statsig config object 