### PR TITLE
chore: update s6 notification w/ statsig + show total rewards

### DIFF
--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -226,12 +226,15 @@ export enum ReleaseUpdateNotificationIds {
 // Incentives Season
 export enum IncentivesDistributedNotificationIds {
   IncentivesDistributedS5 = 'incentives-distributed-s5',
+  IncentivesDistributedS6 = 'incentives-distributed-s6',
 }
 
 export const INCENTIVES_SEASON_NOTIFICATION_ID = ReleaseUpdateNotificationIds.IncentivesS6Ended;
 
 export function getSeasonRewardDistributionNumber(seasonId: IncentivesDistributedNotificationIds) {
   switch (seasonId) {
+    case IncentivesDistributedNotificationIds.IncentivesDistributedS6:
+      return 6;
     case IncentivesDistributedNotificationIds.IncentivesDistributedS5:
     default:
       return 5;

--- a/src/constants/statsig.ts
+++ b/src/constants/statsig.ts
@@ -11,6 +11,7 @@ export enum StatSigFlags {
   ffEnableEvmSwaps = 'ff_enable_evm_swaps',
   ffEnableKeplr = 'ff_enable_keplr',
   ffEnableAffiliates = 'ff_enable_affiliates',
+  ffIncentivesS6RewardsDistributed = 'ff_incentives_s6_rewards_distributed',
 }
 
 export type StatsigDynamicConfigType = Record<StatsigDynamicConfigs, any>;

--- a/src/hooks/useIncentivesSeason.ts
+++ b/src/hooks/useIncentivesSeason.ts
@@ -2,12 +2,18 @@ import {
   getSeasonRewardDistributionNumber,
   IncentivesDistributedNotificationIds,
 } from '@/constants/notifications';
+import { StatSigFlags } from '@/constants/statsig';
+
+import { useStatsigGateValue } from './useStatsig';
 
 export const useIncentivesSeason = () => {
-  // Add an env flag here for easy development + release of reward distribution notifications
+  // Add an env flag or statsig flag here for easy development + release of reward distribution notifications
   // Example: https://github.com/dydxprotocol/v4-web/pull/809
-  const incentivesDistributedSeasonId =
-    IncentivesDistributedNotificationIds.IncentivesDistributedS5;
+  const showS6 = useStatsigGateValue(StatSigFlags.ffIncentivesS6RewardsDistributed);
+  const incentivesDistributedSeasonId = showS6
+    ? IncentivesDistributedNotificationIds.IncentivesDistributedS6
+    : IncentivesDistributedNotificationIds.IncentivesDistributedS5;
+
   const rewardDistributionSeasonNumber = getSeasonRewardDistributionNumber(
     incentivesDistributedSeasonId
   );

--- a/src/hooks/useQueryChaosLabsIncentives.ts
+++ b/src/hooks/useQueryChaosLabsIncentives.ts
@@ -23,10 +23,43 @@ export const useQueryChaosLabsIncentives = ({
     queryFn: wrapAndLogError(
       async () => {
         if (!dydxAddress) return undefined;
-        const resp = await fetch(
-          `https://cloud.chaoslabs.co/query/api/dydx/points/${dydxAddress}?n=${season}`
+
+        // If season is defined, fetch for a specific season
+        if (season !== undefined) {
+          const resp = await fetch(
+            `https://cloud.chaoslabs.co/query/api/dydx/points/${dydxAddress}?n=${season}`
+          );
+          return resp.json();
+        }
+
+        // Fetch all seasons 1-6 and sum the points
+        const responses = await Promise.all(
+          [1, 2, 3, 4, 5, 6].map(async (szn) => {
+            const resp = await fetch(
+              `https://cloud.chaoslabs.co/query/api/dydx/points/${dydxAddress}?n=${szn}`
+            );
+            return resp.json();
+          })
         );
-        return resp.json();
+
+        // Sum up the points from all seasons
+        const summedData = responses.reduce(
+          (acc, curr) => {
+            return {
+              dydxRewards: acc.dydxRewards + (curr.dydxRewards || 0),
+              incentivePoints: acc.incentivePoints + (curr.incentivePoints || 0),
+              marketMakingIncentivePoints:
+                acc.marketMakingIncentivePoints + (curr.marketMakingIncentivePoints || 0),
+            };
+          },
+          {
+            dydxRewards: 0,
+            incentivePoints: 0,
+            marketMakingIncentivePoints: 0,
+          }
+        );
+
+        return summedData;
       },
       'LaunchIncentives/fetchPoints',
       true

--- a/src/pages/token/LaunchIncentivesPanel.tsx
+++ b/src/pages/token/LaunchIncentivesPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 
@@ -27,8 +26,6 @@ import { NewTag, TagSize } from '@/components/Tag';
 import { useAppDispatch } from '@/state/appTypes';
 import { markLaunchIncentivesSeen } from '@/state/configs';
 import { openDialog } from '@/state/dialogs';
-
-import { wrapAndLogError } from '@/lib/asyncUtils';
 
 export const LaunchIncentivesPanel = ({ className }: { className?: string }) => {
   const { isNotTablet } = useBreakpoints();
@@ -76,36 +73,7 @@ const EstimatedRewards = () => {
   const stringGetter = useStringGetter();
   const { dydxAddress } = useAccounts();
 
-  const { data: seasonNumber } = useQuery({
-    queryKey: ['chaos_labs_season_number'],
-    queryFn: wrapAndLogError(
-      async () => {
-        const resp = await fetch('https://cloud.chaoslabs.co/query/ccar-perpetuals', {
-          method: 'POST',
-          headers: {
-            'apollographql-client-name': 'dydx-v4',
-            'content-type': 'application/json',
-            protocol: 'dydx-v4',
-          },
-          body: JSON.stringify({
-            operationName: 'TradingSeasons',
-            variables: {},
-            query: `query TradingSeasons {
-        tradingSeasons {
-          label
-        }
-      }`,
-          }),
-        });
-        const seasons = (await resp.json())?.data?.tradingSeasons;
-        return seasons && seasons.length > 0 ? seasons[seasons.length - 1].label : undefined;
-      },
-      'LaunchIncentives/fetchSeasonNumber',
-      true
-    ),
-  });
-
-  const { data, isLoading } = useQueryChaosLabsIncentives({ dydxAddress, season: seasonNumber });
+  const { data, isLoading } = useQueryChaosLabsIncentives({ dydxAddress });
   const { incentivePoints } = data ?? {};
 
   return (
@@ -113,14 +81,9 @@ const EstimatedRewards = () => {
       <$EstimatedRewardsCardContent>
         <div>
           <span>{stringGetter({ key: STRING_KEYS.ESTIMATED_REWARDS })}</span>
-          {seasonNumber !== undefined && (
-            <span tw="text-color-text-1 font-small-book">
-              {stringGetter({
-                key: STRING_KEYS.LAUNCH_INCENTIVES_SEASON_NUM,
-                params: { SEASON_NUMBER: seasonNumber },
-              })}
-            </span>
-          )}
+          <span tw="text-color-text-1 font-small-book">
+            {stringGetter({ key: STRING_KEYS.LAUNCH_INCENTIVES_TOTAL_REWARDS })}
+          </span>
         </div>
 
         <$Points>
@@ -134,7 +97,7 @@ const EstimatedRewards = () => {
         </$Points>
       </$EstimatedRewardsCardContent>
 
-      <img src="/rewards-stars.svg" tw="relative float-right h-auto w-[5.25rem]" />
+      <img src="/rewards-stars.svg" tw="relative float-right mb-1.5 h-auto w-[5.25rem]" />
     </$EstimatedRewardsCard>
   );
 };


### PR DESCRIPTION
statsig ff: ff_incentives_s6_rewards_distributed; rollout on 9/13 530pm or just launch that time

<img width="815" alt="image" src="https://github.com/user-attachments/assets/472cf083-94d5-463b-99c4-3405858208c0">
https://cloud.chaoslabs.co/query/api/dydx/points/dydx15m3lvgfwe4xad7wqyskvn6qz5w5ahue60hhemn?n=1
(20437417.331058+86389756.838196+85323598.369674+70796421.080448+78327052.52252999)

(this will show up when rewards > 0; im just changing this locally)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c8cbf506-41f8-4fb1-b4dc-118f26e24a30">
