### PR TITLE
refactor(market-type): update market interface for useMarkets hook

### DIFF
--- a/src/components/Table/AssetTableCell.tsx
+++ b/src/components/Table/AssetTableCell.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import type { Asset, MarketConfigs } from '@/constants/abacus';
+import type { MarketConfigs, Nullable } from '@/constants/abacus';
 
 import breakpoints from '@/styles/breakpoints';
 
@@ -14,7 +14,8 @@ import { Output, OutputType } from '../Output';
 import { TableCell } from './TableCell';
 
 interface AssetTableCellProps {
-  asset?: Pick<Asset, 'name' | 'id'>;
+  symbol?: string;
+  name?: Nullable<string>;
   configs:
     | Pick<MarketConfigs, 'effectiveInitialMarginFraction' | 'initialMarginFraction'>
     | null
@@ -24,7 +25,7 @@ interface AssetTableCellProps {
 }
 
 export const AssetTableCell = (props: AssetTableCellProps) => {
-  const { asset, stacked, configs, className } = props;
+  const { symbol, name, stacked, configs, className } = props;
   const { initialMarginFraction, effectiveInitialMarginFraction } = orEmptyRecord(configs);
 
   const maxLeverage =
@@ -39,13 +40,13 @@ export const AssetTableCell = (props: AssetTableCellProps) => {
       />
     ) : undefined;
   return (
-    <TableCell className={className} slotLeft={<$AssetIcon stacked={stacked} symbol={asset?.id} />}>
+    <TableCell className={className} slotLeft={<$AssetIcon stacked={stacked} symbol={symbol} />}>
       <$TableCellContent stacked={stacked}>
         <div tw="row gap-0.5">
-          <$Asset stacked={stacked}>{asset?.name}</$Asset>
+          <$Asset stacked={stacked}>{name}</$Asset>
           <Tag>{maxLeverage}</Tag>
         </div>
-        {stacked ? <span tw="text-color-text-0 font-mini-medium">{asset?.id}</span> : undefined}
+        {stacked ? <span tw="text-color-text-0 font-mini-medium">{symbol}</span> : undefined}
       </$TableCellContent>
     </TableCell>
   );

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -2,9 +2,15 @@ import { Nullable } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 
 export type MarketData = {
+  // Unique Market id (e.g. 'ETH-USD' or 'BUFFI,uniswap_v3,0x4c1b1302220d7de5c22b495e78b72f2dd2457d45-USD')
   id: string;
+
+  // Base asset id (e.g. 'ETH' or 'BUFFI,uniswap_v3,0x4c1b1302220d7de5c22b495e78b72f2dd2457d45')
   assetId: string;
+
+  // Displayable Market id (e.g. 'ETH-USD' or 'BUFFI-USD')
   displayId: Nullable<string>;
+
   clobPairId: number;
   effectiveInitialMarginFraction: Nullable<number>;
   initialMarginFraction: Nullable<number>;

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -1,15 +1,27 @@
-import { Asset, Nullable, PerpetualMarket } from '@/constants/abacus';
+import { Nullable } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
 
 export type MarketData = {
-  asset: Asset;
-  tickSizeDecimals: Nullable<number>;
-  oneDaySparkline?: number[];
-  isNew?: boolean;
+  id: string;
+  assetId: string;
+  displayId: Nullable<string>;
   clobPairId: number;
-} & PerpetualMarket &
-  PerpetualMarket['perpetual'] &
-  PerpetualMarket['configs'];
+  effectiveInitialMarginFraction: Nullable<number>;
+  initialMarginFraction: Nullable<number>;
+  isNew?: boolean;
+  line?: Nullable<number[]>;
+  name?: Nullable<string>;
+  nextFundingRate?: Nullable<number>;
+  openInterest?: Nullable<number>;
+  openInterestUSDC?: Nullable<number>;
+  oraclePrice?: Nullable<number>;
+  priceChange24H?: Nullable<number>;
+  priceChange24HPercent?: Nullable<number>;
+  tickSizeDecimals?: Nullable<number>;
+  trades24H?: Nullable<number>;
+  volume24H?: Nullable<number>;
+  tags?: Nullable<string[]>;
+};
 
 export enum MarketSorting {
   GAINERS = 'gainers',

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -20,38 +20,38 @@ import { orEmptyRecord } from '@/lib/typeUtils';
 
 const filterFunctions = {
   [MarketFilters.AI]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('AI');
+    return market.tags?.includes('AI');
   },
   [MarketFilters.ALL]: () => true,
   [MarketFilters.DEFI]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Defi');
+    return market.tags?.includes('Defi');
   },
   [MarketFilters.ENT]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('ENT');
+    return market.tags?.includes('ENT');
   },
   [MarketFilters.GAMING]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Gaming');
+    return market.tags?.includes('Gaming');
   },
   [MarketFilters.LAYER_1]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Layer 1');
