### PR TITLE
chore: close position 10% option + bump abacus

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@cosmjs/proto-signing": "^0.32.1",
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
-    "@dydxprotocol/v4-abacus": "1.8.95",
+    "@dydxprotocol/v4-abacus": "1.8.96",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.177",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^0.32.1
     version: 0.32.2
   '@dydxprotocol/v4-abacus':
-    specifier: 1.8.95
-    version: 1.8.95
+    specifier: 1.8.96
+    version: 1.8.96
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
@@ -3222,8 +3222,8 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  /@dydxprotocol/v4-abacus@1.8.95:
-    resolution: {integrity: sha512-N10iUnTtePDfk/xMmhQIXLgTCUwU07waMawBXIczND7HVDuafqBtZKtG2p2qjk4CZ9xzGcLHm5hLPcVWFqTQKg==}
+  /@dydxprotocol/v4-abacus@1.8.96:
+    resolution: {integrity: sha512-89Qzu1V5vq5eK5al+vPHsDe4iihIRdbS+wLp8+UllZwmemhQHzX7eTGXfqzggEHR6dpt8+Imda8xNBDgZLcZ+w==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -54,8 +54,8 @@ import { PlaceOrderButtonAndReceipt } from './TradeForm/PlaceOrderButtonAndRecei
 
 const MAX_KEY = 'MAX';
 
-// Abacus only takes in these percent options
 const SIZE_PERCENT_OPTIONS = {
+  '10%': 0.1,
   '25%': 0.25,
   '50%': 0.5,
   '75%': 0.75,
@@ -131,11 +131,6 @@ export const ClosePositionForm = ({
     abacusStateManager.setClosePositionValue({
       value: market,
       field: ClosePositionInputField.market,
-    });
-
-    abacusStateManager.setClosePositionValue({
-      value: SIZE_PERCENT_OPTIONS[MAX_KEY],
-      field: ClosePositionInputField.percent,
     });
   }, [market, currentStep]);
 


### PR DESCRIPTION
post abacus bump set full close as default (i.e. percent = 1), therefore we can remove that call
also add a 10% option since that was a request a while back and it's ez to add now

testing: 
- close a position / switch to another market during close position and observe that full close is selected, and size / diff state should reflect that
- select 10% option

<img width="385" alt="image" src="https://github.com/user-attachments/assets/e8b6eb1f-0325-4a55-bbc1-8bd8773a00d9">

<img width="347" alt="image" src="https://github.com/user-attachments/assets/7102f481-2a2e-4efa-bd31-5575acd12454">
