### PR TITLE
fix: memoize compliance string

### DIFF
--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { shallowEqual } from 'react-redux';
 
 import { ComplianceStatus } from '@/constants/abacus';
@@ -34,63 +36,70 @@ export const useComplianceState = () => {
   const onboardingState = useAppSelector(getOnboardingState);
   const { checkForGeo } = useEnvFeatures();
 
-  const updatedAtDate = complianceUpdatedAt ? new Date(complianceUpdatedAt) : undefined;
-  updatedAtDate?.setDate(updatedAtDate.getDate() + CLOSE_ONLY_GRACE_PERIOD);
+  const complianceState = useMemo(() => {
+    if (
+      complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY ||
+      complianceStatus === ComplianceStatus.CLOSE_ONLY
+    ) {
+      return ComplianceStates.CLOSE_ONLY;
+    }
 
-  let complianceState = ComplianceStates.FULL_ACCESS;
+    if (
+      complianceStatus === ComplianceStatus.BLOCKED ||
+      (geo && isBlockedGeo(geo) && checkForGeo)
+    ) {
+      return ComplianceStates.READ_ONLY;
+    }
 
-  let complianceMessage;
+    return ComplianceStates.FULL_ACCESS;
+  }, [checkForGeo, complianceStatus, geo]);
 
-  if (
-    complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY ||
-    complianceStatus === ComplianceStatus.CLOSE_ONLY
-  ) {
-    complianceState = ComplianceStates.CLOSE_ONLY;
-  } else if (
-    complianceStatus === ComplianceStatus.BLOCKED ||
-    (geo && isBlockedGeo(geo) && checkForGeo)
-  ) {
-    complianceState = ComplianceStates.READ_ONLY;
-  }
+  const complianceMessage = useMemo(() => {
+    let message;
 
-  if (complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY) {
-    complianceMessage = `${stringGetter({ key: STRING_KEYS.CLICK_TO_VIEW })} →`;
-  } else if (complianceStatus === ComplianceStatus.CLOSE_ONLY) {
-    complianceMessage = stringGetter({
-      key: STRING_KEYS.CLOSE_ONLY_MESSAGE_WITH_HELP,
-      params: {
-        DATE: updatedAtDate
-          ? formatDateOutput(updatedAtDate.valueOf(), OutputType.DateTime, {
-              dateFormat: 'medium',
-              selectedLocale,
-            })
-          : undefined,
-        HELP_LINK: (
-          <Link href={help} isInline>
-            {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
-          </Link>
-        ),
-      },
-    });
-  } else if (complianceStatus === ComplianceStatus.BLOCKED) {
-    complianceMessage = stringGetter({
-      key: STRING_KEYS.PERMANENTLY_BLOCKED_MESSAGE_WITH_HELP,
-      params: {
-        HELP_LINK: (
-          <Link href={help} isInline>
-            {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
-          </Link>
-        ),
-      },
-    });
-  } else if (geo && isBlockedGeo(geo)) {
-    complianceMessage = stringGetter({
-      key: STRING_KEYS.BLOCKED_MESSAGE,
-      params: {
-        TERMS_OF_USE_LINK: <TermsOfUseLink isInline tw="underline" />,
-      },
-    });
-  }
+    const updatedAtDate = complianceUpdatedAt ? new Date(complianceUpdatedAt) : undefined;
+    updatedAtDate?.setDate(updatedAtDate.getDate() + CLOSE_ONLY_GRACE_PERIOD);
+
+    if (complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY) {
+      message = `${stringGetter({ key: STRING_KEYS.CLICK_TO_VIEW })} →`;
+    } else if (complianceStatus === ComplianceStatus.CLOSE_ONLY) {
+      message = stringGetter({
+        key: STRING_KEYS.CLOSE_ONLY_MESSAGE_WITH_HELP,
+        params: {
+          DATE: updatedAtDate
+            ? formatDateOutput(updatedAtDate.valueOf(), OutputType.DateTime, {
+                dateFormat: 'medium',
+                selectedLocale,
+              })
+            : undefined,
+          HELP_LINK: (
+            <Link href={help} isInline>
+              {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
+            </Link>
+          ),
+        },
+      });
+    } else if (complianceStatus === ComplianceStatus.BLOCKED) {
+      message = stringGetter({
+        key: STRING_KEYS.PERMANENTLY_BLOCKED_MESSAGE_WITH_HELP,
+        params: {
+          HELP_LINK: (
+            <Link href={help} isInline>
+              {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
+            </Link>
+          ),
+        },
+      });
+    } else if (geo && isBlockedGeo(geo)) {
+      message = stringGetter({
+        key: STRING_KEYS.BLOCKED_MESSAGE,
+        params: {
+          TERMS_OF_USE_LINK: <TermsOfUseLink isInline tw="underline" />,
+        },
+      });
+    }
+    return message;
+  }, [complianceStatus, complianceUpdatedAt, geo, help, selectedLocale, stringGetter]);
 
   const disableConnectButton =
     complianceState === ComplianceStates.READ_ONLY &&


### PR DESCRIPTION
The `complianceMessage` was not being memo-ized leading to a non-stop rendering of the compliance notification, which was eating up a lot CPU when website is in user restricted area.

Memoize the `complianceMessage` to fix this.