### PR TITLE
chore: better metamask error message [OTE-662]

### DIFF
--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -15,7 +15,14 @@ export const DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS = {
   errorStringKey: STRING_KEYS.SOMETHING_WENT_WRONG,
 };
 
-export enum MetamaskErrorCodes {
+/**
+ * Error codes provided by ethereum EIPS 1474 and 1193
+ * https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ * https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+ *
+ * There error codes are valid for EIPS compliant EVM wallets (including Metamask) and Phantom wallet.
+ */
+export enum EipErrorCodes {
   // https://blog.logrocket.com/understanding-resolving-metamask-error-codes/#32002
   RESOURCE_UNAVAILABLE = -32002,
 }

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -13,3 +13,8 @@ export type ErrorParams =
 export const DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS = {
   errorStringKey: STRING_KEYS.SOMETHING_WENT_WRONG,
 };
+
+export enum MetamaskErrorCodes {
+  // https://blog.logrocket.com/understanding-resolving-metamask-error-codes/#32002
+  RESOURCE_UNAVAILABLE = -32002,
+}

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,4 +1,5 @@
 import { STRING_KEYS } from './localization';
+import { WalletConnectionType } from './wallets';
 
 export type ErrorParams =
   | {
@@ -17,4 +18,14 @@ export const DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS = {
 export enum MetamaskErrorCodes {
   // https://blog.logrocket.com/understanding-resolving-metamask-error-codes/#32002
   RESOURCE_UNAVAILABLE = -32002,
+}
+
+/**
+ * Dydx has an interface for errors that includes more accessible properties than the generic ts error interface
+ * The generic interface only has name, message, and stack.
+ * This interface includes an optional code and walletConnectionType as well.
+ */
+export interface DydxError extends Error {
+  code?: string | number;
+  walletConnectionType?: WalletConnectionType;
 }

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -16,18 +16,6 @@ export const DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS = {
 };
 
 /**
- * Error codes provided by ethereum EIPS 1474 and 1193
- * https://eips.ethereum.org/EIPS/eip-1474#error-codes
- * https://eips.ethereum.org/EIPS/eip-1193#provider-errors
- *
- * There error codes are valid for EIPS compliant EVM wallets (including Metamask) and Phantom wallet.
- */
-export enum EipErrorCodes {
-  // https://blog.logrocket.com/understanding-resolving-metamask-error-codes/#32002
-  RESOURCE_UNAVAILABLE = -32002,
-}
-
-/**
  * Dydx has an interface for errors that includes more accessible properties than the generic ts error interface
  * The generic interface only has name, message, and stack.
  * This interface includes an optional code and walletConnectionType as well.

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -50,8 +50,8 @@ export enum WalletErrorType {
   // Misc
   Unknown,
 
-  // Metamask
-  PendingMetamaskRequest,
+  // EIP specified errors
+  EipResourceUnavailable,
 }
 
 type WalletConnectionTypeConfig = {

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -49,6 +49,9 @@ export enum WalletErrorType {
 
   // Misc
   Unknown,
+
+  // Metamask
+  PendingMetamaskRequest,
 }
 
 type WalletConnectionTypeConfig = {

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -178,6 +178,8 @@ export const useWalletConnection = () => {
           throw Object.assign(
             new Error([error.message, error.cause?.message].filter(Boolean).join('\n')),
             {
+              // Currently the only usecase for this is piping in metamask error codes.
+              // There's a nonzero chance of overlap so we should be wary of this
               code: error.code,
               walletConnectionType: walletConnection?.type,
             }

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -178,8 +178,8 @@ export const useWalletConnection = () => {
           throw Object.assign(
             new Error([error.message, error.cause?.message].filter(Boolean).join('\n')),
             {
-              // Currently the only usecase for this is piping in metamask error codes.
-              // There's a nonzero chance of overlap so we should be wary of this
+              // Currently the only usecase for this is piping in EIP specified error codes.
+              // There's a nonzero chance of overlap so we should watch out for this
               code: error.code,
               walletConnectionType: walletConnection?.type,
             }

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -178,6 +178,7 @@ export const useWalletConnection = () => {
           throw Object.assign(
             new Error([error.message, error.cause?.message].filter(Boolean).join('\n')),
             {
+              code: error.code,
               walletConnectionType: walletConnection?.type,
             }
           );

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -1,4 +1,4 @@
-import { MetamaskErrorCodes } from '@/constants/errors';
+import { DydxError, MetamaskErrorCodes } from '@/constants/errors';
 import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
 import {
   WalletConnectionType,
@@ -78,7 +78,7 @@ export const getWalletConnection = ({
   return undefined;
 };
 
-const getWalletErrorType = ({ error }: { error: any }) => {
+const getWalletErrorType = ({ error }: { error: DydxError }) => {
   const { message, code } = error;
   const messageLower = message.toLowerCase();
 
@@ -118,7 +118,8 @@ const getWalletErrorType = ({ error }: { error: any }) => {
   return WalletErrorType.Unknown;
 };
 
-export const getErrorMessageForCode = ({ code, message }: { code: number; message: string }) => {
+export const getErrorMessageForCode = (error: DydxError) => {
+  const { code, message } = error;
   if (code === MetamaskErrorCodes.RESOURCE_UNAVAILABLE) {
     // TODO: localize
     return 'Request already pending. Please complete in your wallet extension';
@@ -130,7 +131,7 @@ export const parseWalletError = ({
   error,
   stringGetter,
 }: {
-  error: any;
+  error: DydxError;
   stringGetter: StringGetterFunction;
 }) => {
   const walletErrorType = getWalletErrorType({ error });

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -1,4 +1,6 @@
-import { DydxError, EipErrorCodes } from '@/constants/errors';
+import { ResourceUnavailableRpcError } from 'viem';
+
+import { DydxError } from '@/constants/errors';
 import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
 import {
   WalletConnectionType,
@@ -83,8 +85,8 @@ const getWalletErrorType = ({ error }: { error: DydxError }) => {
   const messageLower = message.toLowerCase();
 
   // Metamask - already pending request
-  if (code === EipErrorCodes.RESOURCE_UNAVAILABLE) {
-    return WalletErrorType.PendingMetamaskRequest;
+  if (code === ResourceUnavailableRpcError.code) {
+    return WalletErrorType.EipResourceUnavailable;
   }
 
   // General - Cancelled
@@ -120,7 +122,7 @@ const getWalletErrorType = ({ error }: { error: DydxError }) => {
 
 export const getErrorMessageForCode = (error: DydxError) => {
   const { code, message } = error;
-  if (code === EipErrorCodes.RESOURCE_UNAVAILABLE) {
+  if (code === ResourceUnavailableRpcError.code) {
     // TODO: localize
     return 'Request already pending. Please complete in your wallet extension';
   }

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -1,4 +1,4 @@
-import { DydxError, MetamaskErrorCodes } from '@/constants/errors';
+import { DydxError, EipErrorCodes } from '@/constants/errors';
 import { STRING_KEYS, StringGetterFunction } from '@/constants/localization';
 import {
   WalletConnectionType,
@@ -83,7 +83,7 @@ const getWalletErrorType = ({ error }: { error: DydxError }) => {
   const messageLower = message.toLowerCase();
 
   // Metamask - already pending request
-  if (code === MetamaskErrorCodes.RESOURCE_UNAVAILABLE) {
+  if (code === EipErrorCodes.RESOURCE_UNAVAILABLE) {
     return WalletErrorType.PendingMetamaskRequest;
   }
 
@@ -120,7 +120,7 @@ const getWalletErrorType = ({ error }: { error: DydxError }) => {
 
 export const getErrorMessageForCode = (error: DydxError) => {
   const { code, message } = error;
-  if (code === MetamaskErrorCodes.RESOURCE_UNAVAILABLE) {
+  if (code === EipErrorCodes.RESOURCE_UNAVAILABLE) {
     // TODO: localize
     return 'Request already pending. Please complete in your wallet extension';
   }

--- a/src/views/dialogs/OnboardingDialog/ChooseWallet.tsx
+++ b/src/views/dialogs/OnboardingDialog/ChooseWallet.tsx
@@ -31,7 +31,6 @@ export const ChooseWallet = ({
   const displayedWallets = useDisplayedWallets();
 
   const { selectedWalletType, selectedWalletError } = useAccounts();
-
   return (
     <>
       {selectedWalletType && selectedWalletError && (


### PR DESCRIPTION
https://linear.app/dydx/issue/OTE-662/when-receiving-this-see-description-error-from-metamask-display-this

Override base error message from metamask error by:
- creating MetamaskErrorCodes enum (to track further metamask errors)
- creating DydxError class to enable more flexible error properties
- piping in error.code when receiving an unexpected error from the walletconnect
- add MetamaskErrorCodes.RESOURCE_UNAVAILABLE as a return type for the `getWalletErrorType` function
- create `getErrorMessageForCode` which **defaults to the given error message** and use that for the error message catchall


Followup thoughts:

we should maybe in the future create a MetamaskErrorHandling function. Right now there's like 4-5 layers of indirection to 
get the error which is kind of a lot for something that could be relatively simply. This isn't because we are bad coders, it's because trying to reduce down an N number of errors from different sources with different formats is **hard**.

But with metamask errors, we know how they're shaped and what the error codes mean so we can pretty easily parse them all in a single function.