### PR TITLE
feat: disable coinbase smart wallet

### DIFF
--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -223,6 +223,8 @@ export const resolveWagmiConnector = ({
     return coinbaseWalletConnector({
       appName: 'dYdX',
       reloadOnDisconnect: false,
+      // disable Coinbase Smart Wallet because dydx-client currently doesn't handle EIP-6492 signatures
+      preference: 'eoaOnly',
     });
   }
 


### PR DESCRIPTION
This PR disables using smart wallets through Coinbase's wallet connector.

|Before|After|
|------|------|
|<img width="461" alt="image" src="https://github.com/user-attachments/assets/0cef5fd1-edcf-42ac-8095-fc9368df185e">|<img width="479" alt="image" src="https://github.com/user-attachments/assets/59e77455-b0e5-44ab-b923-8cb24dd5fa39">|

^^ Note these only show up if the user doesn't have the extension wallet installed.
