### PR TITLE
fix(ohlc): add in missing dep to useTradingView hook

### DIFF
--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -158,7 +158,14 @@ export const useTradingView = ({
       tvWidgetRef.current = null;
       setIsChartReady(false);
     };
-  }, [selectedLocale, selectedNetwork, !!marketId, hasPriceScaleInfo, orderbookCandlesToggleOn]);
+  }, [
+    tvWidgetRef,
+    selectedLocale,
+    selectedNetwork,
+    !!marketId,
+    hasPriceScaleInfo,
+    orderbookCandlesToggleOn,
+  ]);
 
   return { savedResolution };
 };


### PR DESCRIPTION
ohlc was a little buggy (sometimes the toggle had to be clicked twice, or the toggle on was a few seconds delayed). Narrowed it down to a missing dep in `useTradingView` (adding `tvWidgetRef` to make sure toggle refs are set at appropriate times). That hook is still missing a lot of deps but I think a good number of them are intentional, so not otherwise touching 

testing:

just toggling ohlc on/off a million times and verifying there's no delay