### PR TITLE
fix: hide right toolbar in TradingView

### DIFF
--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -242,7 +242,7 @@ export const getWidgetOptions = (): Partial<TradingTerminalWidgetOptions> &
       'hide_last_na_study_output',
       'dont_show_boolean_study_arguments',
       'hide_left_toolbar_by_default',
-      'keep_object_tree_widget_in_right_toolbar',
+      'hide_right_toolbar',
     ],
   };
 };


### PR DESCRIPTION
This hides the right toolbar which shows the "Object tree" menu by default. Unfortunately it doesn't look like there's a way to only hide it by default but still make it expandable, but I think hiding it is better than showing it for now 🙏 

![image](https://github.com/user-attachments/assets/22c4fdad-ade4-4d2b-a7fd-3eaa4e4b16dc)
