### PR TITLE
fix: place order tx should use marketInfo and currentHeight from abacus payload

### DIFF
--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -232,6 +232,8 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
         postOnly,
         reduceOnly,
         triggerPrice,
+        marketInfo,
+        currentHeight,
       } = params || {};
 
       setTimeout(() => {
@@ -255,8 +257,8 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
         postOnly ?? undefined,
         reduceOnly ?? undefined,
         triggerPrice ?? undefined,
-        undefined,
-        undefined,
+        marketInfo ?? undefined,
+        currentHeight ?? undefined,
         goodTilBlock ?? undefined
       );
 


### PR DESCRIPTION
this should skip 2 round trip calls for getting market info and block height. 
abacus already has that info from fetched markets info and polled/estimated block height
- latter could potentially increase risk of some errors related to GTB, but will monitor next week
```
   * @param marketInfo optional market information for calculating quantums and subticks.
   *        This can be constructed from Indexer API. If set to null, additional round
   *        trip to Indexer API will be made.
   * @param currentHeight Current block height. This can be obtained from ValidatorClient.
   *        If set to null, additional round trip to ValidatorClient will be made.
 ```
https://github.com/dydxprotocol/v4-clients/blob/56d8c2deacffd97eb70343b2904ac94f4c91d242/v4-client-js/src/clients/composite-client.ts#L342-L346

before:
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/b449e50d-4c59-4dad-8b8c-998f5d346573">

testing:
- place order should still work and succeed
- no extra call to perpetual market info
- abacus still poll validator height so that one is a little unclear, but that call shouldn't be a blocker now
