### PR TITLE
fix: fix uncentered loading button

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -68,7 +68,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
             {withContentOnLoading && slotLeft}
             {withContentOnLoading && children}
             {withContentOnLoading && slotRight}
-            <LoadingDots size={3} tw="pt-[0.5em]" />
+            <LoadingDots size={3} />
           </>
         ) : (
           <>


### PR DESCRIPTION
the stuff that bothers me // unsure if this is a personal preference but I'm pretty sure this looks better centered??

| before | after |
| ---- | ---- |
| <img width="1512" alt="Screenshot 2024-08-23 at 1 41 27 PM" src="https://github.com/user-attachments/assets/6789521d-17de-4d17-a2d1-23213a607510"> | <img width="1512" alt="Screenshot 2024-08-23 at 1 40 31 PM" src="https://github.com/user-attachments/assets/bd6b72a1-eab6-4c6f-8f5f-267b0ce1f06d"> |



