### PR TITLE
chore(ohlc): enable orderbook mid price candles across all envs

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -314,8 +314,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-dev-2": {
@@ -349,8 +348,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-dev-3": {
@@ -386,8 +384,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-dev-4": {
@@ -423,8 +420,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-dev-5": {
@@ -458,8 +454,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-staging": {
@@ -494,8 +489,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-staging-forced-update": {
@@ -542,8 +536,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-staging-west": {
@@ -578,8 +571,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet": {
@@ -622,8 +614,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-dydx": {
@@ -659,8 +650,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-nodefleet": {
@@ -696,8 +686,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-kingnodes": {
@@ -733,8 +722,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-liquify": {
@@ -770,8 +758,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-polkachu": {
@@ -807,8 +794,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-testnet-bware": {
@@ -844,8 +830,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": true
+            "isSlTpLimitOrdersEnabled": false
          }
       },
       "dydxprotocol-mainnet": {
@@ -881,8 +866,7 @@
             "CCTPWithdrawalOnly": true,
             "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
-            "isSlTpLimitOrdersEnabled": false,
-            "isOhlcEnabled": false
+            "isSlTpLimitOrdersEnabled": false
          }
       }
    }

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -27,7 +27,6 @@ import { getDydxDatafeed } from '@/lib/tradingView/dydxfeed';
 import { getSavedResolution, getWidgetOptions, getWidgetOverrides } from '@/lib/tradingView/utils';
 
 import { useDydxClient } from '../useDydxClient';
-import { useEnvFeatures } from '../useEnvFeatures';
 import { useLocalStorage } from '../useLocalStorage';
 import { useLocaleSeparators } from '../useLocaleSeparators';
 import { useAllStatsigGateValues } from '../useStatsig';
@@ -66,7 +65,6 @@ export const useTradingView = ({
   const urlConfigs = useURLConfigs();
   const featureFlags = useAllStatsigGateValues();
 
-  const { isOhlcEnabled } = useEnvFeatures();
   const { group, decimal } = useLocaleSeparators();
 
   const appTheme = useAppSelector(getAppTheme);
@@ -107,15 +105,13 @@ export const useTradingView = ({
       label: string;
       tooltip: string;
     }) => {
-      if (toggleRef) {
-        toggleRef.current = tvWidget.createButton();
-        toggleRef.current.innerHTML = `<span>${label}</span> <div class="toggle"></div>`;
-        toggleRef.current.setAttribute('title', tooltip);
-        if (isOn) {
-          toggleRef.current.classList.add(TOGGLE_ACTIVE_CLASS_NAME);
-        }
-        toggleRef.current.onclick = () => setToggleOn((prev) => !prev);
+      toggleRef.current = tvWidget.createButton();
+      toggleRef.current.innerHTML = `<span>${label}</span> <div class="toggle"></div>`;
+      toggleRef.current.setAttribute('title', tooltip);
+      if (isOn) {
+        toggleRef.current.classList.add(TOGGLE_ACTIVE_CLASS_NAME);
       }
+      toggleRef.current.onclick = () => setToggleOn((prev) => !prev);
     },
     []
   );
@@ -163,6 +159,7 @@ export const useTradingView = ({
       tvWidgetRef.current?.onChartReady(() => {
         tvWidgetRef.current?.headerReady().then(() => {
           if (tvWidgetRef.current) {
+            // Order Lines
             initializeToggle({
               toggleRef: orderLineToggleRef,
               tvWidget: tvWidgetRef.current,
@@ -175,24 +172,26 @@ export const useTradingView = ({
                 key: STRING_KEYS.ORDER_LINES_TOOLTIP,
               }),
             });
-            if (isOhlcEnabled) {
-              const getOhlcTooltipString = tooltipStrings.ohlc;
-              const { title: ohlcTitle, body: ohlcBody } = getOhlcTooltipString({
-                stringGetter,
-                stringParams: {},
-                urlConfigs,
-                featureFlags,
-              });
 
-              initializeToggle({
-                toggleRef: orderbookCandlesToggleRef,
-                tvWidget: tvWidgetRef.current,
-                isOn: orderbookCandlesToggleOn,
-                setToggleOn: setOrderbookCandlesToggleOn,
-                label: `${ohlcTitle}*`,
-                tooltip: ohlcBody as string,
-              });
-            }
+            // Orderbook Candles (OHLC)
+            const getOhlcTooltipString = tooltipStrings.ohlc;
+            const { title: ohlcTitle, body: ohlcBody } = getOhlcTooltipString({
+              stringGetter,
+              stringParams: {},
+              urlConfigs,
+              featureFlags,
+            });
+
+            initializeToggle({
+              toggleRef: orderbookCandlesToggleRef,
+              tvWidget: tvWidgetRef.current,
+              isOn: orderbookCandlesToggleOn,
+              setToggleOn: setOrderbookCandlesToggleOn,
+              label: `${ohlcTitle}*`,
+              tooltip: ohlcBody as string,
+            });
+
+            // Buy/Sell Marks
             initializeToggle({
               toggleRef: buySellMarksToggleRef,
               tvWidget: tvWidgetRef.current,

--- a/src/hooks/useEnvFeatures.ts
+++ b/src/hooks/useEnvFeatures.ts
@@ -9,7 +9,6 @@ export interface EnvironmentFeatures {
   CCTPWithdrawalOnly: boolean;
   CCTPDepositOnly: boolean;
   isSlTpLimitOrdersEnabled: boolean;
-  isOhlcEnabled: boolean;
 }
 
 export const useEnvFeatures = (): EnvironmentFeatures => {


### PR DESCRIPTION
Remove `isOhlcEnabled` flag, clean up an unnecessary check against toggle refs being null in `useTradingView`