### PR TITLE
feat: filter out solana chain for other wallets

### DIFF
--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -97,13 +97,17 @@ export const SourceSelectMenu = ({
       [feesDecoratorProp]: getFeeDecoratorComponentForChainId(chain.type),
     }))
     .filter((chain) => {
+      // only cosmos chains are supported on kepler
       if (isKeplrWallet) {
         return selectedDydxChainId !== chain.value && SUPPORTED_COSMOS_CHAINS.includes(chain.value);
       }
       // only solana chains are supported on phantom
-      if (walletType === WalletType.Phantom && !chain.value.startsWith(solanaChainIdPrefix)) {
-        return false;
+      if (walletType === WalletType.Phantom) {
+        return selectedDydxChainId !== chain.value && chain.value.startsWith(solanaChainIdPrefix);
       }
+      // other wallets do not support solana
+      if (chain.value.startsWith(solanaChainIdPrefix)) return false;
+
       return true;
     })
     .filter((chain) => {


### PR DESCRIPTION
Only phantom wallet supports solana as a deposit option