### PR TITLE
fix: set pointer events to auto in dialog to fix behavior when theres another layer

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -224,6 +224,7 @@ const $Container = styled(Content)<{
   isolation: isolate;
   z-index: 1;
   position: absolute;
+  pointer-events: auto !important;
 
   inset: 0;
   width: 100%;


### PR DESCRIPTION
check dialog with dropdown menus in Trade page
rest of dialog should have the right cursor / behavior when having the menu open 

<img width="793" alt="image" src="https://github.com/user-attachments/assets/a468de4a-5db4-48ce-af58-4203068a5972">
