### PR TITLE
fix: remove duplicate transfer notification steps

### DIFF
--- a/src/views/notifications/TransferStatusNotification/index.tsx
+++ b/src/views/notifications/TransferStatusNotification/index.tsx
@@ -174,6 +174,7 @@ export const TransferStatusNotification = ({
           )}
         </>
       )}
+      <div>{stringGetter({ key: STRING_KEYS.KEEP_WINDOW_OPEN })}</div>
       {!isToast && !isComplete && !hasError && !isCosmosDeposit && (
         <TransferStatusSteps status={status} type={type} tw="px-0 pb-0 pt-0.5" />
       )}
@@ -198,17 +199,7 @@ export const TransferStatusNotification = ({
               </div>
             </>
           ) : (
-            <>
-              {content}
-              {!isCosmosDeposit && !isComplete && (
-                <>
-                  <div>{stringGetter({ key: STRING_KEYS.KEEP_WINDOW_OPEN })}</div>
-                  {!isToast && !hasError && (
-                    <TransferStatusSteps status={status} type={type} tw="px-0 pb-0 pt-0.5" />
-                  )}
-                </>
-              )}
-            </>
+            content
           )}
         </div>
       }


### PR DESCRIPTION
TransferStatusSteps ended up getting rendered twice in the notifications. This was introduced due a bad merge conflict.