### PR TITLE
feat(pml-launcher): Add route and scaffold new forms under testflag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ import { useComplianceState } from './hooks/useComplianceState';
 import { useInitializePage } from './hooks/useInitializePage';
 import { useShouldShowFooter } from './hooks/useShouldShowFooter';
 import { useTokenConfigs } from './hooks/useTokenConfigs';
+import { testFlags } from './lib/testFlags';
+import LaunchMarket from './pages/LaunchMarket';
 import breakpoints from './styles/breakpoints';
 
 const NewMarket = lazy(() => import('@/pages/markets/NewMarket'));
@@ -107,7 +109,14 @@ const Content = () => {
               </Route>
 
               <Route path={AppRoute.Markets}>
-                <Route path={MarketsRoute.New} element={<NewMarket />} />
+                {testFlags.pml ? (
+                  <Route
+                    path={MarketsRoute.New}
+                    element={<Navigate to={AppRoute.LaunchMarket} replace />}
+                  />
+                ) : (
+                  <Route path={MarketsRoute.New} element={<NewMarket />} />
+                )}
                 <Route path={AppRoute.Markets} element={<MarketsPage />} />
               </Route>
 
@@ -129,6 +138,7 @@ const Content = () => {
                 <Route path={AppRoute.Vault} element={<VaultPage />} />
               </Route>
 
+              {testFlags.pml && <Route path={AppRoute.LaunchMarket} element={<LaunchMarket />} />}
               <Route path={AppRoute.Terms} element={<TermsOfUsePage />} />
               <Route path={AppRoute.Privacy} element={<PrivacyPolicyPage />} />
               <Route

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -87,7 +87,13 @@ const NavItemWithRef = <MenuItemValue extends string>(
       asChild
       target={isExternalLink(href) ? '_blank' : undefined}
     >
-      <NavLink to={href} ref={ref as Ref<HTMLAnchorElement>} type={`${type}`} {...props}>
+      <NavLink
+        to={href}
+        ref={ref as Ref<HTMLAnchorElement>}
+        type={`${type}`}
+        tw="whitespace-nowrap"
+        {...props}
+      >
         {children}
       </NavLink>
     </Link>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -10,6 +10,7 @@ export enum AppRoute {
   Settings = '/settings',
   Terms = '/terms',
   Privacy = '/privacy',
+  LaunchMarket = '/launch-market',
 }
 
 export enum MarketsRoute {

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { shallowEqual } from 'react-redux';
+
+import { useAppSelector } from '@/state/appTypes';
+import { getMarketIds } from '@/state/perpetualsSelectors';
+
+import { useSelectedNetwork } from './useSelectedNetwork';
+
+type MarketMapTicker = {
+  currency_pair: {
+    Base: string;
+    Quote: string;
+  };
+  decimals: string;
+  min_provider_count: string;
+  enabled: boolean;
+  metadata_JSON?: string;
+};
+
+type MarketMapProviderConfigs = {
+  name: string;
+  off_chain_ticker: string;
+  normalize_by_pair?: {
+    Base: string;
+    Quote: string;
+  };
+  invert: boolean;
+  metadata_JSON: string;
+};
+
+export type MarketMapResponse = {
+  chain_id: string;
+  last_updated: string;
+  market_map: {
+    markets: Record<
+      string,
+      {
+        ticker: MarketMapTicker;
+        provider_configs: MarketMapProviderConfigs[];
+      }
+    >;
+  };
+};
+
+export type HydratedMarketMap = MarketMapResponse['market_map']['markets'][string] & { id: string };
+
+export const useMarketMap = () => {
+  const { selectedNetwork } = useSelectedNetwork();
+
+  const launchableMarkets = useQuery({
+    enabled: selectedNetwork === 'dydxprotocol-staging',
+    queryKey: ['launchableMarkets', selectedNetwork],
+    queryFn: async () => {
+      return fetch('https://validator.v4staging.dydx.exchange:1317/slinky/marketmap/v1/marketmap')
+        .then((res) => res.json())
+        .then((data) => data as MarketMapResponse);
+    },
+  });
+
+  return launchableMarkets;
+};
+
+export const useLaunchableMarkets = () => {
+  const launchableMarkets = useMarketMap();
+  const marketIds = useAppSelector(getMarketIds, shallowEqual);
+
+  const filteredPotentialMarkets: HydratedMarketMap[] = useMemo(() => {
+    const marketMap = launchableMarkets.data?.market_map.markets;
+    if (!marketMap) {
+      return [];
+    }
+
+    return Object.entries(marketMap)
+      .map(([id, data]) => ({
+        id,
+        ...data,
+      }))
+      .filter(({ id }) => {
+        if (marketIds.includes(id)) {
+          return false;
+        }
+
+        return true;
+      });
+  }, [launchableMarkets.data, marketIds]);
+
+  return {
+    ...launchableMarkets,
+    data: filteredPotentialMarkets,
+  };
+};

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -78,11 +78,7 @@ export const useLaunchableMarkets = () => {
         ...data,
       }))
       .filter(({ id }) => {
-        if (marketIds.includes(id)) {
-          return false;
-        }
-
-        return true;
+        return !marketIds.includes(id);
       });
   }, [launchableMarkets.data, marketIds]);
 

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -67,7 +67,7 @@ export const useLaunchableMarkets = () => {
   const marketIds = useAppSelector(getMarketIds, shallowEqual);
 
   const filteredPotentialMarkets: HydratedMarketMap[] = useMemo(() => {
-    const marketMap = launchableMarkets.data?.market_map.markets;
+    const marketMap = launchableMarkets.data?.market_map?.markets;
     if (!marketMap) {
       return [];
     }

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -42,6 +42,7 @@ export const HeaderDesktop = () => {
 
   const hasSeenLaunchIncentives = useAppSelector(getHasSeenLaunchIncentives);
   const showVaults = testFlags.enableVaults;
+  const showLaunchMarkets = testFlags.pml;
 
   const navItems = [
     {
@@ -61,6 +62,11 @@ export const HeaderDesktop = () => {
           value: 'MARKETS',
           label: stringGetter({ key: STRING_KEYS.MARKETS }),
           href: AppRoute.Markets,
+        },
+        showLaunchMarkets && {
+          value: 'LAUNCH_MARKET',
+          label: 'Launch Markets',
+          href: AppRoute.LaunchMarket,
         },
         showVaults && {
           value: 'VAULT',

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -51,6 +51,10 @@ class TestFlags {
   get enablePredictionMarketPerp() {
     return !!this.queryParams.prediction;
   }
+
+  get pml() {
+    return !!this.queryParams.pml;
+  }
 }
 
 export const testFlags = new TestFlags();

--- a/src/pages/LaunchMarket.tsx
+++ b/src/pages/LaunchMarket.tsx
@@ -1,0 +1,125 @@
+import styled from 'styled-components';
+
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { LinkOutIcon } from '@/icons';
+import breakpoints from '@/styles/breakpoints';
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Details } from '@/components/Details';
+import { Output, OutputType } from '@/components/Output';
+import { Tag } from '@/components/Tag';
+import { NewMarketForm } from '@/views/forms/NewMarketForm';
+
+const LaunchMarket = () => {
+  const stringGetter = useStringGetter();
+
+  useDocumentTitle(stringGetter({ key: STRING_KEYS.ADD_A_MARKET }));
+
+  const items = [
+    {
+      key: 'market-cap',
+      label: 'Market Cap',
+      value: <Output type={OutputType.CompactFiat} tw="text-color-text-1" value={1232604.23} />,
+    },
+    {
+      key: 'max-leverage',
+      label: stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE }),
+      value: <Output type={OutputType.Multiple} value={5} />,
+    },
+  ];
+
+  return (
+    <$Page>
+      <$Content>
+        <$FormContainer>
+          <NewMarketForm />
+        </$FormContainer>
+
+        <div tw="flex h-fit w-[25rem] flex-col gap-1 rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]">
+          <div id="header" tw="flex flex-row items-center justify-between">
+            <div tw="flex flex-row items-center gap-0.5">
+              <AssetIcon tw="h-2.5 w-2.5" symbol="ETH" />
+              <h2 tw="flex flex-row items-center gap-[0.5ch] text-extra text-color-text-1">
+                Ethereum
+                <LinkOutIcon tw="h-1.25 w-1.25" />
+              </h2>
+            </div>
+            <Tag>ETH</Tag>
+          </div>
+
+          <div tw="flex flex-row justify-between">
+            <Details
+              layout="rowColumns"
+              items={[
+                {
+                  key: 'reference-price',
+                  label: stringGetter({ key: STRING_KEYS.REFERENCE_PRICE }),
+                  tooltip: 'reference-price',
+                  value: <Output type={OutputType.Fiat} tw="text-color-text-1" value={2604.23} />,
+                },
+              ]}
+            />
+          </div>
+
+          <div tw="h-[8.75rem] rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]" />
+
+          <Details layout="rowColumns" items={items} />
+        </div>
+      </$Content>
+    </$Page>
+  );
+};
+const $Page = styled.div`
+  ${layoutMixins.contentContainerPage}
+  gap: 1.5rem;
+  padding: 2.5rem 0;
+
+  > * {
+    --content-max-width: 80rem;
+    max-width: min(calc(100vw - 4rem), var(--content-max-width));
+  }
+
+  @media ${breakpoints.tablet} {
+    --stickyArea-topHeight: var(--page-header-height-mobile);
+    padding: 0 1rem 1rem;
+
+    > * {
+      max-width: calc(100vw - 2rem);
+      width: 100%;
+    }
+  }
+`;
+
+const $Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+  margin: 0 auto;
+
+  @media ${breakpoints.tablet} {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 0 auto;
+  }
+`;
+
+const $FormContainer = styled.div`
+  width: 25rem;
+  height: fit-content;
+  border-radius: 1rem;
+  background-color: var(--color-layer-3);
+  padding: 1.5rem;
+
+  @media ${breakpoints.tablet} {
+    width: 100%;
+    min-width: unset;
+  }
+`;
+
+export default LaunchMarket;

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -1,17 +1,26 @@
 import { useMemo, useState } from 'react';
 
-import { TOKEN_DECIMALS } from '@/constants/numbers';
+import { STRING_KEYS } from '@/constants/localization';
+import { PERCENT_DECIMALS, TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { type NewMarketProposal } from '@/constants/potentialMarkets';
 
 import { useNextClobPairId } from '@/hooks/useNextClobPairId';
 import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
+import { useStringGetter } from '@/hooks/useStringGetter';
 import { useURLConfigs } from '@/hooks/useURLConfigs';
 
+import { DiffOutput } from '@/components/DiffOutput';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
+import { Output, OutputType } from '@/components/Output';
+
+import { isTruthy } from '@/lib/isTruthy';
+import { testFlags } from '@/lib/testFlags';
 
 import { NewMarketPreviewStep } from './NewMarketPreviewStep';
 import { NewMarketSelectionStep } from './NewMarketSelectionStep';
 import { NewMarketSuccessStep } from './NewMarketSuccessStep';
+import { NewMarketPreviewStep as NewMarketPreviewStep2 } from './v7/NewMarketPreviewStep';
+import { NewMarketSelectionStep as NewMarketSelectionStep2 } from './v7/NewMarketSelectionStep';
 
 enum NewMarketFormStep {
   SELECTION,
@@ -22,9 +31,11 @@ enum NewMarketFormStep {
 export const NewMarketForm = () => {
   const [step, setStep] = useState(NewMarketFormStep.SELECTION);
   const [assetToAdd, setAssetToAdd] = useState<NewMarketProposal>();
+  const [tickerToAdd, setTickerToAdd] = useState<string>();
   const [liquidityTier, setLiquidityTier] = useState<number>();
   const [proposalTxHash, setProposalTxHash] = useState<string>();
   const { mintscan: mintscanTxUrl } = useURLConfigs();
+  const stringGetter = useStringGetter();
 
   const { tickersFromProposals } = useNextClobPairId();
   const { hasPotentialMarketsData } = usePotentialMarkets();
@@ -34,6 +45,87 @@ export const NewMarketForm = () => {
     const p = Math.floor(Math.log(Number(assetToAdd.meta.referencePrice)));
     return Math.abs(p - 3);
   }, [assetToAdd]);
+
+  const receiptItems = useMemo(() => {
+    return [
+      {
+        key: 'deposit-apr',
+        label: 'Deposit APR (30d)',
+        value: (
+          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
+        ),
+      },
+      {
+        key: 'deposit-lockup',
+        label: 'Deposit Lockup',
+        value: (
+          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
+        ),
+      },
+      {
+        key: 'cross-margin-usage',
+        label: stringGetter({ key: STRING_KEYS.CROSS_MARGIN_USAGE }),
+        value: (
+          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
+        ),
+      },
+      step === NewMarketFormStep.PREVIEW && {
+        key: 'cross-free-collateral',
+        label: stringGetter({ key: STRING_KEYS.CROSS_FREE_COLLATERAL }),
+        value: (
+          <DiffOutput
+            withDiff
+            type={OutputType.Fiat}
+            value={100000}
+            newValue={88000}
+            fractionDigits={USD_DECIMALS}
+          />
+        ),
+      },
+      {
+        key: 'megavault-balance',
+        label: stringGetter({ key: STRING_KEYS.YOUR_VAULT_BALANCE }),
+        value: <Output type={OutputType.Fiat} value={10000} fractionDigits={USD_DECIMALS} />,
+      },
+    ].filter(isTruthy);
+  }, [step, stringGetter]);
+
+  /**
+   * Permissionless Markets Flow
+   */
+  if (testFlags.pml) {
+    if (NewMarketFormStep.SUCCESS === step) {
+      return <NewMarketSuccessStep href="" />;
+    }
+
+    if (NewMarketFormStep.PREVIEW === step && tickerToAdd) {
+      return (
+        <NewMarketPreviewStep2
+          onSuccess={() => {
+            setStep(NewMarketFormStep.SUCCESS);
+          }}
+          onBack={() => setStep(NewMarketFormStep.SELECTION)}
+          ticker={tickerToAdd}
+          receiptItems={receiptItems}
+        />
+      );
+    }
+
+    return (
+      <NewMarketSelectionStep2
+        onConfirmMarket={() => {
+          setStep(NewMarketFormStep.PREVIEW);
+        }}
+        setAssetToAdd={setTickerToAdd}
+        assetToAdd={tickerToAdd}
+        receiptItems={receiptItems}
+      />
+    );
+  }
+
+  /**
+   * Current Market Proposal Flow
+   */
 
   if (!hasPotentialMarketsData) {
     return <LoadingSpace id="new-market-form" tw="min-h-[18.75rem]" />;

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { STRING_KEYS } from '@/constants/localization';
-import { PERCENT_DECIMALS, TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
+import { TOKEN_DECIMALS } from '@/constants/numbers';
 import { type NewMarketProposal } from '@/constants/potentialMarkets';
 
 import { useNextClobPairId } from '@/hooks/useNextClobPairId';
@@ -9,6 +9,7 @@ import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useURLConfigs } from '@/hooks/useURLConfigs';
 
+import { DetailsItem } from '@/components/Details';
 import { DiffOutput } from '@/components/DiffOutput';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Output, OutputType } from '@/components/Output';
@@ -46,46 +47,32 @@ export const NewMarketForm = () => {
     return Math.abs(p - 3);
   }, [assetToAdd]);
 
-  const receiptItems = useMemo(() => {
+  const receiptItems: DetailsItem[] = useMemo(() => {
     return [
       {
         key: 'deposit-apr',
         label: 'Deposit APR (30d)',
-        value: (
-          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
-        ),
+        value: <Output type={OutputType.Percent} value={0.3256} />,
       },
       {
         key: 'deposit-lockup',
         label: 'Deposit Lockup',
-        value: (
-          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
-        ),
+        value: <Output type={OutputType.Percent} value={0.3256} />,
       },
       {
         key: 'cross-margin-usage',
         label: stringGetter({ key: STRING_KEYS.CROSS_MARGIN_USAGE }),
-        value: (
-          <Output type={OutputType.Percent} value={0.3256} fractionDigits={PERCENT_DECIMALS} />
-        ),
+        value: <Output type={OutputType.Percent} value={0.3256} />,
       },
       step === NewMarketFormStep.PREVIEW && {
         key: 'cross-free-collateral',
         label: stringGetter({ key: STRING_KEYS.CROSS_FREE_COLLATERAL }),
-        value: (
-          <DiffOutput
-            withDiff
-            type={OutputType.Fiat}
-            value={100000}
-            newValue={88000}
-            fractionDigits={USD_DECIMALS}
-          />
-        ),
+        value: <DiffOutput withDiff type={OutputType.Fiat} value={100000} newValue={88000} />,
       },
       {
         key: 'megavault-balance',
         label: stringGetter({ key: STRING_KEYS.YOUR_VAULT_BALANCE }),
-        value: <Output type={OutputType.Fiat} value={10000} fractionDigits={USD_DECIMALS} />,
+        value: <Output type={OutputType.Fiat} value={10000} />,
       },
     ].filter(isTruthy);
   }, [step, stringGetter]);

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -116,8 +116,8 @@ export const NewMarketForm = () => {
         onConfirmMarket={() => {
           setStep(NewMarketFormStep.PREVIEW);
         }}
-        setAssetToAdd={setTickerToAdd}
-        assetToAdd={tickerToAdd}
+        setTickerToAdd={setTickerToAdd}
+        tickerToAdd={tickerToAdd}
         receiptItems={receiptItems}
       />
     );

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -15,7 +15,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { AlertMessage } from '@/components/AlertMessage';
 import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
-import { Details } from '@/components/Details';
+import { Details, type DetailsItem } from '@/components/Details';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 
@@ -28,7 +28,7 @@ type NewMarketPreviewStepProps = {
   ticker: string;
   onBack: () => void;
   onSuccess: (ticker: string) => void;
-  receiptItems: Parameters<typeof Details>[0]['items'];
+  receiptItems: DetailsItem[];
 };
 
 export const NewMarketPreviewStep = ({

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -158,7 +158,10 @@ export const NewMarketPreviewStep = ({
 
       {alertMessage}
 
-      <Details items={receiptItems} />
+      <Details
+        items={receiptItems}
+        tw="rounded-[0.625rem] bg-color-layer-2 px-1 py-0.5 text-small"
+      />
 
       <div tw="grid w-full grid-cols-[1fr_2fr] gap-1">
         <Button onClick={onBack}>{stringGetter({ key: STRING_KEYS.BACK })}</Button>

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -1,0 +1,205 @@
+import { FormEvent, useMemo } from 'react';
+
+import { LightningBoltIcon } from '@radix-ui/react-icons';
+import styled from 'styled-components';
+
+import { OnboardingState } from '@/constants/account';
+import { AlertType } from '@/constants/alerts';
+import { ButtonAction, ButtonType } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+import { isMainnet } from '@/constants/networks';
+import { USD_DECIMALS } from '@/constants/numbers';
+
+import { useAccountBalance } from '@/hooks/useAccountBalance';
+import { useGovernanceVariables } from '@/hooks/useGovernanceVariables';
+import { useLaunchableMarkets } from '@/hooks/useLaunchableMarkets';
+import { useStringGetter } from '@/hooks/useStringGetter';
+import { useTokenConfigs } from '@/hooks/useTokenConfigs';
+
+import { formMixins } from '@/styles/formMixins';
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AlertMessage } from '@/components/AlertMessage';
+import { Button } from '@/components/Button';
+import { Details } from '@/components/Details';
+import { DiffOutput } from '@/components/DiffOutput';
+import { FormInput } from '@/components/FormInput';
+import { InputType } from '@/components/Input';
+import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
+import { OutputType } from '@/components/Output';
+import { SearchSelectMenu } from '@/components/SearchSelectMenu';
+import { Tag } from '@/components/Tag';
+import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
+import { WithReceipt } from '@/components/WithReceipt';
+import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton';
+
+import { getOnboardingState } from '@/state/accountSelectors';
+import { useAppSelector } from '@/state/appTypes';
+
+import { MustBigNumber } from '@/lib/numbers';
+
+type NewMarketSelectionStepProps = {
+  assetToAdd?: string;
+  setAssetToAdd: (ticker: string) => void;
+  onConfirmMarket: () => void;
+  receiptItems: Parameters<typeof Details>[0]['items'];
+};
+
+export const NewMarketSelectionStep = ({
+  assetToAdd,
+  setAssetToAdd,
+  onConfirmMarket,
+  receiptItems,
+}: NewMarketSelectionStepProps) => {
+  const { nativeTokenBalance } = useAccountBalance();
+  const onboardingState = useAppSelector(getOnboardingState);
+  const isDisconnected = onboardingState === OnboardingState.Disconnected;
+  const { chainTokenDecimals, chainTokenLabel } = useTokenConfigs();
+  const launchableMarkets = useLaunchableMarkets();
+  const stringGetter = useStringGetter();
+  const { newMarketProposal } = useGovernanceVariables();
+  const initialDepositAmountBN = MustBigNumber(newMarketProposal.initialDepositAmount).div(
+    Number(`1e${chainTokenDecimals}`)
+  );
+  const initialDepositAmountDecimals = isMainnet ? 0 : chainTokenDecimals;
+  const initialDepositAmount = initialDepositAmountBN.toFixed(initialDepositAmountDecimals);
+
+  const alertMessage = useMemo(() => {
+    let alert;
+    if (nativeTokenBalance.lt(initialDepositAmountBN)) {
+      alert = {
+        type: AlertType.Warning,
+        message: stringGetter({
+          key: STRING_KEYS.NOT_ENOUGH_BALANCE,
+          params: {
+            NUM_TOKENS_REQUIRED: initialDepositAmount,
+            NATIVE_TOKEN_DENOM: chainTokenLabel,
+          },
+        }),
+      };
+    }
+
+    if (alert) return <AlertMessage type={alert.type}>{alert.message}</AlertMessage>;
+    return null;
+  }, [chainTokenLabel, initialDepositAmount, nativeTokenBalance, stringGetter]);
+
+  const formHeader = useMemo(() => {
+    return (
+      <>
+        <h2>
+          Launch a Market
+          <span tw="flex flex-row items-center text-small text-color-text-1">
+            <LightningBoltIcon tw="text-color-warning" /> Trade Instantly
+          </span>
+        </h2>
+        <span tw="text-base text-color-text-0">
+          Select the market you’d like to launch and deposit $10,000 into MegaVault. Your deposit
+          will earn an estimated 34.56% APR (based on the last 30 days).
+        </span>
+      </>
+    );
+  }, []);
+
+  return (
+    <$Form
+      onSubmit={(e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        onConfirmMarket();
+      }}
+    >
+      {formHeader}
+
+      {launchableMarkets.isLoading ? (
+        <LoadingSpace id="launch-markets" />
+      ) : (
+        <>
+          <SearchSelectMenu
+            items={[
+              {
+                group: 'markets',
+                groupLabel: stringGetter({ key: STRING_KEYS.MARKETS }),
+                items:
+                  launchableMarkets.data?.map((launchableMarket) => ({
+                    value: launchableMarket.id,
+                    label: launchableMarket.id,
+                    tag: launchableMarket.ticker.currency_pair.Base,
+                    onSelect: () => {
+                      setAssetToAdd(launchableMarket.id);
+                    },
+                  })) ?? [],
+              },
+            ]}
+            label={stringGetter({ key: STRING_KEYS.MARKETS })}
+          >
+            {assetToAdd ? (
+              <span tw="text-color-text-2">
+                {assetToAdd} <Tag>{assetToAdd}</Tag>
+              </span>
+            ) : (
+              `${stringGetter({ key: STRING_KEYS.EG })} "BTC-USD"`
+            )}
+          </SearchSelectMenu>
+
+          <WithDetailsReceipt
+            side="bottom"
+            detailItems={[
+              {
+                key: 'cross-free-collateral',
+                label: stringGetter({ key: STRING_KEYS.CROSS_FREE_COLLATERAL }),
+                value: (
+                  <DiffOutput
+                    withDiff
+                    type={OutputType.Fiat}
+                    value={100000}
+                    newValue={88000}
+                    fractionDigits={USD_DECIMALS}
+                  />
+                ),
+              },
+            ]}
+            tw="[--withReceipt-backgroundColor:--color-layer-2]"
+          >
+            <FormInput
+              type={InputType.Currency}
+              label="Required Amount to Deposit"
+              placeholder="$10,000"
+              value="$10000"
+            />
+          </WithDetailsReceipt>
+
+          {alertMessage}
+
+          <WithReceipt
+            tw="[--withReceipt-backgroundColor:--color-layer-2]"
+            slotReceipt={<Details items={receiptItems} tw="px-0.75 pb-0.25 pt-0.375 text-small" />}
+          >
+            {isDisconnected ? (
+              <OnboardingTriggerButton />
+            ) : (
+              <Button
+                type={ButtonType.Submit}
+                state={{ isDisabled: !assetToAdd }}
+                action={ButtonAction.Primary}
+              >
+                Preview Launch
+              </Button>
+            )}
+          </WithReceipt>
+        </>
+      )}
+    </$Form>
+  );
+};
+const $Form = styled.form`
+  ${formMixins.transfersForm}
+  ${layoutMixins.stickyArea0}
+  --stickyArea0-background: transparent;
+
+  h2 {
+    ${layoutMixins.row}
+    justify-content: space-between;
+    margin: 0;
+    font: var(--font-large-medium);
+    color: var(--color-text-2);
+  }
+`;

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -17,7 +17,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 
 import { AlertMessage } from '@/components/AlertMessage';
 import { Button } from '@/components/Button';
-import { Details } from '@/components/Details';
+import { Details, type DetailsItem } from '@/components/Details';
 import { DiffOutput } from '@/components/DiffOutput';
 import { FormInput } from '@/components/FormInput';
 import { InputType } from '@/components/Input';
@@ -36,7 +36,7 @@ type NewMarketSelectionStepProps = {
   tickerToAdd?: string;
   setTickerToAdd: (ticker: string) => void;
   onConfirmMarket: () => void;
-  receiptItems: Parameters<typeof Details>[0]['items'];
+  receiptItems: DetailsItem[];
 };
 
 export const NewMarketSelectionStep = ({


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1032" alt="Screenshot 2024-08-21 at 12 15 07 PM" src="https://github.com/user-attachments/assets/31e9af52-660d-417d-ac9b-fbbd6021a976">

<img width="1079" alt="Screenshot 2024-08-21 at 12 16 50 PM" src="https://github.com/user-attachments/assets/da4a3a13-b8e4-4709-89b5-923c2f510d5b">

<!-- Overall purpose of the PR -->
Launch Market page
- Set-up app routes for `/launch-market` url
- Scaffold NewMarketPreview and NewMarketSelection forms

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* New `<LaunchMarket>`
  * add new page
  * rough scaffold of components on page

* New `<NewMarketPreviewStep>` and `<NewMarketSelectionStep>`
  * Rough scaffold of brand new forms in the `v7` directory (protocol support version)

* `<HeaderDesktop>`
  * add `Launch Market` item behind testFlag

* `<App>`
  * Add new route behind testflag and redirect `/markets/new` -> `/launch-market`

* `<NewMarketForm>`
  * add new components under `pml` flag
  * add hook to get receipt items since receipts are shared on two forms

## Components

* `<NavigationMenu>`
  * `white-space: nowrap` for nav items

## Constants/Types

* `constants/routes`
  * add new route

## Functions

* `lib/testFlags`
  * add `pml` testflag

## Hooks

* `hooks/useLaunchableMarkets`
  * Add dummy query (only queries hardcoded staging url) to get market map data
  * returns filtered list (referencing existing marketIds)

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
