### PR TITLE
feat: Allow dynamic sitemap.xml generation on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Edit `vercel.json` and configure the `rewrites` configuration option. It is an a
 
 Note: The first matching rule takes precedence over anything defined afterwards in the array.
 
+## Part 6: Configure sitemap generation (optional)
+
+1. Edit `public/configs/sitemap.json`. Provide the base site URL and the list of static URLs that you wish to appear in the sitemap.
+2. Edit the deploy command and ensure that `node scripts/generate-sitemap.js` is run before `pnpm run build`.
+
+The sitemap will be generated at build time.
+It will contain the static URLs as well as up-to-date URLs for market pairs.
+The market pairs are evaluated by inspecting an appropriate REST API of a full node.
+
 # Testing
 
 ## Unit testing

--- a/public/configs/sitemap.json
+++ b/public/configs/sitemap.json
@@ -1,0 +1,4 @@
+{
+  "baseURL": "your-base-url",
+  "staticURLs": []
+}

--- a/scripts/__test__/active-market-pairs.test.ts
+++ b/scripts/__test__/active-market-pairs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, Mock } from 'vitest';
+import { fetchActiveMarketPairs } from '../markets/active-market-pairs';
+
+global.fetch = vi.fn() as Mock;
+
+describe('fetchActiveMarketPairs', () => {
+  it('should return only active market pairs', async () => {
+    const mockMarketsResponse = {
+      market_params: [
+        { id: '1', pair: 'BTC-USD' },
+        { id: '2', pair: 'ETH-USD' },
+      ],
+      pagination: {}
+    };
+
+    const mockClobPairsPage1 = {
+      clob_pair: [{ id: '1', status: 'STATUS_ACTIVE' }],
+      pagination: { next_key: 'page2' }
+    };
+
+    const mockClobPairsPage2 = {
+      clob_pair: [{ id: '2', status: 'STATUS_INACTIVE' }],
+      pagination: {}
+    };
+
+    (fetch as Mock).mockImplementation((url: string) => ({
+      status: 200,
+      json: async () => {
+        if (url.includes('market')) {
+          return mockMarketsResponse;
+        }
+        if (url.includes('clob_pair')) {
+          return url.includes('pagination.key=page2')
+            ? mockClobPairsPage2
+            : mockClobPairsPage1
+        }
+        return {};
+      }
+    }));
+
+    const result = await fetchActiveMarketPairs('https://example.com');
+
+    expect(result).toEqual(['BTC-USD']);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+vi.restoreAllMocks();

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,103 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+console.log('Generating sitemap...');
+
+const MARKET_URL = 'https://dydx-ops-rest.kingnodes.com/dydxprotocol/prices/params/market';
+const CLOB_PAIR_URL = 'https://dydx-ops-rest.kingnodes.com/dydxprotocol/clob/clob_pair';
+
+const currentPath = fileURLToPath(import.meta.url);
+const scriptsDir = path.dirname(currentPath);
+const sitemapConfigFilePath = path.resolve(scriptsDir, '../public/configs/sitemap.json');
+const sitemapFilePath = path.resolve(scriptsDir, '../public/sitemap.xml');
+
+await writeSitemap();
+
+
+// --- Functions ---
+
+async function writeSitemap() {
+    try {
+        const sitemapConfigJson = await fs.readFile(sitemapConfigFilePath, 'utf-8');
+        const baseURL = JSON.parse(sitemapConfigJson)['baseURL'];
+        const staticURLs = JSON.parse(sitemapConfigJson)['staticURLs'];
+
+        const markets = await fetchActiveMarketPairs();
+
+        const staticPart = staticURLs.map((url) => `
+            <url>
+                <loc>${url}</loc>
+                <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>1.0</priority>
+            </url>`
+        ).join('');
+
+        const marketsPart = markets.map((pairText) => `
+            <url>
+                <loc>${baseURL}/trade/${pairText}</loc>
+                <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.8</priority>
+            </url>`
+        ).join('');
+
+        const siteMap = `<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            ${staticPart}
+            ${marketsPart}
+        </urlset>
+        `;
+
+        await fs.writeFile(sitemapFilePath, siteMap, 'utf-8');
+
+        console.log('Sitemap generated successfully.');
+    } catch (err) {
+        console.error('Error generating sitemap:', err);
+    }
+}
+
+async function fetchActiveMarketPairs() {
+    // 1. Fetch all markets
+    // 2. Fetch inactive markets (CLOB pair ids that have status different than 'STAUTS_ACTIVE')
+    // 3. Evaluate active markets: all markets - inactive markets
+
+    const markets = {};
+
+    let marketsResponse = {};
+    let key = '';
+    do {
+        marketsResponse = await fetchResponse(MARKET_URL, key);
+        key = marketsResponse["pagination"]["next_key"];
+        marketsResponse['market_params'].forEach((market) => {
+            markets[market['id']] = market['pair'];
+        });
+    } while (key);
+    console.log('Original number of markets:', Object.keys(markets).length);
+
+    let clobPairResponse = {};
+    key = '';
+    do {
+        clobPairResponse = await fetchResponse(CLOB_PAIR_URL, key);
+        key = clobPairResponse["pagination"]["next_key"];
+        clobPairResponse['clob_pair'].forEach((clobPair) => {
+            if (clobPair['status'] !== 'STATUS_ACTIVE') {
+                delete markets[clobPair['id']];
+            }
+        });
+    } while (key);
+    console.log('Final number of markets:', Object.keys(markets).length);
+
+    return Object.values(markets);
+}
+
+async function fetchResponse(url, key) {
+    let params = new URLSearchParams();
+    params.set('pagination.key', key);
+    params.toString();
+
+    const response = await fetch(`${url}?${params}`);
+
+    return await response.json();
+}

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,103 +1,57 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { fetchActiveMarketPairs } from './markets/active-market-pairs.ts';
 
 console.log('Generating sitemap...');
-
-const MARKET_URL = 'https://dydx-ops-rest.kingnodes.com/dydxprotocol/prices/params/market';
-const CLOB_PAIR_URL = 'https://dydx-ops-rest.kingnodes.com/dydxprotocol/clob/clob_pair';
 
 const currentPath = fileURLToPath(import.meta.url);
 const scriptsDir = path.dirname(currentPath);
 const sitemapConfigFilePath = path.resolve(scriptsDir, '../public/configs/sitemap.json');
 const sitemapFilePath = path.resolve(scriptsDir, '../public/sitemap.xml');
 
-await writeSitemap();
+try {
+    const sitemapConfigRaw = await fs.readFile(sitemapConfigFilePath, 'utf-8');
+    const sitemapConfig = JSON.parse(sitemapConfigRaw);
+    const baseURL = sitemapConfig['baseURL'];
+    const staticURLs = sitemapConfig['staticURLs'];
+
+    const marketPairs = await fetchActiveMarketPairs('https://dydx-ops-rest.kingnodes.com');
+
+    const siteMap = await generateSitemap(baseURL, staticURLs, marketPairs);
+    await fs.writeFile(sitemapFilePath, siteMap, 'utf-8');
+
+    console.log('Sitemap generated successfully.');
+} catch (err) {
+    console.error('Error generating sitemap:', err);
+}
 
 
-// --- Functions ---
-
-async function writeSitemap() {
-    try {
-        const sitemapConfigJson = await fs.readFile(sitemapConfigFilePath, 'utf-8');
-        const baseURL = JSON.parse(sitemapConfigJson)['baseURL'];
-        const staticURLs = JSON.parse(sitemapConfigJson)['staticURLs'];
-
-        const markets = await fetchActiveMarketPairs();
-
-        const staticPart = staticURLs.map((url) => `
+async function generateSitemap(baseURL, staticURLs, marketPairs) {
+    const staticPart = staticURLs.map((url) => `
             <url>
                 <loc>${url}</loc>
                 <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>1.0</priority>
             </url>`
-        ).join('');
+    ).join('');
 
-        const marketsPart = markets.map((pairText) => `
+    const marketsPart = marketPairs.map((pairText) => `
             <url>
                 <loc>${baseURL}/trade/${pairText}</loc>
                 <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.8</priority>
             </url>`
-        ).join('');
+    ).join('');
 
-        const siteMap = `<?xml version="1.0" encoding="UTF-8"?>
+    const siteMap = `<?xml version="1.0" encoding="UTF-8"?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
             ${staticPart}
             ${marketsPart}
         </urlset>
-        `;
+    `;
 
-        await fs.writeFile(sitemapFilePath, siteMap, 'utf-8');
-
-        console.log('Sitemap generated successfully.');
-    } catch (err) {
-        console.error('Error generating sitemap:', err);
-    }
-}
-
-async function fetchActiveMarketPairs() {
-    // 1. Fetch all markets
-    // 2. Fetch inactive markets (CLOB pair ids that have status different than 'STAUTS_ACTIVE')
-    // 3. Evaluate active markets: all markets - inactive markets
-
-    const markets = {};
-
-    let marketsResponse = {};
-    let key = '';
-    do {
-        marketsResponse = await fetchResponse(MARKET_URL, key);
-        key = marketsResponse["pagination"]["next_key"];
-        marketsResponse['market_params'].forEach((market) => {
-            markets[market['id']] = market['pair'];
-        });
-    } while (key);
-    console.log('Original number of markets:', Object.keys(markets).length);
-
-    let clobPairResponse = {};
-    key = '';
-    do {
-        clobPairResponse = await fetchResponse(CLOB_PAIR_URL, key);
-        key = clobPairResponse["pagination"]["next_key"];
-        clobPairResponse['clob_pair'].forEach((clobPair) => {
-            if (clobPair['status'] !== 'STATUS_ACTIVE') {
-                delete markets[clobPair['id']];
-            }
-        });
-    } while (key);
-    console.log('Final number of markets:', Object.keys(markets).length);
-
-    return Object.values(markets);
-}
-
-async function fetchResponse(url, key) {
-    let params = new URLSearchParams();
-    params.set('pagination.key', key);
-    params.toString();
-
-    const response = await fetch(`${url}?${params}`);
-
-    return await response.json();
+    return siteMap;
 }

--- a/scripts/markets/active-market-pairs.ts
+++ b/scripts/markets/active-market-pairs.ts
@@ -1,0 +1,41 @@
+export async function fetchActiveMarketPairs(apiHost: string): Promise<string[]> {
+    // Active market pairs are those whose IDs have a status of 'STATUS_ACTIVE' in the CLOB_PAIR_URL.
+    const marketURL = `${apiHost}/dydxprotocol/prices/params/market`;
+    const clobPairURL = `${apiHost}/dydxprotocol/clob/clob_pair`;
+
+    const allMarkets = await fetchItems(marketURL, 'market_params');
+    const clobPairs = await fetchItems(clobPairURL, 'clob_pair');
+
+    const activeMarketIds = new Set(
+        clobPairs
+            .filter((clobPair: { status: string }) => clobPair.status === 'STATUS_ACTIVE')
+            .map((clobPair: { id: string }) => clobPair.id)
+    );
+
+    const activeMarketPairs = allMarkets
+        .filter((market: { id: string }) => activeMarketIds.has(market.id))
+        .map((market: { pair: string }) => market.pair);
+
+    console.log('Original number of markets:', allMarkets.length);
+    console.log('Final number of markets:', activeMarketPairs.length);
+
+    return activeMarketPairs;
+}
+
+async function fetchItems(url: string, contentItemsKey: string): Promise<any[]> {
+    const items: any[] = [];
+    let key = '';
+
+    do {
+        const params = new URLSearchParams();
+        params.set('pagination.key', key);
+
+        const response = await fetch(`${url}?${params}`);
+        const data = await response.json();
+
+        items.push(...data[contentItemsKey]);
+        key = data.pagination?.next_key || '';
+    } while (key);
+
+    return items;
+}


### PR DESCRIPTION
This PR introduces an optional feature - sitemap generation - that can be added as a build step.

The sitemap consists of 2 groups of URLs:
- Static URLs provided in a config file
- URLs for active market pairs, evaluated using an external API.

The market pairs are obtained according to the following rule:

1. Get all the id and pair from [markets/param](https://dydx-ops-rest.kingnodes.com/dydxprotocol/prices/params/market)
2. minus the id that are NOT in STATUS_ACTIVE from [clob/clob_pair](https://dydx-ops-rest.kingnodes.com/dydxprotocol/clob/clob_pair)

The current implementation uses Kingnodes REST API.