### PR TITLE
refactor(launch-market-dialog): add callback to set title/description within dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy:update-ipns": "node scripts/update-ipns.js",
     "deploy:update-dnslink": "node scripts/update-dnslink.js",
     "coverage": "vitest run --coverage",
-    "clean-install": "rm -rf node_modules/ && pnpm i",
+    "clean-install": "rm -rf node_modules/.vite && pnpm i",
     "preview": "vite preview",
     "install-local-abacus": "node scripts/install-local-abacus",
     "install-local-l10n": "pnpm link ../v4-localization && echo Linking... please remember to restart your dev server",

--- a/src/lib/__test__/assetUtils.spec.ts
+++ b/src/lib/__test__/assetUtils.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getDisplayableAssetFromBaseAsset,
+  getDisplayableAssetFromTicker,
   getDisplayableTickerFromMarket,
   getTickerFromMarketmapId,
 } from '../assetUtils';
@@ -47,6 +48,38 @@ describe('getDisplayableAssetFromBaseAsset', () => {
 
   it('should return blank dex if invalid asset is provided', () => {
     expect(getDisplayableAssetFromBaseAsset('', 'dex')).toEqual('');
+  });
+});
+
+describe('getDisplayableAssetFromTicker', () => {
+  it('should return the base asset from a ticker string', () => {
+    expect(getDisplayableAssetFromTicker(`${ASSET_WITH_DEX_AND_ADDRESS}-USD`)).toEqual('BUFFI');
+  });
+
+  it('should handle existing base asset with no dex or address', () => {
+    expect(getDisplayableAssetFromTicker('ETH-USD')).toEqual('ETH');
+  });
+
+  it('should handle empty ticker strings', () => {
+    expect(getDisplayableAssetFromTicker('')).toEqual('');
+  });
+
+  it('should return dex from ticker string', () => {
+    expect(getDisplayableAssetFromTicker(`${ASSET_WITH_DEX_AND_ADDRESS}-USD`, 'dex')).toEqual(
+      'uniswap_v3'
+    );
+  });
+
+  it('should return address from ticker string', () => {
+    expect(getDisplayableAssetFromTicker(`${ASSET_WITH_DEX_AND_ADDRESS}-USD`, 'address')).toEqual(
+      '0x4c1b1302220d7de5c22b495e78b72f2dd2457d45'
+    );
+  });
+
+  it('should return full base asset from ticker string', () => {
+    expect(getDisplayableAssetFromTicker(`${ASSET_WITH_DEX_AND_ADDRESS}-USD`, 'full')).toEqual(
+      ASSET_WITH_DEX_AND_ADDRESS
+    );
   });
 });
 

