### PR TITLE
fix: address impersonation

### DIFF
--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -319,7 +319,7 @@ export const useWalletConnection = () => {
   useEffect(() => {
     (async () => {
       if (testFlags.addressOverride) {
-        setSelectedWallet({ connectorType: ConnectorType.Test, name: WalletType.TestWallet });
+        setConnectedWallet({ connectorType: ConnectorType.Test, name: WalletType.TestWallet });
       }
     })();
   }, []);


### PR DESCRIPTION
This bug was introduced because I removed a flow that extraneously wrote from `selectedWallet` ->`connectedWallet` state, and the address override reads from `connectedWallet`, which is why setting the test wallet through `selectedWallet` worked before. But we can just write directly to `connectedWallet` in this case.
 
<img width="1761" alt="image" src="https://github.com/user-attachments/assets/3fdc109d-9de8-4d6a-b329-2aa15c5bb7d7">
