### PR TITLE
refactor(new-market-agreement): add agreement to v7 preview step

### DIFF
--- a/src/lib/tradingView/dydxfeed/cache.ts
+++ b/src/lib/tradingView/dydxfeed/cache.ts
@@ -1,4 +1,8 @@
-import type { Bar, QuotesCallback, ResolutionString } from 'public/tradingview/charting_library';
+import type {
+  Bar,
+  ResolutionString,
+  SubscribeBarsCallback,
+} from 'public/tradingview/charting_library';
 
 export const lastBarsCache = new Map();
 export const subscriptionsByChannelId: Map<
@@ -7,6 +11,6 @@ export const subscriptionsByChannelId: Map<
     subscribeUID: string;
     resolution: ResolutionString;
     lastBar: Bar;
-    handlers: Record<string, { id: string; callback: QuotesCallback }>;
+    handlers: Record<string, { id: string; callback: SubscribeBarsCallback }>;
   }
 > = new Map();

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -5,13 +5,14 @@ import type {
   ErrorCallback,
   GetMarksCallback,
   HistoryCallback,
+  IBasicDataFeed,
   LibrarySymbolInfo,
   Mark,
   OnReadyCallback,
-  QuotesCallback,
   ResolutionString,
   ResolveCallback,
   SearchSymbolsCallback,
+  SubscribeBarsCallback,
   Timezone,
 } from 'public/tradingview/charting_library';
 
@@ -72,7 +73,7 @@ export const getDydxDatafeed = (
   },
   selectedLocale: SupportedLocales,
   stringGetter: StringGetterFunction
