### PR TITLE
fix: validate withdraw form address by destination type instead of wallet type

### DIFF
--- a/src/lib/addressUtils.ts
+++ b/src/lib/addressUtils.ts
@@ -1,4 +1,5 @@
 import { fromBech32, fromHex, toBech32, toHex } from '@cosmjs/encoding';
+import { isAddress } from 'viem';
 
 /**
  *
@@ -36,4 +37,19 @@ export function validateCosmosAddress(address: string, prefix: string) {
     // If decoding fails, the address is not valid
     return false;
   }
+}
+
+type MultiChainAddress =
+  | { address?: string | null; network: 'cosmos'; prefix: string }
+  | { address?: string | null; network: 'evm' };
+
+// TODO: Add unit test once `isAddress` works with vitest
+export function isValidAddress(input: MultiChainAddress): boolean {
+  if (!input.address) return false;
+
+  if (input.network === 'evm') {
+    return isAddress(input.address, { strict: true }); // enable checksum matching
+  }
+
+  return validateCosmosAddress(input.address, input.prefix);
 }

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -106,18 +106,16 @@ export const WithdrawForm = () => {
   const { usdcWithdrawalCapacity } = useWithdrawalInfo({ transferType: 'withdrawal' });
 
   const isValidDestinationAddress = useMemo(() => {
-    let prefix = exchange ? 'noble' : '';
-    if (walletType === WalletType.Keplr) {
-      prefix =
-        GRAZ_CHAINS.find((chain) => chain.chainId === chainIdStr)?.bech32Config
-          .bech32PrefixAccAddr ?? '';
-    }
+    const grazChainPrefix =
+      GRAZ_CHAINS.find((chain) => chain.chainId === chainIdStr)?.bech32Config.bech32PrefixAccAddr ??
+      '';
+    const prefix = exchange ? 'noble' : grazChainPrefix;
     return isValidAddress({
       address: toAddress,
       network: exchange || walletType === WalletType.Keplr ? 'cosmos' : 'evm',
       prefix,
     });
-  }, [toAddress, exchange]);
+  }, [exchange, walletType, toAddress, chainIdStr]);
 
   const toToken = useMemo(
     () => (token ? resources?.tokenResources?.get(token) : undefined),

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -11,7 +11,12 @@ import { AlertType } from '@/constants/alerts';
 import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
 import { NEUTRON_USDC_IBC_DENOM, OSMO_USDC_IBC_DENOM } from '@/constants/denoms';
-import { getNeutronChainId, getNobleChainId, getOsmosisChainId } from '@/constants/graz';
+import {
+  getNeutronChainId,
+  getNobleChainId,
+  getOsmosisChainId,
+  GRAZ_CHAINS,
+} from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
 import { TransferNotificationTypes } from '@/constants/notifications';
@@ -101,10 +106,16 @@ export const WithdrawForm = () => {
   const { usdcWithdrawalCapacity } = useWithdrawalInfo({ transferType: 'withdrawal' });
 
   const isValidDestinationAddress = useMemo(() => {
+    let prefix = exchange ? 'noble' : '';
+    if (walletType === WalletType.Keplr) {
+      prefix =
+        GRAZ_CHAINS.find((chain) => chain.chainId === chainIdStr)?.bech32Config
+          .bech32PrefixAccAddr ?? '';
+    }
     return isValidAddress({
       address: toAddress,
-      network: exchange ? 'cosmos' : 'evm',
-      prefix: exchange ? 'noble' : '',
+      network: exchange || walletType === WalletType.Keplr ? 'cosmos' : 'evm',
+      prefix,
     });
   }, [toAddress, exchange]);
 

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -112,10 +112,10 @@ export const WithdrawForm = () => {
     const prefix = exchange ? 'noble' : grazChainPrefix;
     return isValidAddress({
       address: toAddress,
-      network: exchange || walletType === WalletType.Keplr ? 'cosmos' : 'evm',
+      network: prefix ? 'cosmos' : 'evm',
       prefix,
     });
-  }, [exchange, walletType, toAddress, chainIdStr]);
+  }, [exchange, toAddress, chainIdStr]);
 
   const toToken = useMemo(
     () => (token ? resources?.tokenResources?.get(token) : undefined),

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -5,19 +5,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { NumberFormatValues } from 'react-number-format';
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
-import { isAddress } from 'viem';
 
 import { TransferInputField, TransferInputTokenResource, TransferType } from '@/constants/abacus';
 import { AlertType } from '@/constants/alerts';
 import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonSize } from '@/constants/buttons';
 import { NEUTRON_USDC_IBC_DENOM, OSMO_USDC_IBC_DENOM } from '@/constants/denoms';
-import {
-  getNeutronChainId,
-  getNobleChainId,
-  getOsmosisChainId,
-  GRAZ_CHAINS,
-} from '@/constants/graz';
+import { getNeutronChainId, getNobleChainId, getOsmosisChainId } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { isMainnet } from '@/constants/networks';
 import { TransferNotificationTypes } from '@/constants/notifications';
@@ -65,7 +59,7 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import abacusStateManager from '@/lib/abacus';
-import { validateCosmosAddress } from '@/lib/addressUtils';
+import { isValidAddress } from '@/lib/addressUtils';
 import { track } from '@/lib/analytics/analytics';
 import { getRouteErrorMessageOverride } from '@/lib/errors';
 import { MustBigNumber } from '@/lib/numbers';
@@ -106,20 +100,13 @@ export const WithdrawForm = () => {
   const { usdcLabel } = useTokenConfigs();
   const { usdcWithdrawalCapacity } = useWithdrawalInfo({ transferType: 'withdrawal' });
 
-  const isValidAddress = useMemo(() => {
-    if (toAddress) {
-      if (walletType === WalletType.Keplr) {
-        const prefix = GRAZ_CHAINS.find((chain) => chain.chainId === chainIdStr)?.bech32Config
-          .bech32PrefixAccAddr;
-
-        if (prefix) {
-          return validateCosmosAddress(toAddress, prefix);
-        }
-      }
-      return isAddress(toAddress);
-    }
-    return false;
-  }, [chainIdStr, toAddress, walletType]);
+  const isValidDestinationAddress = useMemo(() => {
+    return isValidAddress({
+      address: toAddress,
+      network: exchange ? 'cosmos' : 'evm',
+      prefix: exchange ? 'noble' : '',
+    });
+  }, [toAddress, exchange]);
 
   const toToken = useMemo(
     () => (token ? resources?.tokenResources?.get(token) : undefined),
@@ -356,7 +343,7 @@ export const WithdrawForm = () => {
         value: nobleChainId,
       });
     }
-  }, [walletType]);
+  }, [nobleChainId, walletType]);
 
   const onSelectNetwork = useCallback(
     (name: string, type: 'chain' | 'exchange') => {
@@ -475,7 +462,7 @@ export const WithdrawForm = () => {
         }),
       };
 
-    if (!isValidAddress) {
+    if (!isValidDestinationAddress) {
       return {
         errorMessage: stringGetter({
           key: STRING_KEYS.ENTER_VALID_ADDRESS,
@@ -569,22 +556,18 @@ export const WithdrawForm = () => {
     stringGetter,
     summary,
     usdcWithdrawalCapacity,
-    isValidAddress,
+    isValidDestinationAddress,
   ]);
-
-  const isInvalidNobleAddress = Boolean(
-    exchange && toAddress && !validateCosmosAddress(toAddress, 'noble')
-  );
 
   const isDisabled =
     !!errorMessage ||
     !toToken ||
     (!chainIdStr && !exchange) ||
-    !toAddress ||
     debouncedAmountBN.isNaN() ||
     debouncedAmountBN.isZero() ||
     isLoading ||
-    isInvalidNobleAddress;
+    !isValidDestinationAddress;
+
   const skipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
 
   return (
@@ -614,7 +597,7 @@ export const WithdrawForm = () => {
           label={
             <span>
               {stringGetter({ key: STRING_KEYS.DESTINATION })}{' '}
-              {isValidAddress ? (
+              {isValidDestinationAddress ? (
                 <Icon
                   iconName={IconName.Check}
                   tw="mx-[1ch] my-0 text-[0.625rem] text-color-success"
@@ -629,7 +612,7 @@ export const WithdrawForm = () => {
           onSelect={onSelectNetwork}
         />
       </div>
-      {isInvalidNobleAddress && (
+      {toAddress && Boolean(exchange) && !isValidDestinationAddress && (
         <AlertMessage type={AlertType.Error}>
           {stringGetter({ key: STRING_KEYS.NOBLE_ADDRESS_VALIDATION })}
         </AlertMessage>


### PR DESCRIPTION
This PR updates the logic to combine the `isValidAddress` check for both evm and noble to be in the same place. And removes the logic to only validate cosmos addresses if the user is connected to Keplr.

<img width="556" alt="image" src="https://github.com/user-attachments/assets/0f5c3ac2-1afa-47d1-a6a9-cb2378489413">
<img width="511" alt="image" src="https://github.com/user-attachments/assets/a137abf8-69ea-4902-8f50-a4b2c748e149">
<img width="572" alt="image" src="https://github.com/user-attachments/assets/8345966b-4bbb-48a4-b6f6-f83e84d901f2">
