### PR TITLE
fix: ensure smartbanner is clickable [OTE-711]

### DIFF
--- a/scripts/inject-smartbanner.js
+++ b/scripts/inject-smartbanner.js
@@ -3,11 +3,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const SMARTBANNER_APP_NAME = process.env.SMARTBANNER_APP_NAME;
-const SMARTBANNER_ORG_NAME = process.env.SMARTBANNER_ORG_NAME;
-const SMARTBANNER_ICON_URL = process.env.SMARTBANNER_ICON_URL;
-const SMARTBANNER_APPSTORE_URL = process.env.SMARTBANNER_APPSTORE_URL;
-const SMARTBANNER_GOOGLEPLAY_URL = process.env.SMARTBANNER_GOOGLEPLAY_URL;
+const SMARTBANNER_APP_NAME = 'some fake thing';
+const SMARTBANNER_ORG_NAME = 'some fake thing';
+const SMARTBANNER_ICON_URL = 'some fake thing';
+const SMARTBANNER_APPSTORE_URL = 'some fake thing';
+const SMARTBANNER_GOOGLEPLAY_URL = 'some fake thing';
 
 const currentPath = fileURLToPath(import.meta.url);
 const projectRoot = path.dirname(currentPath);
@@ -23,7 +23,7 @@ if (
     const files = await fs.readdir('entry-points');
     for (const file of files) {
       inject(file);
-    };
+    }
   } catch (err) {
     console.error('Error injecting Smartbanner scripts:', err);
   }
