### PR TITLE
style(marketDropdown): remove label

### DIFF
--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -292,7 +292,7 @@ export const MarketsDropdown = memo(
                 </div>
               )}
               <p tw="row gap-0.5 text-color-text-0 font-small-book">
-                {stringGetter({ key: isOpen ? STRING_KEYS.TAP_TO_CLOSE : STRING_KEYS.ALL_MARKETS })}
+                {isOpen && stringGetter({ key: STRING_KEYS.TAP_TO_CLOSE })}
                 <DropdownIcon isOpen={isOpen} />
               </p>
             </$TriggerContainer>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/23a3eb42-8f0c-4cf0-ba06-4c381fcf55ed) | <img width="422" alt="Screen Shot 2024-08-30 at 1 11 12 PM" src="https://github.com/user-attachments/assets/65690349-96e2-4374-a69f-bcd74dac2151"> |

<!-- Overall purpose of the PR -->

Add additional space to the MarketsDropdown so tickers do not wrap.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketsDropdown>`
  * Remove `All Markets` label

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