--- a/src/lib/assetUtils.ts
+++ b/src/lib/assetUtils.ts
@@ -1,7 +1,7 @@
 /**
  *
  * @param fullBaseAsset contains base asset, occassionally accompanied (comma-separated) by dex and address. i.e. 'baseAsset,dex,address'
- * @param part
+ * @param part base, dex or address
  * @returns base asset or dex or address from the full base asset.
  */
 export const getDisplayableAssetFromBaseAsset = (
@@ -12,6 +12,21 @@ export const getDisplayableAssetFromBaseAsset = (
   if (part === 'dex') return dex;
   if (part === 'address') return address;
   return base;
+};
+
+/**
+ *
+ * @param ticker baseAsset-quoteAsset
+ * @param part base, dex or address
+ * @returns desired part of the base asset from ticker
+ */
+export const getDisplayableAssetFromTicker = (
+  ticker: string,
+  part?: 'base' | 'dex' | 'address' | 'full'
+): string => {
+  const [fullBaseAsset] = ticker.split('-');
+  if (part === 'full') return fullBaseAsset;
+  return getDisplayableAssetFromBaseAsset(fullBaseAsset, part);
 };
 
 /**

--- a/src/views/dialogs/LaunchMarketDialog.tsx
+++ b/src/views/dialogs/LaunchMarketDialog.tsx
@@ -1,21 +1,100 @@
+import { useMemo, useState } from 'react';
+
+import { LightningBoltIcon } from '@radix-ui/react-icons';
+import styled from 'styled-components';
+
 import { DialogProps, LaunchMarketDialogProps } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Dialog, DialogPlacement } from '@/components/Dialog';
+import { Output, OutputType } from '@/components/Output';
 
-import { NewMarketForm } from '../forms/NewMarketForm';
+import { NewMarketForm, NewMarketFormStep } from '../forms/NewMarketForm';
 
 export const LaunchMarketDialog = ({ setIsOpen }: DialogProps<LaunchMarketDialogProps>) => {
   const { isMobile } = useBreakpoints();
+  const [formStep, setFormStep] = useState<NewMarketFormStep>();
+  const stringGetter = useStringGetter();
+
+  const { title, description } = useMemo(() => {
+    switch (formStep) {
+      case NewMarketFormStep.SELECTION:
+        return {
+          title: (
+            <$Title>
+              {stringGetter({ key: STRING_KEYS.LAUNCH_A_MARKET })}
+              <span tw="flex flex-row items-center text-small text-color-text-1">
+                <LightningBoltIcon tw="text-color-warning" />{' '}
+                {stringGetter({ key: STRING_KEYS.TRADE_INSTANTLY })}
+              </span>
+            </$Title>
+          ),
+          description: stringGetter({
+            key: STRING_KEYS.MARKET_LAUNCH_DETAILS,
+            params: {
+              APR_PERCENTAGE: (
+                <Output
+                  type={OutputType.Percent}
+                  tw="inline-block text-color-success"
+                  value={0.3456}
+                />
+              ),
+              DEPOSIT_AMOUNT: (
+                <Output useGrouping type={OutputType.Fiat} tw="inline-block" value={10_000} />
+              ),
+              PAST_DAYS: 30,
+            },
+          }),
+        };
+      case NewMarketFormStep.PREVIEW:
+        return {
+          title: <$Title>{stringGetter({ key: STRING_KEYS.CONFIRM_LAUNCH_DETAILS })}</$Title>,
+          description: stringGetter({
+            key: STRING_KEYS.DEPOSIT_LOCKUP_DESCRIPTION,
+            params: {
+              NUM_DAYS: <span tw="text-color-text-1">30</span>,
+              PAST_DAYS: 30,
+              APR_PERCENTAGE: (
+                <Output
+                  type={OutputType.Percent}
+                  tw="inline-block text-color-success"
+                  value={0.3456}
+                />
+              ),
+            },
+          }),
+        };
+      case NewMarketFormStep.SUCCESS:
+      default:
+        return {
+          title: null,
+          description: null,
+        };
+    }
+  }, [formStep, stringGetter]);
 
   return (
     <Dialog
       isOpen
+      title={title}
+      description={description}
       setIsOpen={setIsOpen}
       placement={isMobile ? DialogPlacement.FullScreen : DialogPlacement.Default}
     >
-      <NewMarketForm />
+      <NewMarketForm setFormStep={setFormStep} />
     </Dialog>
   );
 };
+
+const $Title = styled.h2`
+  ${layoutMixins.row}
+  justify-content: space-between;
+  margin: 0;
+  font: var(--font-large-medium);
+  color: var(--color-text-2);
+`;

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useMemo, useState } from 'react';
 
 import { STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS } from '@/constants/numbers';
@@ -23,13 +23,17 @@ import { NewMarketSuccessStep } from './NewMarketSuccessStep';
 import { NewMarketPreviewStep as NewMarketPreviewStep2 } from './v7/NewMarketPreviewStep';
 import { NewMarketSelectionStep as NewMarketSelectionStep2 } from './v7/NewMarketSelectionStep';
 
-enum NewMarketFormStep {
+export enum NewMarketFormStep {
   SELECTION,
   PREVIEW,
   SUCCESS,
 }
 
-export const NewMarketForm = () => {
+export const NewMarketForm = ({
+  setFormStep,
+}: {
+  setFormStep?: Dispatch<SetStateAction<NewMarketFormStep | undefined>>;
+}) => {
   const [step, setStep] = useState(NewMarketFormStep.SELECTION);
   const [assetToAdd, setAssetToAdd] = useState<NewMarketProposal>();
   const [tickerToAdd, setTickerToAdd] = useState<string>();
@@ -46,6 +50,12 @@ export const NewMarketForm = () => {
     const p = Math.floor(Math.log(Number(assetToAdd.meta.referencePrice)));
     return Math.abs(p - 3);
   }, [assetToAdd]);
+
+  useEffect(() => {
+    setFormStep?.(step);
+  }, [setFormStep, step]);
+
+  const shouldHideTitleAndDescription = setFormStep !== undefined;
 
   const receiptItems: DetailsItem[] = useMemo(() => {
     return [
@@ -92,8 +102,9 @@ export const NewMarketForm = () => {
             setStep(NewMarketFormStep.SUCCESS);
           }}
           onBack={() => setStep(NewMarketFormStep.SELECTION)}
-          ticker={tickerToAdd}
           receiptItems={receiptItems}
+          shouldHideTitleAndDescription={shouldHideTitleAndDescription}
+          ticker={tickerToAdd}
         />
       );
     }
@@ -103,9 +114,10 @@ export const NewMarketForm = () => {
         onConfirmMarket={() => {
           setStep(NewMarketFormStep.PREVIEW);
         }}
-        setTickerToAdd={setTickerToAdd}
-        tickerToAdd={tickerToAdd}
         receiptItems={receiptItems}
+        setTickerToAdd={setTickerToAdd}
+        shouldHideTitleAndDescription={shouldHideTitleAndDescription}
+        tickerToAdd={tickerToAdd}
       />
     );
   }

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -22,6 +22,7 @@ import { Output, OutputType } from '@/components/Output';
 import { useAppDispatch } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
 
+import { getDisplayableAssetFromTicker } from '@/lib/assetUtils';
 import { log } from '@/lib/telemetry';
 
 type NewMarketPreviewStepProps = {
@@ -62,6 +63,9 @@ export const NewMarketPreviewStep = ({
   }, [errorMessage]);
 
   const isDisabled = alertMessage !== null;
+
+  const baseAsset = getDisplayableAssetFromTicker(ticker);
+  const fullBaseAsset = getDisplayableAssetFromTicker(ticker, 'full');
 
   const heading = shouldHideTitleAndDescription ? null : (
     <>
@@ -104,8 +108,8 @@ export const NewMarketPreviewStep = ({
           {stringGetter({ key: STRING_KEYS.MARKET_TO_LAUNCH })}
         </span>
         <div tw="flex w-[9.375rem] flex-col items-center justify-center gap-0.5 rounded-[0.625rem] bg-color-layer-4 py-1">
-          <AssetIcon tw="h-2 w-2" symbol="ETH" />
-          <Output useGrouping type={OutputType.Text} value="ETH" />
+          <AssetIcon tw="h-2 w-2" symbol={fullBaseAsset} />
+          <Output useGrouping type={OutputType.Text} value={baseAsset} />
         </div>
       </div>
     </div>

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -29,6 +29,7 @@ type NewMarketPreviewStepProps = {
   onBack: () => void;
   onSuccess: (ticker: string) => void;
   receiptItems: DetailsItem[];
+  shouldHideTitleAndDescription?: boolean;
 };
 
 export const NewMarketPreviewStep = ({
@@ -36,6 +37,7 @@ export const NewMarketPreviewStep = ({
   onBack,
   onSuccess,
   receiptItems,
+  shouldHideTitleAndDescription,
 }: NewMarketPreviewStepProps) => {
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
@@ -61,7 +63,7 @@ export const NewMarketPreviewStep = ({
 
   const isDisabled = alertMessage !== null;
 
-  const heading = (
+  const heading = shouldHideTitleAndDescription ? null : (
     <>
       <h2>{stringGetter({ key: STRING_KEYS.CONFIRM_LAUNCH_DETAILS })}</h2>
       <span tw="text-color-text-0">

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -37,6 +37,7 @@ type NewMarketSelectionStepProps = {
   setTickerToAdd: (ticker: string) => void;
   onConfirmMarket: () => void;
   receiptItems: DetailsItem[];
+  shouldHideTitleAndDescription?: boolean;
 };
 
 export const NewMarketSelectionStep = ({
@@ -44,6 +45,7 @@ export const NewMarketSelectionStep = ({
   setTickerToAdd,
   onConfirmMarket,
   receiptItems,
+  shouldHideTitleAndDescription,
 }: NewMarketSelectionStepProps) => {
   const onboardingState = useAppSelector(getOnboardingState);
   const isDisconnected = onboardingState === OnboardingState.Disconnected;
@@ -57,6 +59,8 @@ export const NewMarketSelectionStep = ({
   }, []);
 
   const formHeader = useMemo(() => {
+    if (shouldHideTitleAndDescription) return null;
+
     return (
       <>
         <h2>
@@ -86,7 +90,7 @@ export const NewMarketSelectionStep = ({
         </span>
       </>
     );
-  }, []);
+  }, [shouldHideTitleAndDescription]);
 
   return (
     <$Form

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -32,6 +32,8 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 import { getOnboardingState } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
+import { getDisplayableAssetFromBaseAsset, getDisplayableTickerFromMarket } from '@/lib/assetUtils';
+
 type NewMarketSelectionStepProps = {
   tickerToAdd?: string;
   setTickerToAdd: (ticker: string) => void;
@@ -90,7 +92,9 @@ export const NewMarketSelectionStep = ({
         </span>
       </>
     );
-  }, [shouldHideTitleAndDescription]);
+  }, [shouldHideTitleAndDescription, stringGetter]);
+
+  const shortenedTicker = tickerToAdd ? getDisplayableTickerFromMarket(tickerToAdd) : tickerToAdd;
 
   return (
     <$Form
@@ -113,8 +117,10 @@ export const NewMarketSelectionStep = ({
                 items:
                   launchableMarkets.data?.map((launchableMarket) => ({
                     value: launchableMarket.id,
-                    label: launchableMarket.id,
-                    tag: launchableMarket.ticker.currency_pair.Base,
+                    label: getDisplayableTickerFromMarket(launchableMarket.id),
+                    tag: getDisplayableAssetFromBaseAsset(
+                      launchableMarket.ticker.currency_pair.Base
+                    ),
                     onSelect: () => {
                       setTickerToAdd(launchableMarket.id);
                     },
@@ -123,9 +129,9 @@ export const NewMarketSelectionStep = ({
             ]}
             label={stringGetter({ key: STRING_KEYS.MARKETS })}
           >
-            {tickerToAdd ? (
+            {shortenedTicker ? (
               <span tw="text-color-text-2">
-                {tickerToAdd} <Tag>{tickerToAdd}</Tag>
+                {shortenedTicker} <Tag>{shortenedTicker}</Tag>
               </span>
             ) : (
               `${stringGetter({ key: STRING_KEYS.EG })} "BTC-USD"`


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/user-attachments/assets/6a7d743e-291f-47f7-a7f6-0d06c12d0ce9


<!-- Overall purpose of the PR -->
LaunchMarketDialog is in charge of rendering title and description. This PR adds a callback that allows us to set title/description for the Dialog without needing to pull state outside of the NewMarketForm.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<LaunchMarketDialog>`
  * add callback to determine title/description

* `<NewMarketForm>`
  * Add prop for callback and call within a side effect tracking changes to `step`

* `<NewMarketPreviewStep>`, `<NewMarketSelectionStep>`
  * Hide title/description if being displayed within the LaunchMarketDialog 

## Functions

* `lib/assetUtils`
  * add another helper function to get baseAsset from ticker w/ tests 

## Packages

* `clean-install`
  * Update `clean-install` script to only delete `.vite` (this is what is cached) instead of the entirety of `node_modules` 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