+    return market.tags?.includes('Layer 1');
   },
   [MarketFilters.LAYER_2]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Layer 2');
+    return market.tags?.includes('Layer 2');
   },
   [MarketFilters.MEME]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Meme');
+    return market.tags?.includes('Meme');
   },
   [MarketFilters.NEW]: (market: MarketData) => {
     return market.isNew;
   },
   [MarketFilters.NFT]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('NFT');
+    return market.tags?.includes('NFT');
   },
   [MarketFilters.PREDICTION_MARKET]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('Prediction Market');
+    return market.tags?.includes('Prediction Market');
   },
   [MarketFilters.RWA]: (market: MarketData) => {
-    return market.asset.tags?.toArray().includes('RWA');
+    return market.tags?.includes('RWA');
   },
 };
 
@@ -71,7 +71,7 @@ export const useMarketsData = (
   const sevenDaysSparklineData = usePerpetualMarketSparklines();
 
   const markets = useMemo(() => {
-    return Object.values(allPerpetualMarkets)
+    const listOfMarkets = Object.values(allPerpetualMarkets)
       .filter(isTruthy)
       .map((marketData): MarketData => {
         const sevenDaySparklineEntries = sevenDaysSparklineData?.[marketData.id]?.length ?? 0;
@@ -79,20 +79,49 @@ export const useMarketsData = (
           sevenDaysSparklineData && sevenDaySparklineEntries < SEVEN_DAY_SPARKLINE_ENTRIES
         );
         const clobPairId = allPerpetualClobIds?.[marketData.id] ?? 0;
+        const {
+          assetId,
+          displayId,
+          id,
+          configs,
+          oraclePrice,
+          priceChange24H,
+          priceChange24HPercent,
+          perpetual,
+        } = marketData;
+        const { nextFundingRate, line, openInterest, openInterestUSDC, trades24H, volume24H } =
+          perpetual ?? {};
+        const { name, tags } = allAssets[assetId] ?? {};
+        const { effectiveInitialMarginFraction, initialMarginFraction, tickSizeDecimals } =
+          configs ?? {};
 
         return safeAssign(
           {},
           {
-            asset: allAssets[marketData.assetId] ?? {},
-            tickSizeDecimals: marketData.configs?.tickSizeDecimals,
-            isNew,
+            id,
+            assetId,
+            displayId,
             clobPairId,
-          },
-          marketData,
-          marketData.perpetual,
-          marketData.configs
+            effectiveInitialMarginFraction,
+            initialMarginFraction,
+            isNew,
+            line: line?.toArray(),
+            name,
+            nextFundingRate,
+            openInterest,
+            openInterestUSDC,
+            oraclePrice,
+            priceChange24H,
+            priceChange24HPercent,
+            tags: tags?.toArray(),
+            tickSizeDecimals,
+            trades24H,
+            volume24H,
+          }
         );
       });
+
+    return listOfMarkets;
   }, [allPerpetualClobIds, allPerpetualMarkets, allAssets, sevenDaysSparklineData]);
 
   const filteredMarkets = useMemo(() => {
@@ -100,9 +129,9 @@ export const useMarketsData = (
 
     if (searchFilter) {
       return filtered.filter(
-        ({ asset, id }) =>
-          matchesSearchFilter(searchFilter, asset?.name) ||
-          matchesSearchFilter(searchFilter, asset?.id) ||
+        ({ assetId, id, name }) =>
+          matchesSearchFilter(searchFilter, name) ||
+          matchesSearchFilter(searchFilter, assetId) ||
           matchesSearchFilter(searchFilter, id)
       );
     }
@@ -114,7 +143,7 @@ export const useMarketsData = (
       MarketFilters.ALL,
       MarketFilters.NEW,
       ...objectKeys(MARKET_FILTER_OPTIONS).filter((marketFilter) =>
-        markets.some((market) => market.asset?.tags?.toArray().some((tag) => tag === marketFilter))
+        markets.some((market) => market.tags?.some((tag) => tag === marketFilter))
       ),
     ],
     [markets]

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -50,11 +50,17 @@ export const MarketsCompactTable = ({
           columnKey: 'market',
           allowsSorting: false,
           label: stringGetter({ key: STRING_KEYS.MARKET }),
-          renderCell: ({ asset, effectiveInitialMarginFraction, initialMarginFraction }) => (
+          renderCell: ({
+            assetId,
+            effectiveInitialMarginFraction,
+            initialMarginFraction,
+            name,
+          }) => (
             <AssetTableCell
               stacked
-              asset={asset}
               configs={{ effectiveInitialMarginFraction, initialMarginFraction }}
+              name={name}
+              symbol={assetId}
             />
           ),
         },
@@ -117,14 +123,14 @@ export const MarketsCompactTable = ({
               columnKey: 'openInterest',
               allowsSorting: false,
               label: stringGetter({ key: STRING_KEYS.OPEN_INTEREST }),
-              renderCell: ({ asset, openInterestUSDC, openInterest }) => (
+              renderCell: ({ assetId, openInterestUSDC, openInterest }) => (
                 <$DetailsCell>
                   <$RecentlyListed>
                     <Output type={OutputType.CompactFiat} value={openInterestUSDC} />
                     <Output
                       type={OutputType.CompactNumber}
                       value={openInterest}
-                      slotRight={` ${asset.id}`}
+                      slotRight={` ${assetId}`}
                       tw="text-color-text-0 font-mini-medium"
                     />
                   </$RecentlyListed>
@@ -170,7 +176,7 @@ export const MarketsCompactTable = ({
     <$Table
       withInnerBorders
       data={sortedMarkets.slice(0, 3)}
-      getRowKey={(row) => row.market ?? ''}
+      getRowKey={(row) => row.id ?? ''}
       label="Markets"
       onRowAction={(market: Key) =>
         navigate(`${AppRoute.Trade}/${market}`, { state: { from: AppRoute.Markets } })

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -53,12 +53,18 @@ export const MarketsTable = ({ className }: { className?: string }) => {
         ? ([
             {
               columnKey: 'market',
-              getCellValue: (row) => row.market,
+              getCellValue: (row) => row.id,
               label: stringGetter({ key: STRING_KEYS.MARKET }),
-              renderCell: ({ asset, effectiveInitialMarginFraction, initialMarginFraction }) => (
+              renderCell: ({
+                assetId,
+                effectiveInitialMarginFraction,
+                initialMarginFraction,
+                name,
+              }) => (
                 <AssetTableCell
-                  asset={asset}
                   configs={{ effectiveInitialMarginFraction, initialMarginFraction }}
+                  name={name}
+                  symbol={assetId}
                 />
               ),
             },
@@ -103,12 +109,18 @@ export const MarketsTable = ({ className }: { className?: string }) => {
         : ([
             {
               columnKey: 'market',
-              getCellValue: (row) => row.market,
+              getCellValue: (row) => row.id,
               label: stringGetter({ key: STRING_KEYS.MARKET }),
-              renderCell: ({ asset, effectiveInitialMarginFraction, initialMarginFraction }) => (
+              renderCell: ({
+                assetId,
+                effectiveInitialMarginFraction,
+                initialMarginFraction,
+                name,
+              }) => (
                 <AssetTableCell
-                  asset={asset}
                   configs={{ effectiveInitialMarginFraction, initialMarginFraction }}
+                  name={name}
+                  symbol={assetId}
                 />
               ),
             },
@@ -130,7 +142,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               renderCell: ({ line, priceChange24HPercent }) => (
                 <div tw="h-2 w-3">
                   <SparklineChart
-                    data={(line?.toArray() ?? []).map((datum, index) => ({
+                    data={(line ?? []).map((datum, index) => ({
                       x: index + 1,
                       y: parseFloat(datum.toString()),
                     }))}
@@ -226,7 +238,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
       <$Table
         withInnerBorders
         data={filteredMarkets}
-        getRowKey={(row: MarketData) => row.market ?? ''}
+        getRowKey={(row: MarketData) => row.id ?? ''}
         label="Markets"
         onRowAction={(market: Key) =>
           navigate(`${AppRoute.Trade}/${market}`, { state: { from: AppRoute.Markets } })


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Refactor `type market`. This is necessary in order to add unlaunched markets to our `useMarkets` hook from `x/marketmap` since it is outside of Abacus.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* `<MarketsTable>`, `<MarketsCompactTable>`
  * Update props passed to `<AssetTableCell>`

## Components

* `<AssetTableCell>`
  * Update props to include `symbol` and `name` instead of taking Abacus' `Asset` type

## Constants/Types

* `constants/markets`
  * update `type Market`

## Hooks

* `hooks/useMarketsData`
  * Update to be compatible with new `type Market`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