-) => ({
+): IBasicDataFeed => ({
   onReady: (callback: OnReadyCallback) => {
     setTimeout(() => callback(configurationData), 0);
   },
@@ -239,21 +240,21 @@ export const getDydxDatafeed = (
   subscribeBars: (
     symbolInfo: LibrarySymbolInfo,
     resolution: ResolutionString,
-    onRealtimeCallback: QuotesCallback,
-    subscribeUID: string,
-    onResetCacheNeededCallback: () => void
+    onTick: SubscribeBarsCallback,
+    listenerGuid: string,
+    onResetCacheNeededCallback: Function
   ) => {
     subscribeOnStream({
       symbolInfo,
       resolution,
-      onRealtimeCallback,
-      subscribeUID,
+      onRealtimeCallback: onTick,
+      listenerGuid,
       onResetCacheNeededCallback,
       lastBar: lastBarsCache.get(`${symbolInfo.ticker}/${RESOLUTION_MAP[resolution]}`),
     });
   },
 
-  unsubscribeBars: (subscriberUID: any) => {
+  unsubscribeBars: (subscriberUID: string) => {
     unsubscribeFromStream(subscriberUID);
   },
 });

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -248,7 +248,7 @@ export const getDydxDatafeed = (
       onRealtimeCallback,
       subscribeUID,
       onResetCacheNeededCallback,
-      lastBar: lastBarsCache.get(`${symbolInfo.full_name}/${RESOLUTION_MAP[resolution]}`),
+      lastBar: lastBarsCache.get(`${symbolInfo.symbol}/${RESOLUTION_MAP[resolution]}`),
     });
   },
 

--- a/src/lib/tradingView/dydxfeed/streaming.ts
+++ b/src/lib/tradingView/dydxfeed/streaming.ts
@@ -1,8 +1,8 @@
 import type {
   Bar,
   LibrarySymbolInfo,
-  QuotesCallback,
   ResolutionString,
+  SubscribeBarsCallback,
 } from 'public/tradingview/charting_library';
 
 import { RESOLUTION_MAP } from '@/constants/candles';
@@ -15,22 +15,22 @@ export const subscribeOnStream = ({
   symbolInfo,
   resolution,
   onRealtimeCallback,
-  subscribeUID,
+  listenerGuid,
   lastBar,
 }: {
   symbolInfo: LibrarySymbolInfo;
   resolution: ResolutionString;
-  onRealtimeCallback: QuotesCallback;
-  subscribeUID: string;
-  onResetCacheNeededCallback: () => void;
+  onRealtimeCallback: SubscribeBarsCallback;
+  listenerGuid: string;
+  onResetCacheNeededCallback: Function;
   lastBar: Bar;
 }) => {
-  if (!symbolInfo.name) return;
+  if (!symbolInfo.ticker) return;
 
-  const channelId = `${symbolInfo.name}/${RESOLUTION_MAP[resolution]}`;
+  const channelId = `${symbolInfo.ticker}/${RESOLUTION_MAP[resolution]}`;
 
   const handler = {
-    id: subscribeUID,
+    id: listenerGuid,
     callback: onRealtimeCallback,
   };
 
@@ -38,16 +38,16 @@ export const subscribeOnStream = ({
 
   if (subscriptionItem) {
     // already subscribed to the channel, use the existing subscription
-    subscriptionItem.handlers[subscribeUID] = handler;
+    subscriptionItem.handlers[listenerGuid] = handler;
     return;
   }
 
   subscriptionItem = {
-    subscribeUID,
+    subscribeUID: listenerGuid,
     resolution,
     lastBar,
     handlers: {
-      [subscribeUID]: handler,
+      [listenerGuid]: handler,
     },
   };
 

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -12,6 +12,8 @@ import { Themes } from '@/styles/themes';
 
 import { AppTheme, type AppColorMode } from '@/state/configs';
 
+import { getDisplayableTickerFromMarket } from '../assetUtils';
+
 const MIN_NUM_TRADES_FOR_ORDERBOOK_PRICES = 10;
 
 const getOhlcValues = ({
@@ -117,7 +119,7 @@ const mapTradingViewChartBar = ({
 export const getSymbol = (marketId: string): TradingViewSymbol => ({
   description: marketId,
   exchange: 'dYdX',
-  full_name: marketId,
+  full_name: getDisplayableTickerFromMarket(marketId),
   symbol: marketId,
   type: 'crypto',
 });

--- a/src/views/LaunchMarketSidePanel.tsx
+++ b/src/views/LaunchMarketSidePanel.tsx
@@ -6,6 +6,7 @@ import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
+import { AssetIcon } from '@/components/AssetIcon';
 import { Button } from '@/components/Button';
 import { Output, OutputType } from '@/components/Output';
 
@@ -31,8 +32,16 @@ export const LaunchMarketSidePanel = ({
       body: stringGetter({
         key: STRING_KEYS.MARKET_LAUNCH_DETAILS_2,
         params: {
-          DEPOSIT_AMOUNT: `${10_000} USDC`,
-          APR_PERCENTAGE: <Output type={OutputType.Percent} value={0.3456} />,
+          DEPOSIT_AMOUNT: (
+            <Output
+              tw="inline-block"
+              type={OutputType.Asset}
+              value={10_000}
+              slotRight={<AssetIcon tw="mb-[-0.125rem] ml-0.25 inline-block" symbol="USDC" />}
+              fractionDigits={0}
+            />
+          ),
+          APR_PERCENTAGE: <Output tw="inline-block" type={OutputType.Percent} value={0.3456} />,
           PAST_DAYS: 30,
         },
       }),

--- a/src/views/dialogs/NewMarketAgreementDialog.tsx
+++ b/src/views/dialogs/NewMarketAgreementDialog.tsx
@@ -1,27 +1,16 @@
-import { useState } from 'react';
-
-import styled from 'styled-components';
-
-import { ButtonAction } from '@/constants/buttons';
 import { DialogProps, NewMarketAgreementDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import { layoutMixins } from '@/styles/layoutMixins';
-
-import { Button } from '@/components/Button';
-import { Checkbox } from '@/components/Checkbox';
 import { Dialog } from '@/components/Dialog';
-import { Link } from '@/components/Link';
-import { TermsOfUseLink } from '@/components/TermsOfUseLink';
+
+import { NewMarketAgreement } from '../forms/NewMarketForm/NewMarketAgreement';
 
 export const NewMarketAgreementDialog = ({
   acceptTerms,
   setIsOpen,
 }: DialogProps<NewMarketAgreementDialogProps>) => {
-  const [hasAcknowledged, setHasAcknowledged] = useState(false);
-
   const stringGetter = useStringGetter();
 
   return (
@@ -31,58 +20,13 @@ export const NewMarketAgreementDialog = ({
       title={stringGetter({ key: STRING_KEYS.ACKNOWLEDGEMENT })}
       tw="notMobile:[--dialog-width:30rem]"
     >
-      <$Content>
-        <p>
-          {stringGetter({
-            key: STRING_KEYS.NEW_MARKET_PROPOSAL_AGREEMENT,
-            params: {
-              DOCUMENTATION_LINK: (
-                <Link
-                  href="https://docs.dydx.community/dydx-governance/voting-and-governance/governance-process"
-                  withIcon
-                  isAccent
-                  isInline
-                >
-                  {stringGetter({ key: STRING_KEYS.WEBSITE }).toLowerCase()}
-                </Link>
-              ),
-              TERMS_OF_USE: <TermsOfUseLink isInline isAccent />,
-            },
-          })}
-        </p>
-
-        <Checkbox
-          checked={hasAcknowledged}
-          onCheckedChange={setHasAcknowledged}
-          id="acknowledgement-checkbox"
-          label={stringGetter({ key: STRING_KEYS.I_HAVE_READ_AND_AGREE })}
-        />
-        <div tw="grid grid-cols-[1fr_2fr] gap-1">
-          <Button action={ButtonAction.Base} onClick={() => setIsOpen(false)}>
-            {stringGetter({ key: STRING_KEYS.CANCEL })}
-          </Button>
-          <Button
-            action={ButtonAction.Primary}
-            onClick={() => {
-              acceptTerms();
-              setIsOpen(false);
-            }}
-            state={{ isDisabled: !hasAcknowledged }}
-          >
-            {stringGetter({ key: STRING_KEYS.CONTINUE })}
-          </Button>
-        </div>
-      </$Content>
+      <NewMarketAgreement
+        onAccept={() => {
+          acceptTerms();
+          setIsOpen(false);
+        }}
+        onCancel={() => setIsOpen(false)}
+      />
     </Dialog>
   );
 };
-const $Content = styled.div`
-  ${layoutMixins.column}
-  gap: 1rem;
-
-  p {
-    border-radius: 0.5rem;
-    padding: 1rem;
-    background-color: var(--color-layer-1);
-  }
-`;

--- a/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
+++ b/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
@@ -57,7 +57,7 @@ export const NewMarketAgreement = ({
         </Button>
         <Button
           action={ButtonAction.Primary}
-          onClick={() => {
+          onClick={onAccept}
             onAccept();
           }}
           state={{ isDisabled: !hasAcknowledged }}

--- a/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
+++ b/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
@@ -52,7 +52,7 @@ export const NewMarketAgreement = ({
         label={stringGetter({ key: STRING_KEYS.I_HAVE_READ_AND_AGREE })}
       />
       <div tw="grid grid-cols-[1fr_2fr] gap-1">
-        <Button action={ButtonAction.Base} onClick={() => onCancel()}>
+        <Button action={ButtonAction.Base} onClick={onCancel}>
           {stringGetter({ key: STRING_KEYS.CANCEL })}
         </Button>
         <Button

--- a/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
+++ b/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
@@ -58,8 +58,6 @@ export const NewMarketAgreement = ({
         <Button
           action={ButtonAction.Primary}
           onClick={onAccept}
-            onAccept();
-          }}
           state={{ isDisabled: !hasAcknowledged }}
         >
           {stringGetter({ key: STRING_KEYS.CONTINUE })}

--- a/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
+++ b/src/views/forms/NewMarketForm/NewMarketAgreement.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { ButtonAction } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { Button } from '@/components/Button';
+import { Checkbox } from '@/components/Checkbox';
+import { Link } from '@/components/Link';
+import { TermsOfUseLink } from '@/components/TermsOfUseLink';
+
+export const NewMarketAgreement = ({
+  onAccept,
+  onCancel,
+}: {
+  onAccept: () => void;
+  onCancel: () => void;
+}) => {
+  const [hasAcknowledged, setHasAcknowledged] = useState(false);
+  const stringGetter = useStringGetter();
+
+  return (
+    <$Content>
+      <p>
+        {stringGetter({
+          key: STRING_KEYS.NEW_MARKET_PROPOSAL_AGREEMENT,
+          params: {
+            DOCUMENTATION_LINK: (
+              <Link
+                href="https://docs.dydx.community/dydx-governance/voting-and-governance/governance-process"
+                withIcon
+                isAccent
+                isInline
+              >
+                {stringGetter({ key: STRING_KEYS.WEBSITE }).toLowerCase()}
+              </Link>
+            ),
+            TERMS_OF_USE: <TermsOfUseLink isInline isAccent />,
+          },
+        })}
+      </p>
+
+      <Checkbox
+        checked={hasAcknowledged}
+        onCheckedChange={setHasAcknowledged}
+        id="acknowledgement-checkbox"
+        label={stringGetter({ key: STRING_KEYS.I_HAVE_READ_AND_AGREE })}
+      />
+      <div tw="grid grid-cols-[1fr_2fr] gap-1">
+        <Button action={ButtonAction.Base} onClick={() => onCancel()}>
+          {stringGetter({ key: STRING_KEYS.CANCEL })}
+        </Button>
+        <Button
+          action={ButtonAction.Primary}
+          onClick={() => {
+            onAccept();
+          }}
+          state={{ isDisabled: !hasAcknowledged }}
+        >
+          {stringGetter({ key: STRING_KEYS.CONTINUE })}
+        </Button>
+      </div>
+    </$Content>
+  );
+};
+
+const $Content = styled.div`
+  ${layoutMixins.column}
+  gap: 1rem;
+
+  p {
+    border-radius: 0.5rem;
+    padding: 1rem;
+    background-color: var(--color-layer-1);
+  }
+`;

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { AlertType } from '@/constants/alerts';
 import { ButtonAction, ButtonType } from '@/constants/buttons';
-import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -19,11 +18,10 @@ import { Details, type DetailsItem } from '@/components/Details';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 
-import { useAppDispatch } from '@/state/appTypes';
-import { openDialog } from '@/state/dialogs';
-
 import { getDisplayableAssetFromTicker } from '@/lib/assetUtils';
 import { log } from '@/lib/telemetry';
+
+import { NewMarketAgreement } from '../NewMarketAgreement';
 
 type NewMarketPreviewStepProps = {
   ticker: string;
@@ -40,11 +38,11 @@ export const NewMarketPreviewStep = ({
   receiptItems,
   shouldHideTitleAndDescription,
 }: NewMarketPreviewStepProps) => {
-  const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
   const [errorMessage, setErrorMessage] = useState();
   const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [showAgreement, setShowAgreement] = useState(false);
 
   const alertMessage = useMemo(() => {
     let alert;
@@ -157,13 +155,7 @@ export const NewMarketPreviewStep = ({
         e.preventDefault();
 
         if (!hasAcceptedTerms) {
-          dispatch(
-            openDialog(
-              DialogTypes.NewMarketAgreement({
-                acceptTerms: () => setHasAcceptedTerms(true),
-              })
-            )
-          );
+          setShowAgreement(true);
         } else {
           setIsLoading(true);
           setErrorMessage(undefined);
@@ -179,31 +171,43 @@ export const NewMarketPreviewStep = ({
         }
       }}
     >
-      {heading}
+      {showAgreement ? (
+        <NewMarketAgreement
+          onAccept={() => {
+            setHasAcceptedTerms(true);
+            setShowAgreement(false);
+          }}
+          onCancel={() => setShowAgreement(false)}
+        />
+      ) : (
+        <>
+          {heading}
 
-      {launchVisualization}
+          {launchVisualization}
 
-      {liquidityTier}
+          {liquidityTier}
 
-      {alertMessage}
+          {alertMessage}
 
-      <Details
-        items={receiptItems}
-        tw="rounded-[0.625rem] bg-color-layer-2 px-1 py-0.5 text-small"
-      />
+          <Details
+            items={receiptItems}
+            tw="rounded-[0.625rem] bg-color-layer-2 px-1 py-0.5 text-small"
+          />
 
-      <div tw="grid w-full grid-cols-[1fr_2fr] gap-1">
-        <Button onClick={onBack}>{stringGetter({ key: STRING_KEYS.BACK })}</Button>
-        <Button
-          type={ButtonType.Submit}
-          action={ButtonAction.Primary}
-          state={{ isDisabled, isLoading }}
-        >
-          {hasAcceptedTerms
-            ? stringGetter({ key: STRING_KEYS.PROPOSE_NEW_MARKET })
-            : stringGetter({ key: STRING_KEYS.ACKNOWLEDGE_TERMS })}
-        </Button>
-      </div>
+          <div tw="grid w-full grid-cols-[1fr_2fr] gap-1">
+            <Button onClick={onBack}>{stringGetter({ key: STRING_KEYS.BACK })}</Button>
+            <Button
+              type={ButtonType.Submit}
+              action={ButtonAction.Primary}
+              state={{ isDisabled, isLoading }}
+            >
+              {hasAcceptedTerms
+                ? stringGetter({ key: STRING_KEYS.PROPOSE_NEW_MARKET })
+                : stringGetter({ key: STRING_KEYS.ACKNOWLEDGE_TERMS })}
+            </Button>
+          </div>
+        </>
+      )}
     </$Form>
   );
 };


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Pull NewMarketAgreement into a separate `view` to be used in Dialog and directly in `v7/NewMarketPreviewStep`.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

* New: `<NewMarketAgreement>`
  * Add Agreement form to it's own view

* `<NewMarketPreviewStep>` , `<NewMarketAgreementDialog>`
  * Use `<NewMarketAgreement>` view
 
 | Old flow | New flow |
 |---|---|
 | <video src="https://github.com/user-attachments/assets/319a413a-fa47-42c4-8346-74549c74d9df" /> | <video src="https://github.com/user-attachments/assets/66efc7fe-86c1-4d04-96b3-e3917f10f22b" /> |

* `<LaunchMarketSidePanel>`
  * Update copy to use `USDC` icon

## Functions

* `lib/tradingView/dydxfeed`
  * Use `symbol` to index the `lastBarsCache`

* `lib/tradingView/utils`
  * update `full_name` to use displayable ticker in the TradingView chart
  * <img width="221" alt="Screen Shot 2024-09-12 at 11 17 39 AM" src="https://github.com/user-attachments/assets/2995960c-4cc6-4f8e-ab21-9671515597aa">

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
