### PR TITLE
chore(i18n): localize PML Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@dydxprotocol/v4-abacus": "1.8.97",
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-client-js": "^1.1.27",
-    "@dydxprotocol/v4-localization": "^1.1.177",
+    "@dydxprotocol/v4-localization": "^1.1.182",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",
     "@hugocxl/react-to-image": "^0.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ dependencies:
     specifier: ^1.1.27
     version: 1.1.27
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.177
-    version: 1.1.177
+    specifier: ^1.1.182
+    version: 1.1.182
   '@emotion/is-prop-valid':
     specifier: ^1.3.0
     version: 1.3.0
@@ -3276,8 +3276,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.177:
-    resolution: {integrity: sha512-fao+hpInv+rtYWsuJZ6USW4KodXoLmeZhWRovL0CKN43GJ9D6p4QMYvQaDQinD1mWcofXug58ombXv3u2fspvw==}
+  /@dydxprotocol/v4-localization@1.1.182:
+    resolution: {integrity: sha512-YNLkEG2O+4X5PqBU3ID9tqBNAa5txHr7hCLtmYG8WrCOnr10DkJ34pIUEE5za/bpmwmjAS6ZXUJtmksPFugZ6w==}
     dev: false
 
   /@dydxprotocol/v4-proto@5.0.0-dev.0:

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -65,7 +65,7 @@ export const HeaderDesktop = () => {
         },
         showLaunchMarkets && {
           value: 'LAUNCH_MARKET',
-          label: 'Launch Markets',
+          label: stringGetter({ key: STRING_KEYS.LAUNCH_MARKETS }),
           href: AppRoute.LaunchMarket,
         },
         showVaults && {

--- a/src/pages/LaunchMarket.tsx
+++ b/src/pages/LaunchMarket.tsx
@@ -5,14 +5,10 @@ import { STRING_KEYS } from '@/constants/localization';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import { LinkOutIcon } from '@/icons';
 import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
 
-import { AssetIcon } from '@/components/AssetIcon';
-import { Details } from '@/components/Details';
-import { Output, OutputType } from '@/components/Output';
-import { Tag } from '@/components/Tag';
+import { LaunchableMarketChart } from '@/views/charts/LaunchableMarketChart';
 import { NewMarketForm } from '@/views/forms/NewMarketForm';
 
 const LaunchMarket = () => {
@@ -20,56 +16,13 @@ const LaunchMarket = () => {
 
   useDocumentTitle(stringGetter({ key: STRING_KEYS.ADD_A_MARKET }));
 
-  const items = [
-    {
-      key: 'market-cap',
-      label: 'Market Cap',
-      value: <Output type={OutputType.CompactFiat} tw="text-color-text-1" value={1232604.23} />,
-    },
-    {
-      key: 'max-leverage',
-      label: stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE }),
-      value: <Output type={OutputType.Multiple} value={5} />,
-    },
-  ];
-
   return (
     <$Page>
       <$Content>
         <$FormContainer>
           <NewMarketForm />
         </$FormContainer>
-
-        <div tw="flex h-fit w-[25rem] flex-col gap-1 rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]">
-          <div id="header" tw="flex flex-row items-center justify-between">
-            <div tw="flex flex-row items-center gap-0.5">
-              <AssetIcon tw="h-2.5 w-2.5" symbol="ETH" />
-              <h2 tw="flex flex-row items-center gap-[0.5ch] text-extra text-color-text-1">
-                Ethereum
-                <LinkOutIcon tw="h-1.25 w-1.25" />
-              </h2>
-            </div>
-            <Tag>ETH</Tag>
-          </div>
-
-          <div tw="flex flex-row justify-between">
-            <Details
-              layout="rowColumns"
-              items={[
-                {
-                  key: 'reference-price',
-                  label: stringGetter({ key: STRING_KEYS.REFERENCE_PRICE }),
-                  tooltip: 'reference-price',
-                  value: <Output type={OutputType.Fiat} tw="text-color-text-1" value={2604.23} />,
-                },
-              ]}
-            />
-          </div>
-
-          <div tw="h-[8.75rem] rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]" />
-
-          <Details layout="rowColumns" items={items} />
-        </div>
+        <LaunchableMarketChart />
       </$Content>
     </$Page>
   );

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+import { ButtonSize } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { LinkOutIcon } from '@/icons';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Details } from '@/components/Details';
+import { Output, OutputType } from '@/components/Output';
+import { Tag } from '@/components/Tag';
+import { ToggleGroup } from '@/components/ToggleGroup';
+
+enum ChartResolution {
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+}
+
+export const LaunchableMarketChart = ({ className }: { className?: string }) => {
+  const stringGetter = useStringGetter();
+  const [resolution, setResolution] = useState(ChartResolution.DAY);
+
+  const items = [
+    {
+      key: 'market-cap',
+      label: stringGetter({ key: STRING_KEYS.MARKET_CAP }),
+      value: <Output type={OutputType.CompactFiat} tw="text-color-text-1" value={1232604.23} />,
+    },
+    {
+      key: 'max-leverage',
+      label: stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE }),
+      value: <Output type={OutputType.Multiple} value={5} />,
+    },
+  ];
+
+  return (
+    <$LaunchableMarketChartContainer className={className}>
+      <$ChartContainerHeader tw="flex flex-row items-center justify-between">
+        <div tw="flex flex-row items-center gap-0.5">
+          <AssetIcon tw="h-2.5 w-2.5" symbol="ETH" />
+          <h2 tw="flex flex-row items-center gap-[0.5ch] text-extra text-color-text-1">
+            Ethereum
+            <LinkOutIcon tw="h-1.25 w-1.25" />
+          </h2>
+        </div>
+
+        <Tag>ETH</Tag>
+      </$ChartContainerHeader>
+
+      <div tw="flex flex-row justify-between">
+        <$Details
+          layout="rowColumns"
+          items={[
+            {
+              key: 'reference-price',
+              label: stringGetter({ key: STRING_KEYS.REFERENCE_PRICE }),
+              tooltip: 'reference-price',
+              value: <Output type={OutputType.Fiat} tw="text-color-text-1" value={2604.23} />,
+            },
+          ]}
+        />
+        <$ToggleGroup
+          size={ButtonSize.Base}
+          items={[
+            {
+              value: ChartResolution.DAY,
+              label: `1${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+            },
+            {
+              value: ChartResolution.WEEK,
+              label: `7${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+            },
+            {
+              value: ChartResolution.MONTH,
+              label: `30${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+            },
+          ]}
+          value={resolution}
+          onValueChange={setResolution}
+        />
+      </div>
+
+      <$ChartContainer />
+
+      <$Details layout="rowColumns" items={items} />
+    </$LaunchableMarketChartContainer>
+  );
+};
+
+const $LaunchableMarketChartContainer = tw.div`flex h-fit w-[25rem] flex-col gap-1 rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]`;
+
+const $ChartContainerHeader = tw.div`flex flex-row items-center justify-between`;
+
+const $Details = styled(Details)`
+  & > div {
+    &:first-of-type {
+      padding-left: 0;
+    }
+  }
+`;
+
+const $ToggleGroup = styled(ToggleGroup)`
+  button {
+    --button-backgroundColor: transparent;
+    --button-border: none;
+
+    &[data-state='on'],
+    &[data-state='active'] {
+      --button-backgroundColor: transparent;
+      --button-border: none;
+    }
+
+    &:last-of-type {
+      padding-right: 0;
+    }
+  }
+` as typeof ToggleGroup;
+
+const $ChartContainer = tw.div`h-[8.75rem] rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]`;

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -85,15 +85,14 @@ export const NewMarketForm = () => {
       return <NewMarketSuccessStep href="" />;
     }
 
-    if (true) {
-      // (NewMarketFormStep.PREVIEW === step && tickerToAdd) {
+    if (NewMarketFormStep.PREVIEW === step && tickerToAdd) {
       return (
         <NewMarketPreviewStep2
           onSuccess={() => {
             setStep(NewMarketFormStep.SUCCESS);
           }}
           onBack={() => setStep(NewMarketFormStep.SELECTION)}
-          ticker={'ETH-USD'}
+          ticker={tickerToAdd}
           receiptItems={receiptItems}
         />
       );

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -51,12 +51,12 @@ export const NewMarketForm = () => {
     return [
       {
         key: 'deposit-apr',
-        label: 'Deposit APR (30d)',
+        label: `${stringGetter({ key: STRING_KEYS.DEPOSIT_APR })} (30${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })})`,
         value: <Output type={OutputType.Percent} value={0.3256} />,
       },
       {
         key: 'deposit-lockup',
-        label: 'Deposit Lockup',
+        label: stringGetter({ key: STRING_KEYS.DEPOSIT_LOCKUP }),
         value: <Output type={OutputType.Percent} value={0.3256} />,
       },
       {
@@ -85,14 +85,15 @@ export const NewMarketForm = () => {
       return <NewMarketSuccessStep href="" />;
     }
 
-    if (NewMarketFormStep.PREVIEW === step && tickerToAdd) {
+    if (true) {
+      // (NewMarketFormStep.PREVIEW === step && tickerToAdd) {
       return (
         <NewMarketPreviewStep2
           onSuccess={() => {
             setStep(NewMarketFormStep.SUCCESS);
           }}
           onBack={() => setStep(NewMarketFormStep.SELECTION)}
-          ticker={tickerToAdd}
+          ticker={'ETH-USD'}
           receiptItems={receiptItems}
         />
       );

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -63,10 +63,22 @@ export const NewMarketPreviewStep = ({
 
   const heading = (
     <>
-      <h2>Confirm Launch Details</h2>
+      <h2>{stringGetter({ key: STRING_KEYS.CONFIRM_LAUNCH_DETAILS })}</h2>
       <span tw="text-color-text-0">
-        The deposit lockup is 30 days and your deposit will earn an estimated 34.56% APR (based on
-        the last 30 days).
+        {stringGetter({
+          key: STRING_KEYS.DEPOSIT_LOCKUP_DESCRIPTION,
+          params: {
+            NUM_DAYS: <span tw="text-color-text-1">30</span>,
+            PAST_DAYS: 30,
+            APR_PERCENTAGE: (
+              <Output
+                type={OutputType.Percent}
+                tw="inline-block text-color-success"
+                value={0.3456}
+              />
+            ),
+          },
+        })}
       </span>
     </>
   );
@@ -74,7 +86,9 @@ export const NewMarketPreviewStep = ({
   const launchVisualization = (
     <div tw="mx-auto flex flex-row items-center gap-0.25">
       <div tw="flex flex-col items-center justify-center gap-0.5">
-        <span tw="text-small text-color-text-0">Amount to Deposit</span>
+        <span tw="text-small text-color-text-0">
+          {stringGetter({ key: STRING_KEYS.AMOUNT_TO_DEPOSIT })}
+        </span>
         <div tw="flex w-[9.375rem] flex-col items-center justify-center gap-0.5 rounded-[0.625rem] bg-color-layer-4 py-1">
           <AssetIcon tw="h-2 w-2" symbol="USDC" />
           <Output useGrouping type={OutputType.Fiat} value={10_000} />
@@ -84,7 +98,9 @@ export const NewMarketPreviewStep = ({
       <Icon iconName={IconName.FastForward} tw="mt-[1.45rem] h-[1rem] w-[1rem] text-color-text-0" />
 
       <div tw="flex flex-col items-center justify-center gap-0.5">
-        <span tw="text-small text-color-text-0">Market to Launch</span>
+        <span tw="text-small text-color-text-0">
+          {stringGetter({ key: STRING_KEYS.MARKET_TO_LAUNCH })}
+        </span>
         <div tw="flex w-[9.375rem] flex-col items-center justify-center gap-0.5 rounded-[0.625rem] bg-color-layer-4 py-1">
           <AssetIcon tw="h-2 w-2" symbol="ETH" />
           <Output useGrouping type={OutputType.Text} value="ETH" />
@@ -96,7 +112,14 @@ export const NewMarketPreviewStep = ({
   const liquidityTier = (
     <div tw="relative flex flex-col gap-0.75 rounded-[0.625rem] bg-color-layer-2 p-1">
       <span tw="text-base text-color-text-0">
-        Liquidity Tier is <span tw="text-color-text-1">Long-tail</span>
+        {stringGetter({
+          key: STRING_KEYS.LIQUIDITY_TIER_IS,
+          params: {
+            TIER: (
+              <span tw="text-color-text-1">{stringGetter({ key: STRING_KEYS.LONG_TAIL })}</span>
+            ),
+          },
+        })}
       </span>
       <$Details
         layout="rowColumns"

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -22,7 +22,7 @@ import { DiffOutput } from '@/components/DiffOutput';
 import { FormInput } from '@/components/FormInput';
 import { InputType } from '@/components/Input';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
-import { OutputType } from '@/components/Output';
+import { Output, OutputType } from '@/components/Output';
 import { SearchSelectMenu } from '@/components/SearchSelectMenu';
 import { Tag } from '@/components/Tag';
 import { WithDetailsReceipt } from '@/components/WithDetailsReceipt';
@@ -60,14 +60,29 @@ export const NewMarketSelectionStep = ({
     return (
       <>
         <h2>
-          Launch a Market
+          {stringGetter({ key: STRING_KEYS.LAUNCH_A_MARKET })}
           <span tw="flex flex-row items-center text-small text-color-text-1">
-            <LightningBoltIcon tw="text-color-warning" /> Trade Instantly
+            <LightningBoltIcon tw="text-color-warning" />{' '}
+            {stringGetter({ key: STRING_KEYS.TRADE_INSTANTLY })}
           </span>
         </h2>
         <span tw="text-base text-color-text-0">
-          Select the market you’d like to launch and deposit $10,000 into MegaVault. Your deposit
-          will earn an estimated 34.56% APR (based on the last 30 days).
+          {stringGetter({
+            key: STRING_KEYS.MARKET_LAUNCH_DETAILS,
+            params: {
+              APR_PERCENTAGE: (
+                <Output
+                  type={OutputType.Percent}
+                  tw="inline-block text-color-success"
+                  value={0.3456}
+                />
+              ),
+              DEPOSIT_AMOUNT: (
+                <Output useGrouping type={OutputType.Fiat} tw="inline-block" value={10_000} />
+              ),
+              PAST_DAYS: 30,
+            },
+          })}
         </span>
       </>
     );
@@ -134,7 +149,7 @@ export const NewMarketSelectionStep = ({
           >
             <FormInput
               type={InputType.Currency}
-              label="Required Amount to Deposit"
+              label={stringGetter({ key: STRING_KEYS.REQUIRED_AMOUNT_TO_DEPOSIT })}
               placeholder="$10,000"
               value="$10000"
             />
@@ -154,7 +169,7 @@ export const NewMarketSelectionStep = ({
                 state={{ isDisabled: !tickerToAdd }}
                 action={ButtonAction.Primary}
               >
-                Preview Launch
+                {stringGetter({ key: STRING_KEYS.PREVIEW_LAUNCH })}
               </Button>
             )}
           </WithReceipt>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1536" alt="Screen Shot 2024-08-26 at 11 58 42 AM" src="https://github.com/user-attachments/assets/04ec04ee-0b1a-482c-aee3-edebbd7dadad">
<img width="1530" alt="Screen Shot 2024-08-26 at 11 58 17 AM" src="https://github.com/user-attachments/assets/494e3a71-71c6-4552-a605-c207911ccf38">

<!-- Overall purpose of the PR -->
- Clean up and localization of PML widget

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* New: `<LaunchableMarketChart>`
  * Small visualization of important details of a Launchable Markets. Also includes a price chart.

* `<LaunchMarket>`
  * Localize page and move some elements to a new component: `LaunchableMarketChart`

* Remove hardcoded copy and  localize all other views

## Packages

* `v4-localization`
  * Add PML strings
  * updated: v1.1.177 -> v1.1.182

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