@@ -42,26 +42,32 @@ async function inject(fileName) {
   /* hardcoded injection depending on whether the app is available on App Store and/or Google Play */
 
   if (SMARTBANNER_APPSTORE_URL) {
-    smartbanner = `\t<meta name="smartbanner:button-url-apple" content="${SMARTBANNER_APPSTORE_URL}">\n` + smartbanner;
+    smartbanner =
+      `\t<meta name="smartbanner:button-url-apple" content="${SMARTBANNER_APPSTORE_URL}">\n` +
+      smartbanner;
   }
   if (SMARTBANNER_GOOGLEPLAY_URL) {
-    smartbanner = `\t<meta name="smartbanner:button-url-google" content="${SMARTBANNER_GOOGLEPLAY_URL}">\n` + smartbanner;
+    smartbanner =
+      `\t<meta name="smartbanner:button-url-google" content="${SMARTBANNER_GOOGLEPLAY_URL}">\n` +
+      smartbanner;
   }
   if (SMARTBANNER_APPSTORE_URL) {
     if (SMARTBANNER_GOOGLEPLAY_URL) {
-      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="android,ios">\n` + smartbanner;
+      smartbanner =
+        `\t<meta name="smartbanner:enabled-platforms" content="android,ios">\n` + smartbanner;
     } else {
       smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="ios">\n` + smartbanner;
     }
   } else {
     if (SMARTBANNER_GOOGLEPLAY_URL) {
-      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="android">\n` + smartbanner;
+      smartbanner =
+        `\t<meta name="smartbanner:enabled-platforms" content="android">\n` + smartbanner;
     }
   }
 
   const injectedHtml = html.replace('</head>', `${smartbanner}\n</head>`);
 
   await fs.writeFile(htmlFilePath, injectedHtml, 'utf-8');
-
+  console.log(htmlFilePath, injectedHtml);
   console.log(`Smartbanner scripts successfully injected (${fileName}).`);
 }

--- a/scripts/inject-smartbanner.js
+++ b/scripts/inject-smartbanner.js
@@ -3,11 +3,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const SMARTBANNER_APP_NAME = 'some fake thing';
-const SMARTBANNER_ORG_NAME = 'some fake thing';
-const SMARTBANNER_ICON_URL = 'some fake thing';
-const SMARTBANNER_APPSTORE_URL = 'some fake thing';
-const SMARTBANNER_GOOGLEPLAY_URL = 'some fake thing';
+const SMARTBANNER_APP_NAME = process.env.SMARTBANNER_APP_NAME;
+const SMARTBANNER_ORG_NAME = process.env.SMARTBANNER_ORG_NAME;
+const SMARTBANNER_ICON_URL = process.env.SMARTBANNER_ICON_URL;
+const SMARTBANNER_APPSTORE_URL = process.env.SMARTBANNER_APPSTORE_URL;
+const SMARTBANNER_GOOGLEPLAY_URL = process.env.SMARTBANNER_GOOGLEPLAY_URL;
 
 const currentPath = fileURLToPath(import.meta.url);
 const projectRoot = path.dirname(currentPath);
@@ -17,10 +17,11 @@ if (
   SMARTBANNER_APP_NAME &&
   SMARTBANNER_ORG_NAME &&
   SMARTBANNER_ICON_URL &&
-  (SMARTBANNER_APPSTORE_URL || SMARTBANNER_GOOGLEPLAY_URL)
+  (SMARTBANNER_APPSTORE_URL ?? SMARTBANNER_GOOGLEPLAY_URL)
 ) {
   try {
     const files = await fs.readdir('entry-points');
+    // eslint-disable-next-line no-restricted-syntax
     for (const file of files) {
       inject(file);
     }
@@ -42,32 +43,26 @@ async function inject(fileName) {
   /* hardcoded injection depending on whether the app is available on App Store and/or Google Play */
 
   if (SMARTBANNER_APPSTORE_URL) {
-    smartbanner =
-      `\t<meta name="smartbanner:button-url-apple" content="${SMARTBANNER_APPSTORE_URL}">\n` +
-      smartbanner;
+    smartbanner = `\t<meta name="smartbanner:button-url-apple" content="${SMARTBANNER_APPSTORE_URL}">\n${smartbanner}`;
   }
   if (SMARTBANNER_GOOGLEPLAY_URL) {
-    smartbanner =
-      `\t<meta name="smartbanner:button-url-google" content="${SMARTBANNER_GOOGLEPLAY_URL}">\n` +
-      smartbanner;
+    smartbanner = `\t<meta name="smartbanner:button-url-google" content="${SMARTBANNER_GOOGLEPLAY_URL}">\n${smartbanner}`;
   }
   if (SMARTBANNER_APPSTORE_URL) {
     if (SMARTBANNER_GOOGLEPLAY_URL) {
-      smartbanner =
-        `\t<meta name="smartbanner:enabled-platforms" content="android,ios">\n` + smartbanner;
+      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="android,ios">\n${smartbanner}`;
     } else {
-      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="ios">\n` + smartbanner;
+      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="ios">\n${smartbanner}`;
     }
   } else {
     if (SMARTBANNER_GOOGLEPLAY_URL) {
-      smartbanner =
-        `\t<meta name="smartbanner:enabled-platforms" content="android">\n` + smartbanner;
+      smartbanner = `\t<meta name="smartbanner:enabled-platforms" content="android">\n${smartbanner}`;
     }
   }
 
   const injectedHtml = html.replace('</head>', `${smartbanner}\n</head>`);
 
   await fs.writeFile(htmlFilePath, injectedHtml, 'utf-8');
-  console.log(htmlFilePath, injectedHtml);
+
   console.log(`Smartbanner scripts successfully injected (${fileName}).`);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -96,3 +96,8 @@ strong,
 b {
   font-weight: 700;
 }
+
+/* Fixes the smart banner being unclickable. We want this to rise above all app banners */
+.smartbanner--ios {
+  z-index: 999;
+}

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -51,9 +51,3 @@
   --form-input-paddingY: 0.25rem;
   --form-input-paddingX: 0.625rem;
 }
-
-.smartbanner--ios {
-  font-size: 18px;
-  color: #007aff;
-  z-index: 10;
-}

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -51,3 +51,9 @@
   --form-input-paddingY: 0.25rem;
   --form-input-paddingX: 0.625rem;
 }
+
+.smartbanner--ios {
+  font-size: 18px;
+  color: #007aff;
+  z-index: 10;
+}


### PR DESCRIPTION
https://linear.app/dydx/issue/OTE-711/[v4-web]-cant-close-custom-app-store-banner
cant close the custom app store banner. this is a test PR to see if override styles works

this PR targets the smartbanner default ios class and pushes its z-index to 999, placing it above all dydx app banners and modals