### PR TITLE
feat: display usd value for withdrawals [OTE-783]

### DIFF
--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -74,7 +74,6 @@ export const WithdrawButtonAndReceipt = ({
       X: `< ${SKIP_EST_TIME_DEFAULT_MINUTES}`,
     },
   });
-
   const submitButtonReceipt = [
     {
       key: 'expected-amount-received',
@@ -89,6 +88,23 @@ export const WithdrawButtonAndReceipt = ({
         <Output type={OutputType.Asset} value={summary?.toAmount} fractionDigits={TOKEN_DECIMALS} />
       ),
     },
+    typeof summary?.toAmountUSD === 'number' &&
+      !String(withdrawToken?.symbol).includes(usdcLabel) && {
+        key: 'expected-amount-received-usd',
+        label: (
+          <$RowWithGap>
+            {stringGetter({ key: STRING_KEYS.EXPECTED_AMOUNT_RECEIVED })}
+            <Tag>USD</Tag>
+          </$RowWithGap>
+        ),
+        value: (
+          <Output
+            type={OutputType.Asset}
+            value={summary?.toAmountUSD}
+            fractionDigits={TOKEN_DECIMALS}
+          />
+        ),
+      },
     showExchangeRate && {
       key: 'exchange-rate',
       label: <span>{stringGetter({ key: STRING_KEYS.EXCHANGE_RATE })}</span>,

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -74,6 +74,7 @@ export const WithdrawButtonAndReceipt = ({
       X: `< ${SKIP_EST_TIME_DEFAULT_MINUTES}`,
     },
   });
+  console.log('summary', summary);
   const submitButtonReceipt = [
     {
       key: 'expected-amount-received',

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -74,7 +74,7 @@ export const WithdrawButtonAndReceipt = ({
       X: `< ${SKIP_EST_TIME_DEFAULT_MINUTES}`,
     },
   });
-  console.log('summary', summary);
+
   const submitButtonReceipt = [
     {
       key: 'expected-amount-received',


### PR DESCRIPTION
blocked by https://github.com/dydxprotocol/v4-abacus/pull/645/files

USDC withdrawals don't have an extra USD row, since we can assume their values will be very similar.
The values won't be *exactly* the same and i figure it's better not to freak out noob users who may not understand that.
<img width="492" alt="image" src="https://github.com/user-attachments/assets/c66eec72-ac8b-40a3-89f8-025fe114ebb7">

Non USDC Withdrawals have an extra row `Expected Amount Received` row with a `USD` tag. happy to update the copy as people like
<img width="494" alt="image" src="https://github.com/user-attachments/assets/bdb34b44-6b3f-4821-a3ab-75f8f5cd57b5">
