### PR TITLE
fix(notif): update matic wind down date

### DIFF
--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -471,14 +471,14 @@ export const notificationTypes: NotificationTypeConfig[] = [
       const maticWindDownProposal = dynamicConfigs?.[StatsigDynamicConfigs.dcMaticProposalNotif];
       const { contractLossMechanismLearnMore } = useURLConfigs();
 
-      const MATICWindDownProposalExpirationDate = '2024-09-04';
+      const MATICWindDownProposalExpirationDate = '2024-09-02T14:33:25.000Z';
       const MATICWindDownDate = MATICWindDownProposalExpirationDate;
-      const MATICWindDownExpirationDate = '2024-10-04';
+      const MATICWindDownExpirationDate = '2024-10-04T23:59:59.000Z';
       const MATICMarket = 'MATIC-USD';
 
       const currentDate = new Date();
       const outputDate = (
-        <Output tw="inline-block" type={OutputType.Date} value={MATICWindDownDate} />
+        <Output tw="inline-block" type={OutputType.DateTime} value={MATICWindDownDate} />
       );
 
       useEffect(() => {


### PR DESCRIPTION
(time is correct given my current time zone) 
<img width="304" alt="Screenshot 2024-08-30 at 12 35 14 AM" src="https://github.com/user-attachments/assets/a7ab4206-6a54-4b62-af07-dbcd0cb1bd32">
<img width="289" alt="Screenshot 2024-08-30 at 12 37 42 AM" src="https://github.com/user-attachments/assets/e648f15c-938b-4909-b1e5-d59e6469579e">



