### PR TITLE
chore: abacus breaking changes[OTE-803]

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@datadog/browser-logs": "^5.23.3",
-    "@dydxprotocol/v4-abacus": "1.10.2",
+    "@dydxprotocol/v4-abacus": "1.11.2",
     "@dydxprotocol/v4-client-js": "^1.1.27",
     "@dydxprotocol/v4-localization": "^1.1.192",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: ^5.23.3
     version: 5.23.3
   '@dydxprotocol/v4-abacus':
-    specifier: 1.10.2
-    version: 1.10.2
+    specifier: 1.11.2
+    version: 1.11.2
   '@dydxprotocol/v4-client-js':
     specifier: ^1.1.27
     version: 1.1.27
@@ -3155,8 +3155,8 @@ packages:
       '@datadog/browser-core': 5.23.3
     dev: false
 
-  /@dydxprotocol/v4-abacus@1.10.2:
-    resolution: {integrity: sha512-V3iCMgsyiJIxjCkrx8+f+BVAhkAp8jarmEjI/rOUdTIB9akdzno7pg0YYeyzHJOa/Diu5BySSPYxurSiA6bSXQ==}
+  /@dydxprotocol/v4-abacus@1.11.2:
+    resolution: {integrity: sha512-/oydX+4A3/AbCKLgpEf0cbQXhzOCtt51MKkWGcabgY3yGgV0IrEjW5J1fRV0aMZVYAg9X+anmPZJ6/4nY/hjbg==}
     dependencies:
       '@js-joda/core': 3.2.0
       format-util: 1.0.5

--- a/src/constants/__test__/cctp.spec.ts
+++ b/src/constants/__test__/cctp.spec.ts
@@ -11,7 +11,7 @@ import { TransferType } from '../abacus';
 
 describe('getLowestFeeChainNames', () => {
   it('withdrawals skip - returns non eth cctp mainnet chain names as an array', () => {
-    expect(getLowestFeeChainNames(TransferType.withdrawal, true)).toEqual([
+    expect(getLowestFeeChainNames(TransferType.withdrawal)).toEqual([
       'Avalanche',
       'Optimism',
       'Arbitrum',
@@ -21,29 +21,7 @@ describe('getLowestFeeChainNames', () => {
     ]);
   });
   it('deposits skip - returns all cctp mainnet chain names as an array', () => {
-    expect(getLowestFeeChainNames(TransferType.deposit, true)).toEqual([
-      'Ethereum',
-      'Avalanche',
-      'Optimism',
-      'Arbitrum',
-      'Base',
-      'Polygon',
-      'Solana',
-    ]);
-  });
-  it('withdrawals squid - returns all cctp mainnet chain names as an array', () => {
-    expect(getLowestFeeChainNames(TransferType.withdrawal, false)).toEqual([
-      'Ethereum',
-      'Avalanche',
-      'Optimism',
-      'Arbitrum',
-      'Base',
-      'Polygon',
-      'Solana',
-    ]);
-  });
-  it('deposits squid - returns all cctp mainnet chain names as an array', () => {
-    expect(getLowestFeeChainNames(TransferType.deposit, false)).toEqual([
+    expect(getLowestFeeChainNames(TransferType.deposit)).toEqual([
       'Ethereum',
       'Avalanche',
       'Optimism',
@@ -57,7 +35,7 @@ describe('getLowestFeeChainNames', () => {
 
 describe('getMapOfLowestFeeTokensByDenom', () => {
   it('withdrawals skip - returns a map of token denom/addresses to token information except for ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByDenom(TransferType.withdrawal, true)).toEqual({
+    expect(getMapOfLowestFeeTokensByDenom(TransferType.withdrawal)).toEqual({
       '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': [
         {
           chainId: '43114',
@@ -103,113 +81,7 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
     });
   });
   it('deposits skip - returns a map of token denom/addresses to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByDenom(TransferType.deposit, true)).toEqual({
-      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': [
-        {
-          chainId: '1',
-          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          name: 'Ethereum',
-        },
-      ],
-      '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': [
-        {
-          chainId: '43114',
-          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-          name: 'Avalanche',
-        },
-      ],
-      '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85': [
-        {
-          chainId: '10',
-          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-          name: 'optimism',
-        },
-      ],
-      '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': [
-        {
-          chainId: '42161',
-          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-          name: 'arbitrum',
-        },
-      ],
-      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': [
-        {
-          chainId: '8453',
-          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          name: 'Base',
-        },
-      ],
-      '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359': [
-        {
-          chainId: '137',
-          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-          name: 'Polygon',
-        },
-      ],
-      EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: [
-        {
-          chainId: 'solana',
-          name: 'solana',
-          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        },
-      ],
-    });
-  });
-  it('withdrawals squid - returns a map of token denom/addresses to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByDenom(TransferType.withdrawal, false)).toEqual({
-      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': [
-        {
-          chainId: '1',
-          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          name: 'Ethereum',
-        },
-      ],
-      '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': [
-        {
-          chainId: '43114',
-          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-          name: 'Avalanche',
-        },
-      ],
-      '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85': [
-        {
-          chainId: '10',
-          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-          name: 'optimism',
-        },
-      ],
-      '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': [
-        {
-          chainId: '42161',
-          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-          name: 'arbitrum',
-        },
-      ],
-      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': [
-        {
-          chainId: '8453',
-          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          name: 'Base',
-        },
-      ],
-      '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359': [
-        {
-          chainId: '137',
-          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-          name: 'Polygon',
-        },
-      ],
-      EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: [
-        {
-          chainId: 'solana',
-          name: 'solana',
-          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        },
-      ],
-    });
-  });
-  it('deposits squid - returns a map of token denom/addresses to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByDenom(TransferType.deposit, false)).toEqual({
+    expect(getMapOfLowestFeeTokensByDenom(TransferType.deposit)).toEqual({
       '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': [
         {
           chainId: '1',
@@ -264,7 +136,7 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
 });
 describe('getMapOfLowestFeeTokensByChainId', () => {
   it('withdrawals skip - should be a map of chain ids to token information except for ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByChainId(TransferType.withdrawal, true)).toEqual({
+    expect(getMapOfLowestFeeTokensByChainId(TransferType.withdrawal)).toEqual({
       43114: [
         {
           chainId: '43114',
@@ -310,113 +182,7 @@ describe('getMapOfLowestFeeTokensByChainId', () => {
     });
   });
   it('deposits skip - should be a map of chain ids to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByChainId(TransferType.deposit, true)).toEqual({
-      1: [
-        {
-          chainId: '1',
-          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          name: 'Ethereum',
-        },
-      ],
-      43114: [
-        {
-          chainId: '43114',
-          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-          name: 'Avalanche',
-        },
-      ],
-      10: [
-        {
-          chainId: '10',
-          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-          name: 'optimism',
-        },
-      ],
-      42161: [
-        {
-          chainId: '42161',
-          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-          name: 'arbitrum',
-        },
-      ],
-      8453: [
-        {
-          chainId: '8453',
-          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          name: 'Base',
-        },
-      ],
-      137: [
-        {
-          chainId: '137',
-          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-          name: 'Polygon',
-        },
-      ],
-      solana: [
-        {
-          chainId: 'solana',
-          name: 'solana',
-          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        },
-      ],
-    });
-  });
-  it('withdrawals squid - should be a map of chain ids to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByChainId(TransferType.withdrawal, false)).toEqual({
-      1: [
-        {
-          chainId: '1',
-          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          name: 'Ethereum',
-        },
-      ],
-      43114: [
-        {
-          chainId: '43114',
-          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-          name: 'Avalanche',
-        },
-      ],
-      10: [
-        {
-          chainId: '10',
-          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-          name: 'optimism',
-        },
-      ],
-      42161: [
-        {
-          chainId: '42161',
-          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-          name: 'arbitrum',
-        },
-      ],
-      8453: [
-        {
-          chainId: '8453',
-          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          name: 'Base',
-        },
-      ],
-      137: [
-        {
-          chainId: '137',
-          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-          name: 'Polygon',
-        },
-      ],
-      solana: [
-        {
-          chainId: 'solana',
-          name: 'solana',
-          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        },
-      ],
-    });
-  });
-  it('deposits squid - should be a map of chain ids to token information including ETH USDC', () => {
-    expect(getMapOfLowestFeeTokensByChainId(TransferType.deposit, false)).toEqual({
+    expect(getMapOfLowestFeeTokensByChainId(TransferType.deposit)).toEqual({
       1: [
         {
           chainId: '1',
@@ -471,17 +237,11 @@ describe('getMapOfLowestFeeTokensByChainId', () => {
 });
 
 describe('getMapOfHighestFeeTokensByChainId', () => {
-  it('deposits squid - should be an empty map', () => {
-    expect(getMapOfHighestFeeTokensByChainId(TransferType.deposit, false)).toEqual({});
-  });
   it('deposits skip - should be an empty map', () => {
-    expect(getMapOfHighestFeeTokensByChainId(TransferType.deposit, true)).toEqual({});
-  });
-  it('withdrawals squid - should be an empty map', () => {
-    expect(getMapOfHighestFeeTokensByChainId(TransferType.withdrawal, false)).toEqual({});
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.deposit)).toEqual({});
   });
   it('withdrawals skip - should be a map with one property: ethereum chain id', () => {
-    expect(getMapOfHighestFeeTokensByChainId(TransferType.withdrawal, true)).toEqual({
+    expect(getMapOfHighestFeeTokensByChainId(TransferType.withdrawal)).toEqual({
       1: [
         {
           chainId: '1',

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -1,7 +1,7 @@
 import { SupportedLocale } from '@dydxprotocol/v4-localization';
 import { RecordOf, TagsOf, UnionOf, ofType, unionize } from 'unionize';
 
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { ConnectorType, WalletType } from '@/constants/wallets';
 
 import type { AbacusApiStatus, HumanReadablePlaceOrderPayload } from './abacus';
@@ -60,7 +60,7 @@ export const AnalyticsUserProperties = unionize(
     Geo: ofType<string | null>(),
 
     // StatSigFlags
-    StatsigFlags: ofType<{ [key in StatSigFlags]?: boolean }>(),
+    StatsigFlags: ofType<{ [key in StatsigFlags]?: boolean }>(),
 
     // Network
     Network: ofType<DydxNetwork>(),

--- a/src/constants/cctp.ts
+++ b/src/constants/cctp.ts
@@ -13,24 +13,22 @@ type NullableTransferType = TransferTypeType | undefined | null;
 const mainnetChains = cctpTokens.filter((token) => !token.isTestnet);
 
 // Ethereum is a high fee chain for withdrawals but not deposits for Skip only
-const getLowestFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
+const getLowestFeeChains = (type: NullableTransferType) =>
   type === TransferType.deposit
     ? mainnetChains
-    : mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId !== '1' : true));
+    : mainnetChains.filter(({ chainId }) => chainId !== '1');
 
-const getHighestFeeChains = (type: NullableTransferType, skipEnabled: boolean) =>
-  type === TransferType.withdrawal
-    ? mainnetChains.filter(({ chainId }) => (skipEnabled ? chainId === '1' : false))
-    : [];
+const getHighestFeeChains = (type: NullableTransferType) =>
+  type === TransferType.withdrawal ? mainnetChains.filter(({ chainId }) => chainId === '1') : [];
 
 // move this out if we need it in another module
 const capitalizeNames = (str: string) => str[0].toUpperCase() + str.slice(1);
 
-export const getLowestFeeChainNames = (type: NullableTransferType, skipEnabled: boolean) =>
-  getLowestFeeChains(type, skipEnabled).map((token) => capitalizeNames(token.name.toLowerCase()));
+export const getLowestFeeChainNames = (type: NullableTransferType) =>
+  getLowestFeeChains(type).map((token) => capitalizeNames(token.name.toLowerCase()));
 
-export const getMapOfLowestFeeTokensByDenom = (type: NullableTransferType, skipEnabled: boolean) =>
-  getLowestFeeChains(type, skipEnabled).reduce(
+export const getMapOfLowestFeeTokensByDenom = (type: NullableTransferType) =>
+  getLowestFeeChains(type).reduce(
     (acc, token) => {
       if (!acc[token.tokenAddress]) {
         acc[token.tokenAddress] = [];
@@ -53,15 +51,11 @@ const getMapOfChainsByChainId = (chains: CctpTokenInfo[]) =>
     {} as Record<string, CctpTokenInfo[]>
   );
 
-export const getMapOfLowestFeeTokensByChainId = (
-  type: NullableTransferType,
-  skipEnabled: boolean
-) => getMapOfChainsByChainId(getLowestFeeChains(type, skipEnabled));
+export const getMapOfLowestFeeTokensByChainId = (type: NullableTransferType) =>
+  getMapOfChainsByChainId(getLowestFeeChains(type));
 
-export const getMapOfHighestFeeTokensByChainId = (
-  type: NullableTransferType,
-  skipEnabled: boolean
-) => getMapOfChainsByChainId(getHighestFeeChains(type, skipEnabled));
+export const getMapOfHighestFeeTokensByChainId = (type: NullableTransferType) =>
+  getMapOfChainsByChainId(getHighestFeeChains(type));
 
 export const cctpTokensByDenom = cctpTokens.reduce(
   (acc, token) => {

--- a/src/constants/statsig.ts
+++ b/src/constants/statsig.ts
@@ -1,14 +1,12 @@
-export type StatsigConfigType = Record<StatSigFlags, boolean>;
+export type StatsigConfigType = Record<StatsigFlags, boolean>;
 
 /**
  * !README!:
  * If you are using a flag in abacus, you must add it to the abacus
  * StatsigConfig object first! Otherwise it won't be set in the StatsigConfig object
  */
-export enum StatSigFlags {
-  ffSkipMigration = 'ff_skip_migration',
+export enum StatsigFlags {
   ffShowPredictionMarketsUi = 'ff_show_prediction_markets_ui',
-  ffEnableEvmSwaps = 'ff_enable_evm_swaps',
   ffEnableKeplr = 'ff_enable_keplr',
   ffOrderModificationFromChart = 'ff_order_modification_from_chart',
   ffEnableAffiliates = 'ff_enable_affiliates',

--- a/src/constants/tooltips/deposit.ts
+++ b/src/constants/tooltips/deposit.ts
@@ -1,5 +1,5 @@
 import { TOOLTIP_STRING_KEYS, type TooltipStrings } from '@/constants/localization';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { TransferType } from '../abacus';
 import { getLowestFeeChainNames } from '../cctp';
@@ -20,7 +20,7 @@ export const depositTooltips: TooltipStrings = {
       params: {
         LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(
           TransferType.deposit,
-          featureFlags?.[StatSigFlags.ffSkipMigration] ?? false
+          featureFlags?.[StatsigFlags.ffSkipMigration] ?? false
         ).join(', '),
       },
     }),

--- a/src/constants/tooltips/deposit.ts
+++ b/src/constants/tooltips/deposit.ts
@@ -1,5 +1,4 @@
 import { TOOLTIP_STRING_KEYS, type TooltipStrings } from '@/constants/localization';
-import { StatsigFlags } from '@/constants/statsig';
 
 import { TransferType } from '../abacus';
 import { getLowestFeeChainNames } from '../cctp';
@@ -13,15 +12,13 @@ export const depositTooltips: TooltipStrings = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.SWAP_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.SWAP_BODY }),
   }),
-  'lowest-fees-deposit': ({ stringGetter, featureFlags }) => ({
+  // can pipe in featureflags as a param here like so: ({ stringGetter, featureFlags })
+  'lowest-fees-deposit': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.LOWEST_FEE_DEPOSITS_TITLE }),
     body: stringGetter({
       key: TOOLTIP_STRING_KEYS.LOWEST_FEE_DEPOSITS_BODY,
       params: {
-        LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(
-          TransferType.deposit,
-          featureFlags?.[StatsigFlags.ffSkipMigration] ?? false
-        ).join(', '),
+        LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(TransferType.deposit).join(', '),
       },
     }),
   }),

--- a/src/constants/tooltips/withdraw.ts
+++ b/src/constants/tooltips/withdraw.ts
@@ -1,5 +1,5 @@
 import { TOOLTIP_STRING_KEYS, type TooltipStrings } from '@/constants/localization';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { TransferType } from '../abacus';
 import { getLowestFeeChainNames } from '../cctp';
@@ -32,7 +32,7 @@ export const withdrawTooltips: TooltipStrings = {
       params: {
         LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(
           TransferType.withdrawal,
-          featureFlags?.[StatSigFlags.ffSkipMigration] ?? false
+          featureFlags?.[StatsigFlags.ffSkipMigration] ?? false
         ).join(', '),
       },
     }),

--- a/src/constants/tooltips/withdraw.ts
+++ b/src/constants/tooltips/withdraw.ts
@@ -1,5 +1,4 @@
 import { TOOLTIP_STRING_KEYS, type TooltipStrings } from '@/constants/localization';
-import { StatsigFlags } from '@/constants/statsig';
 
 import { TransferType } from '../abacus';
 import { getLowestFeeChainNames } from '../cctp';
@@ -25,15 +24,12 @@ export const withdrawTooltips: TooltipStrings = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.BRIDGE_FEES_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.BRIDGE_FEES_BODY }),
   }),
-  'lowest-fees': ({ stringGetter, featureFlags }) => ({
+  'lowest-fees': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.LOWEST_FEE_WITHDRAWALS_TITLE }),
     body: stringGetter({
       key: TOOLTIP_STRING_KEYS.LOWEST_FEE_WITHDRAWALS_BODY,
       params: {
-        LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(
-          TransferType.withdrawal,
-          featureFlags?.[StatsigFlags.ffSkipMigration] ?? false
-        ).join(', '),
+        LOWEST_FEE_TOKEN_NAMES: getLowestFeeChainNames(TransferType.withdrawal).join(', '),
       },
     }),
   }),

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -169,7 +169,7 @@ export enum CancelOrderStatuses {
 
 export type LocalPlaceOrderData = {
   marketId: string;
-  clientId: number;
+  clientId: string;
   orderId?: string;
   orderType: TradeTypes;
   submissionStatus: PlaceOrderStatuses;

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -7,7 +7,7 @@ import { HumanReadablePlaceOrderPayload, ORDER_SIDES, SubaccountOrder } from '@/
 import { TOGGLE_ACTIVE_CLASS_NAME } from '@/constants/charts';
 import { DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS } from '@/constants/errors';
 import { STRING_KEYS } from '@/constants/localization';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { ORDER_TYPE_STRINGS, TradeTypes, type OrderType } from '@/constants/trade';
 import type { ChartLine, PositionLineType, TvWidget } from '@/constants/tvchart';
 
@@ -78,7 +78,7 @@ export const useChartLines = ({
     shallowEqual
   );
 
-  const canModifyOrdersFromChart = useStatsigGateValue(StatSigFlags.ffOrderModificationFromChart);
+  const canModifyOrdersFromChart = useStatsigGateValue(StatsigFlags.ffOrderModificationFromChart);
 
   const runOnChartReady = useCallback(
     (callback: () => void) => {
@@ -215,7 +215,7 @@ export const useChartLines = ({
     [clientId: string]: { orderPayload: HumanReadablePlaceOrderPayload; oldOrderId: string };
   }>({});
 
-  const removePendingOrderAdjustment = (clientId: number) => {
+  const removePendingOrderAdjustment = (clientId: string) => {
     const { [clientId]: removed, ...withoutOrderId } = pendingOrderAdjustmentsRef.current;
     pendingOrderAdjustmentsRef.current = withoutOrderId;
   };

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { WalletType as CosmosWalletType } from 'graz';
 
 import { isDev, isTestnet } from '@/constants/networks';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import {
   COINBASE_MIPD_RDNS,
   ConnectorType,
@@ -21,7 +21,7 @@ import { useMipdInjectedWallets } from './useMipdInjectedWallets';
 import { useStatsigGateValue } from './useStatsig';
 
 export const useDisplayedWallets = (): WalletInfo[] => {
-  const keplrEnabled = useStatsigGateValue(StatSigFlags.ffEnableKeplr);
+  const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr);
   const injectedWallets = useMipdInjectedWallets();
 
   return useMemo(() => {

--- a/src/hooks/useIncentivesSeason.ts
+++ b/src/hooks/useIncentivesSeason.ts
@@ -2,14 +2,14 @@ import {
   getSeasonRewardDistributionNumber,
   IncentivesDistributedNotificationIds,
 } from '@/constants/notifications';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { useStatsigGateValue } from './useStatsig';
 
 export const useIncentivesSeason = () => {
   // Add an env flag or statsig flag here for easy development + release of reward distribution notifications
   // Example: https://github.com/dydxprotocol/v4-web/pull/809
-  const showS6 = useStatsigGateValue(StatSigFlags.ffIncentivesS6RewardsDistributed);
+  const showS6 = useStatsigGateValue(StatsigFlags.ffIncentivesS6RewardsDistributed);
   const incentivesDistributedSeasonId = showS6
     ? IncentivesDistributedNotificationIds.IncentivesDistributedS6
     : IncentivesDistributedNotificationIds.IncentivesDistributedS5;

--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AnalyticsEvents } from '@/constants/analytics';
 import { LOCAL_STORAGE_VERSIONS, LocalStorageKey } from '@/constants/localStorage';
 import type { TransferNotifcation } from '@/constants/notifications';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { useAccounts } from '@/hooks/useAccounts';
 
@@ -38,7 +38,7 @@ const ERROR_COUNT_THRESHOLD = 3;
 
 const useLocalNotificationsContext = () => {
   const { skip } = useEndpointsConfig();
-  const useSkip = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const useSkip = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const [allTransferNotifications, setAllTransferNotifications] = useLocalStorage<{
     [key: `dydx${string}`]: TransferNotifcation[];

--- a/src/hooks/useLocalNotifications.tsx
+++ b/src/hooks/useLocalNotifications.tsx
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { AnalyticsEvents } from '@/constants/analytics';
 import { LOCAL_STORAGE_VERSIONS, LocalStorageKey } from '@/constants/localStorage';
 import type { TransferNotifcation } from '@/constants/notifications';
-import { StatsigFlags } from '@/constants/statsig';
 
 import { useAccounts } from '@/hooks/useAccounts';
 
@@ -15,11 +14,10 @@ import {
   fetchTransferStatus,
   trackSkipTx,
   trackSkipTxWithTenacity,
-} from '@/lib/squid';
+} from '@/lib/skip';
 
 import { useEndpointsConfig } from './useEndpointsConfig';
 import { useLocalStorage } from './useLocalStorage';
-import { useStatsigGateValue } from './useStatsig';
 
 const LocalNotificationsContext = createContext<
   ReturnType<typeof useLocalNotificationsContext> | undefined
@@ -38,7 +36,6 @@ const ERROR_COUNT_THRESHOLD = 3;
 
 const useLocalNotificationsContext = () => {
   const { skip } = useEndpointsConfig();
-  const useSkip = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const [allTransferNotifications, setAllTransferNotifications] = useLocalStorage<{
     [key: `dydx${string}`]: TransferNotifcation[];
@@ -142,14 +139,11 @@ const useLocalNotificationsContext = () => {
             .map(async (transferNotification) => {
               const {
                 txHash,
-                toChainId,
                 fromChainId,
                 triggeredAt,
-                isCctp,
                 errorCount,
                 status: currentStatus,
                 isExchange,
-                requestId,
                 tracked,
               } = transferNotification;
 
@@ -171,7 +165,7 @@ const useLocalNotificationsContext = () => {
                     chainId: fromChainId,
                     baseUrl: skip,
                   };
-                  if (!tracked && useSkip) {
+                  if (!tracked) {
                     const { tx_hash: trackedTxHash } = await trackSkipTx(skipParams);
                     // if no tx hash was returned, transfer has not yet been tracked
                     if (!trackedTxHash) return transferNotification;
@@ -179,12 +173,8 @@ const useLocalNotificationsContext = () => {
                   }
                   const status = await fetchTransferStatus({
                     transactionId: txHash,
-                    toChainId,
                     fromChainId,
-                    isCctp,
-                    requestId,
                     baseUrl: skip,
-                    useSkip,
                   });
                   if (status) {
                     transferNotification.status = status;

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -30,7 +30,7 @@ import {
   type NotificationTypeConfig,
 } from '@/constants/notifications';
 import { AppRoute } from '@/constants/routes';
-import { StatSigFlags, StatsigDynamicConfigs } from '@/constants/statsig';
+import { StatsigDynamicConfigs, StatsigFlags } from '@/constants/statsig';
 import { DydxChainAsset } from '@/constants/wallets';
 
 import { useLocalNotifications } from '@/hooks/useLocalNotifications';
@@ -113,7 +113,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
           switch (abacusNotificationType) {
             case 'order': {
               const order = ordersById[id]?.[0];
-              const clientId: number | undefined = order?.clientId ?? undefined;
+              const clientId: string | undefined = order?.clientId ?? undefined;
               const localOrderExists =
                 clientId && localPlaceOrders.some((ordr) => ordr.clientId === clientId);
 
@@ -329,7 +329,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
         }
 
         if (
-          featureFlags?.[StatSigFlags.ffShowPredictionMarketsUi] &&
+          featureFlags?.[StatsigFlags.ffShowPredictionMarketsUi] &&
           currentDate <= tradeUSElectionExpirationDate
         ) {
           trigger(
@@ -352,7 +352,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
           );
         }
 
-        if (featureFlags?.[StatSigFlags.ffEnableKeplr]) {
+        if (featureFlags?.[StatsigFlags.ffEnableKeplr]) {
           trigger(
             ReleaseUpdateNotificationIds.KeplrSupport,
             {

--- a/src/hooks/useOnLastOrderIndexed.ts
+++ b/src/hooks/useOnLastOrderIndexed.ts
@@ -8,7 +8,7 @@ import { useAppSelector } from '@/state/appTypes';
  * @param { callback: () => void }
  */
 export const useOnLastOrderIndexed = ({ callback }: { callback: () => void }) => {
-  const [unIndexedClientId, setUnIndexedClientId] = useState<number | undefined>();
+  const [unIndexedClientId, setUnIndexedClientId] = useState<string | undefined>();
   const latestOrderClientId = useAppSelector(getLatestOrderClientId);
 
   useEffect(() => {

--- a/src/hooks/useStatsig.tsx
+++ b/src/hooks/useStatsig.tsx
@@ -7,10 +7,10 @@ import {
 } from '@statsig/react-bindings';
 
 import {
-  StatSigFlags,
   StatsigConfigType,
   StatsigDynamicConfigType,
   StatsigDynamicConfigs,
+  StatsigFlags,
 } from '@/constants/statsig';
 
 import { initStatsigAsync } from '@/lib/statsig';
@@ -28,7 +28,7 @@ export const StatsigProvider = ({ children }: { children: React.ReactNode }) => 
   return <StatsigProviderInternal client={statsigClient}> {children} </StatsigProviderInternal>;
 };
 
-export const useStatsigGateValue = (gate: StatSigFlags) => {
+export const useStatsigGateValue = (gate: StatsigFlags) => {
   const { checkGate } = useStatsigClient();
   return checkGate(gate);
 };
@@ -46,7 +46,7 @@ export const useAllStatsigDynamicConfigValues = () => {
 export const useAllStatsigGateValues = () => {
   const { checkGate } = useStatsigClient();
   const allGateValues = useMemo(() => {
-    return Object.values(StatSigFlags).reduce((acc, gate) => {
+    return Object.values(StatsigFlags).reduce((acc, gate) => {
       return { ...acc, [gate]: checkGate(gate) };
     }, {} as StatsigConfigType);
   }, []);

--- a/src/lib/__test__/skip.spec.ts
+++ b/src/lib/__test__/skip.spec.ts
@@ -4,7 +4,7 @@ import { TransferChainInfo } from '@/constants/abacus';
 import { SkipTransactionStatus } from '@/constants/skip';
 
 import abacusStateManager from '../abacus';
-import { formSkipStatusResponse } from '../squid';
+import { formSkipStatusResponse } from '../skip';
 import { depositFromUsdcEthPending, depositFromUsdcEthSuccess } from './fixtures/skipCctpDeposit';
 import { withdrawToUsdcEthPending, withdrawToUsdcEthSuccess } from './fixtures/skipCctpWithdrawal';
 import {

--- a/src/lib/abacus/__test__/index.spec.ts
+++ b/src/lib/abacus/__test__/index.spec.ts
@@ -2,16 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import abacusStateManager from '..';
 import { StatsigConfig } from '../../../constants/abacus';
-import { StatSigFlags } from '../../../constants/statsig';
 
 describe('setStatsigConfigs', () => {
-  it('only sets properties that exist in the kotlin object', () => {
+  it('does not set properties that do not exist in the kotlin object', () => {
     abacusStateManager.setStatsigConfigs({
-      [StatSigFlags.ffEnableEvmSwaps]: true,
       // @ts-ignore
       nonexistent_flag: true,
     });
-    expect(StatsigConfig.ff_enable_evm_swaps).toBe(true);
     // @ts-ignore
     expect(StatsigConfig.nonexistent_flag).toBeUndefined();
   });

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -301,7 +301,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
     try {
       const tx = await this.compositeClient?.cancelRawOrder(
         new SubaccountClient(this.localWallet, subaccountNumber),
-        clientId,
+        parseInt(clientId, 10),
         orderFlags,
         clobPairId,
         goodTilBlock === 0 ? undefined : goodTilBlock ?? undefined,

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -251,7 +251,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
         side as OrderSide,
         price,
         size,
-        clientId,
+        parseInt(clientId, 10),
         timeInForce as OrderTimeInForce,
         goodTilTimeInSeconds ?? 0,
         execution as OrderExecution,

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -40,7 +40,7 @@ import {
 import { Hdkey } from '@/constants/account';
 import { DEFAULT_MARKETID } from '@/constants/markets';
 import { CURRENT_ABACUS_DEPLOYMENT, type DydxNetwork } from '@/constants/networks';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { CLEARED_SIZE_INPUTS, CLEARED_TRADE_INPUTS } from '@/constants/trade';
 import {
   CLEARED_TRIGGER_LIMIT_INPUTS,
@@ -464,8 +464,8 @@ class AbacusStateManager {
    * You must define the property in abacus first, and then add to the enum.
    *
    */
-  setStatsigConfigs = (statsigConfig: { [key in StatSigFlags]?: boolean }) => {
-    const { [StatSigFlags.ffSkipMigration]: useSkip = false, ...rest } = statsigConfig;
+  setStatsigConfigs = (statsigConfig: { [key in StatsigFlags]?: boolean }) => {
+    const { [StatsigFlags.ffSkipMigration]: useSkip = false, ...rest } = statsigConfig;
     StatsigConfig.useSkip = useSkip;
     Object.entries(rest).forEach(([k, v]) => {
       // This filters out any feature flags in the enum that are not part of the

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -465,9 +465,7 @@ class AbacusStateManager {
    *
    */
   setStatsigConfigs = (statsigConfig: { [key in StatsigFlags]?: boolean }) => {
-    const { [StatsigFlags.ffSkipMigration]: useSkip = false, ...rest } = statsigConfig;
-    StatsigConfig.useSkip = useSkip;
-    Object.entries(rest).forEach(([k, v]) => {
+    Object.entries(statsigConfig).forEach(([k, v]) => {
       // This filters out any feature flags in the enum that are not part of the
       // kotlin statsig config object
       if (k in StatsigConfig) {

--- a/src/lib/orderModification.ts
+++ b/src/lib/orderModification.ts
@@ -78,10 +78,7 @@ export const createPlaceOrderPayloadFromExistingOrder = (
   return new Abacus.exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload(
     subaccountNumber,
     marketId,
-    // There's a problem with Abacus parsing client IDs that are full 32 bytes so dividing by 2 ensures that all
-    // client IDs generated here are < 32 bytes
-    // TODO: fix this in abacus
-    Math.floor(generateRandomClientId() / 2),
+    generateRandomClientId().toString(),
     type.rawValue,
     side.rawValue,
     orderPrice,

--- a/src/lib/skip.ts
+++ b/src/lib/skip.ts
@@ -1,4 +1,3 @@
-import { GetStatus, StatusResponse } from '@0xsquid/sdk';
 import {
   AxelarTransferInfoJSON,
   CCTPTransferInfoJSON,
@@ -9,7 +8,6 @@ import {
   TxStatusResponseJSON,
 } from '@skip-router/core';
 
-import { isMainnet } from '@/constants/networks';
 import {
   RouteStatus,
   SkipStatusResponse,
@@ -25,46 +23,6 @@ import { sleep } from './timeUtils';
 export const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
 export const STATUS_ERROR_GRACE_PERIOD = 300_000;
-
-const getSquidStatusUrl = (isV2: boolean) => {
-  if (isV2) {
-    return isMainnet
-      ? 'https://v2.api.squidrouter.com/v2/status'
-      : 'https://testnet.v2.api.squidrouter.com/v2/status';
-  }
-  return isMainnet
-    ? 'https://api.squidrouter.com/v1/status'
-    : 'https://testnet.api.squidrouter.com/v1/status';
-};
-
-export const fetchSquidStatus = async (
-  params: GetStatus,
-  isV2?: boolean,
-  integratorId?: string,
-  requestId?: string
-): Promise<StatusResponse> => {
-  const parsedParams: { [key: string]: string } = {
-    transactionId: params.transactionId,
-    fromChainId: String(params.fromChainId),
-    toChainId: String(params.toChainId),
-  };
-  if (isV2) parsedParams.bridgeType = 'cctp';
-  const url = `${getSquidStatusUrl(!!isV2)}?${new URLSearchParams(parsedParams).toString()}`;
-
-  const response = await fetch(url, {
-    headers: {
-      'x-integrator-id': integratorId ?? 'dYdX-api',
-      'x-request-id': requestId ?? '',
-    },
-  });
-
-  if (!response.ok) {
-    const error = await response.json();
-    throw error;
-  }
-
-  return response.json();
-};
 
 type SkipStatusParams = {
   transactionHash: string;
@@ -270,32 +228,12 @@ export const formSkipStatusResponse = (
 
 export const fetchTransferStatus = ({
   transactionId,
-  toChainId,
   fromChainId,
-  isCctp,
-  requestId,
   baseUrl,
-  useSkip = false,
 }: {
   transactionId: string;
-  toChainId: string | undefined;
   fromChainId: string | undefined;
-  isCctp: boolean | undefined;
-  requestId: string | undefined;
   baseUrl: string;
-  useSkip: boolean;
 }) => {
-  if (useSkip) {
-    return fetchSkipStatus({ transactionHash: transactionId, chainId: fromChainId, baseUrl });
-  }
-  return fetchSquidStatus(
-    {
-      transactionId,
-      toChainId,
-      fromChainId,
-    },
-    isCctp,
-    undefined,
-    requestId
-  );
+  return fetchSkipStatus({ transactionHash: transactionId, chainId: fromChainId, baseUrl });
 };

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -2,7 +2,7 @@ import { StatsigClient } from '@statsig/js-client';
 import { merge } from 'lodash';
 
 import { STATSIG_ENVIRONMENT_TIER } from '@/constants/networks';
-import { StatSigFlags, StatsigConfigType, StatsigDynamicConfigs } from '@/constants/statsig';
+import { StatsigConfigType, StatsigDynamicConfigs, StatsigFlags } from '@/constants/statsig';
 
 import { log } from './telemetry';
 
@@ -45,7 +45,7 @@ export const initStatsigAsync = async () => {
  * @param gateId
  * @returns
  */
-const checkGateTyped = (client: StatsigClient, gateId: StatSigFlags) => {
+const checkGateTyped = (client: StatsigClient, gateId: StatsigFlags) => {
   return client.checkGate(gateId);
 };
 
@@ -60,7 +60,7 @@ const checkGateTyped = (client: StatsigClient, gateId: StatSigFlags) => {
 export const getStatsigConfigAsync = async (): Promise<StatsigConfigType> => {
   try {
     const client = await initStatsigAsync();
-    const gateValuesList = Object.values(StatSigFlags).map((gateId) => ({
+    const gateValuesList = Object.values(StatsigFlags).map((gateId) => ({
       [gateId]: checkGateTyped(client, gateId),
     }));
 

--- a/src/pages/markets/Markets.tsx
+++ b/src/pages/markets/Markets.tsx
@@ -7,7 +7,7 @@ import { ButtonAction } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { PREDICTION_MARKET } from '@/constants/markets';
 import { AppRoute, MarketsRoute } from '@/constants/routes';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
@@ -35,7 +35,7 @@ const Markets = () => {
   useDocumentTitle(stringGetter({ key: STRING_KEYS.MARKETS }));
 
   const marketsPageBanner = useMemo(() => {
-    if (featureFlags?.[StatSigFlags.ffShowPredictionMarketsUi]) {
+    if (featureFlags?.[StatsigFlags.ffShowPredictionMarketsUi]) {
       return (
         <$MarketsPageBanner to={`${AppRoute.Trade}/${PREDICTION_MARKET.TRUMPWIN}`}>
           <span>🇺🇸 {stringGetter({ key: STRING_KEYS.LEVERAGE_TRADE_US_ELECTION })}</span>

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
 import { AppRoute, PortfolioRoute } from '@/constants/routes';
-import { StatsigDynamicConfigs, StatSigFlags } from '@/constants/statsig';
+import { StatsigDynamicConfigs, StatsigFlags } from '@/constants/statsig';
 
 import { useAccounts } from '@/hooks/useAccounts';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
@@ -42,7 +42,7 @@ export const Overview = () => {
     dynamicConfigs?.[StatsigDynamicConfigs.dcHighestVolumeUsers];
   const shouldShowTelegramInvite =
     dydxAddress && feedbackRequestWalletAddresses?.includes(dydxAddress);
-  const affiliatesEnabled = useStatsigGateValue(StatSigFlags.ffEnableAffiliates);
+  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
 
   const handleViewUnopenedIsolatedOrders = useCallback(() => {
     navigate(`${AppRoute.Portfolio}/${PortfolioRoute.Orders}`, {

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -69,7 +69,7 @@ export type AccountState = {
   hasUnseenOrderUpdates: boolean;
   latestOrder?: Nullable<SubaccountOrder>;
   historicalPnlPeriod?: HistoricalPnlPeriods;
-  uncommittedOrderClientIds: number[];
+  uncommittedOrderClientIds: string[];
   localPlaceOrders: LocalPlaceOrderData[];
   localCancelOrders: LocalCancelOrderData[];
 
@@ -321,7 +321,7 @@ export const accountSlice = createSlice({
     },
     placeOrderSubmitted: (
       state,
-      action: PayloadAction<{ marketId: string; clientId: number; orderType: TradeTypes }>
+      action: PayloadAction<{ marketId: string; clientId: string; orderType: TradeTypes }>
     ) => {
       state.localPlaceOrders.push({
         ...action.payload,
@@ -331,7 +331,7 @@ export const accountSlice = createSlice({
     },
     placeOrderFailed: (
       state,
-      action: PayloadAction<{ clientId: number; errorParams: ErrorParams }>
+      action: PayloadAction<{ clientId: string; errorParams: ErrorParams }>
     ) => {
       state.localPlaceOrders = state.localPlaceOrders.map((order) =>
         order.clientId === action.payload.clientId
@@ -345,7 +345,7 @@ export const accountSlice = createSlice({
         (id) => id !== action.payload.clientId
       );
     },
-    placeOrderTimeout: (state, action: PayloadAction<number>) => {
+    placeOrderTimeout: (state, action: PayloadAction<string>) => {
       if (state.uncommittedOrderClientIds.includes(action.payload)) {
         placeOrderFailed({
           clientId: action.payload,

--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -63,7 +63,7 @@ export const calculateIsAccountViewOnly = createAppSelector(
  */
 export const calculateHasUncommittedOrders = createAppSelector(
   [getUncommittedOrderClientIds],
-  (uncommittedOrderClientIds: number[]) => uncommittedOrderClientIds.length > 0
+  (uncommittedOrderClientIds: string[]) => uncommittedOrderClientIds.length > 0
 );
 
 /**

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -250,7 +250,7 @@ export const getOrderById = () =>
  */
 export const getOrderByClientId = () =>
   createAppSelector(
-    [getSubaccountOrders, (s, orderClientId: number) => orderClientId],
+    [getSubaccountOrders, (s, orderClientId: string) => orderClientId],
     (orders, orderClientId) => orders?.find((order) => order.clientId === orderClientId)
   );
 

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -8,7 +8,7 @@ import { LocalStorageKey } from '@/constants/localStorage';
 import { STRING_KEYS } from '@/constants/localization';
 import { MarketFilters, PREDICTION_MARKET, type MarketData } from '@/constants/markets';
 import { AppRoute, MarketsRoute } from '@/constants/routes';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useMarketsData } from '@/hooks/useMarketsData';
@@ -153,7 +153,7 @@ const MarketsDropdownContent = ({
   const slotTop = useMemo(() => {
     if (
       !hasSeenElectionBannerTrumpWin &&
-      featureFlags?.[StatSigFlags.ffShowPredictionMarketsUi] &&
+      featureFlags?.[StatsigFlags.ffShowPredictionMarketsUi] &&
       currentDate < new Date('2024-11-06T23:59:59')
     ) {
       return (

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -76,7 +76,7 @@ import { getTransferInputs } from '@/state/inputsSelectors';
 import abacusStateManager from '@/lib/abacus';
 import { track } from '@/lib/analytics/analytics';
 import { MustBigNumber } from '@/lib/numbers';
-import { NATIVE_TOKEN_ADDRESS } from '@/lib/squid';
+import { NATIVE_TOKEN_ADDRESS } from '@/lib/skip';
 import { log } from '@/lib/telemetry';
 import { sleep } from '@/lib/timeUtils';
 import { parseWalletError } from '@/lib/wallet';

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -8,12 +8,10 @@ import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign, TOKEN_DECIMALS } from '@/constants/numbers';
 import { SKIP_EST_TIME_DEFAULT_MINUTES } from '@/constants/skip';
-import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { ConnectionErrorType, useApiState } from '@/hooks/useApiState';
 import { useMatchingEvmNetwork } from '@/hooks/useMatchingEvmNetwork';
-import { useStatsigGateValue } from '@/hooks/useStatsig';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
 import { useWalletConnection } from '@/hooks/useWalletConnection';
@@ -107,13 +105,12 @@ export const DepositButtonAndReceipt = ({
   } = useAppSelector(getTransferInputs, shallowEqual) ?? {};
 
   const { usdcLabel } = useTokenConfigs();
-  const isSkipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const sourceChainName =
     depositOptions?.chains?.toArray().find((chain) => chain.type === chainIdStr)?.stringKey ?? '';
 
-  const showExchangeRate = typeof summary?.exchangeRate === 'number' || !isSkipEnabled;
-  const showMinDepositAmount = typeof summary?.toAmountMin === 'number' || !isSkipEnabled;
+  const showExchangeRate = typeof summary?.exchangeRate === 'number';
+  const showMinDepositAmount = typeof summary?.toAmountMin === 'number';
   const fallbackRouteDuration = stringGetter({
     key: STRING_KEYS.X_MINUTES_LOWERCASED,
     params: {
@@ -241,9 +238,7 @@ export const DepositButtonAndReceipt = ({
                         : Math.round(summary.estimatedRouteDuration / 60),
                   },
                 })
-              : isSkipEnabled
-                ? fallbackRouteDuration
-                : null
+              : fallbackRouteDuration
           }
         />
       ),

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -8,7 +8,7 @@ import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign, TOKEN_DECIMALS } from '@/constants/numbers';
 import { SKIP_EST_TIME_DEFAULT_MINUTES } from '@/constants/skip';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { ConnectionErrorType, useApiState } from '@/hooks/useApiState';
@@ -107,7 +107,7 @@ export const DepositButtonAndReceipt = ({
   } = useAppSelector(getTransferInputs, shallowEqual) ?? {};
 
   const { usdcLabel } = useTokenConfigs();
-  const isSkipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const isSkipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const sourceChainName =
     depositOptions?.chains?.toArray().find((chain) => chain.type === chainIdStr)?.stringKey ?? '';

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -12,12 +12,10 @@ import {
 import { SUPPORTED_COSMOS_CHAINS } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
-import { StatsigFlags } from '@/constants/statsig';
 import { ConnectorType, WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
 import { useEnvFeatures } from '@/hooks/useEnvFeatures';
-import { useStatsigGateValue } from '@/hooks/useStatsig';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { SearchSelectMenu } from '@/components/SearchSelectMenu';
@@ -64,17 +62,9 @@ export const SourceSelectMenu = ({
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.exchanges?.toArray() ??
     EMPTY_ARR;
 
-  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
+  const lowestFeeTokensByChainId = useMemo(() => getMapOfLowestFeeTokensByChainId(type), [type]);
 
-  const lowestFeeTokensByChainId = useMemo(
-    () => getMapOfLowestFeeTokensByChainId(type, skipEnabled),
-    [type, skipEnabled]
-  );
-
-  const highestFeeTokensByChainId = useMemo(
-    () => getMapOfHighestFeeTokensByChainId(type, skipEnabled),
-    [type, skipEnabled]
-  );
+  const highestFeeTokensByChainId = useMemo(() => getMapOfHighestFeeTokensByChainId(type), [type]);
   const isKeplrWallet = connectedWallet?.name === WalletType.Keplr;
 
   // withdrawals SourceSelectMenu is half width size so we must throw the decorator text

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -12,7 +12,7 @@ import {
 import { SUPPORTED_COSMOS_CHAINS } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { ConnectorType, WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
@@ -64,7 +64,7 @@ export const SourceSelectMenu = ({
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.exchanges?.toArray() ??
     EMPTY_ARR;
 
-  const skipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const lowestFeeTokensByChainId = useMemo(
     () => getMapOfLowestFeeTokensByChainId(type, skipEnabled),

--- a/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
@@ -9,7 +9,7 @@ import { NEUTRON_USDC_IBC_DENOM, OSMO_USDC_IBC_DENOM } from '@/constants/denoms'
 import { getNeutronChainId, getNobleChainId, getOsmosisChainId } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
@@ -45,7 +45,7 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
   } = orEmptyObj(useAppSelector(getTransferInputs, shallowEqual));
   const { connectedWallet } = useAccounts();
   const { CCTPWithdrawalOnly, CCTPDepositOnly } = useEnvFeatures();
-  const skipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const lowestFeeTokensByDenom = useMemo(
     () => getMapOfLowestFeeTokensByDenom(type, skipEnabled),

--- a/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
@@ -9,12 +9,10 @@ import { NEUTRON_USDC_IBC_DENOM, OSMO_USDC_IBC_DENOM } from '@/constants/denoms'
 import { getNeutronChainId, getNobleChainId, getOsmosisChainId } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { EMPTY_ARR } from '@/constants/objects';
-import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
 import { useEnvFeatures } from '@/hooks/useEnvFeatures';
-import { useStatsigGateValue } from '@/hooks/useStatsig';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { DiffArrow } from '@/components/DiffArrow';
@@ -45,12 +43,8 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
   } = orEmptyObj(useAppSelector(getTransferInputs, shallowEqual));
   const { connectedWallet } = useAccounts();
   const { CCTPWithdrawalOnly, CCTPDepositOnly } = useEnvFeatures();
-  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
-  const lowestFeeTokensByDenom = useMemo(
-    () => getMapOfLowestFeeTokensByDenom(type, skipEnabled),
-    [type, skipEnabled]
-  );
+  const lowestFeeTokensByDenom = useMemo(() => getMapOfLowestFeeTokensByDenom(type), [type]);
   const isKeplrWallet = connectedWallet?.name === WalletType.Keplr;
 
   const tokens =

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -28,7 +28,6 @@ import {
   TOKEN_DECIMALS,
   USD_DECIMALS,
 } from '@/constants/numbers';
-import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
@@ -37,7 +36,6 @@ import { useDydxClient } from '@/hooks/useDydxClient';
 import { useLocalNotifications } from '@/hooks/useLocalNotifications';
 import { useLocaleSeparators } from '@/hooks/useLocaleSeparators';
 import { useRestrictions } from '@/hooks/useRestrictions';
-import { useStatsigGateValue } from '@/hooks/useStatsig';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useSubaccount } from '@/hooks/useSubaccount';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
@@ -577,15 +575,11 @@ export const WithdrawForm = () => {
     isLoading ||
     !isValidDestinationAddress;
 
-  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
-
   return (
     <$Form onSubmit={onSubmit}>
       <div tw="text-color-text-0">
         {stringGetter({
-          key: skipEnabled
-            ? STRING_KEYS.LOWEST_FEE_WITHDRAWALS_SKIP
-            : STRING_KEYS.LOWEST_FEE_WITHDRAWALS,
+          key: STRING_KEYS.LOWEST_FEE_WITHDRAWALS_SKIP,
           params: {
             LOWEST_FEE_TOKENS_TOOLTIP: (
               <WithTooltip tooltip="lowest-fees">

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -28,7 +28,7 @@ import {
   TOKEN_DECIMALS,
   USD_DECIMALS,
 } from '@/constants/numbers';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 import { WalletType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
@@ -577,7 +577,7 @@ export const WithdrawForm = () => {
     isLoading ||
     !isValidDestinationAddress;
 
-  const skipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const skipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   return (
     <$Form onSubmit={onSubmit}>

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -9,7 +9,7 @@ import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign, TOKEN_DECIMALS } from '@/constants/numbers';
 import { SKIP_EST_TIME_DEFAULT_MINUTES } from '@/constants/skip';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { ConnectionErrorType, useApiState } from '@/hooks/useApiState';
 import { useStatsigGateValue } from '@/hooks/useStatsig';
@@ -67,7 +67,7 @@ export const WithdrawButtonAndReceipt = ({
   const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
   const { usdcLabel } = useTokenConfigs();
   const { connectionError } = useApiState();
-  const isSkipEnabled = useStatsigGateValue(StatSigFlags.ffSkipMigration);
+  const isSkipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const showExchangeRate =
     (!isSkipEnabled && !exchange) ||

--- a/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm/WithdrawButtonAndReceipt.tsx
@@ -9,10 +9,8 @@ import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign, TOKEN_DECIMALS } from '@/constants/numbers';
 import { SKIP_EST_TIME_DEFAULT_MINUTES } from '@/constants/skip';
-import { StatsigFlags } from '@/constants/statsig';
 
 import { ConnectionErrorType, useApiState } from '@/hooks/useApiState';
-import { useStatsigGateValue } from '@/hooks/useStatsig';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
 
@@ -67,12 +65,9 @@ export const WithdrawButtonAndReceipt = ({
   const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
   const { usdcLabel } = useTokenConfigs();
   const { connectionError } = useApiState();
-  const isSkipEnabled = useStatsigGateValue(StatsigFlags.ffSkipMigration);
 
   const showExchangeRate =
-    (!isSkipEnabled && !exchange) ||
-    (withdrawToken && typeof summary?.exchangeRate === 'number' && !exchange);
-  const showMinAmountReceived = !isSkipEnabled || typeof summary?.toAmountMin === 'number';
+    !exchange || (withdrawToken && typeof summary?.exchangeRate === 'number' && !exchange);
   const fallbackRouteDuration = stringGetter({
     key: STRING_KEYS.X_MINUTES_LOWERCASED,
     params: {
@@ -93,23 +88,6 @@ export const WithdrawButtonAndReceipt = ({
       value: (
         <Output type={OutputType.Asset} value={summary?.toAmount} fractionDigits={TOKEN_DECIMALS} />
       ),
-    },
-    showMinAmountReceived && {
-      key: 'minimum-amount-received',
-      label: (
-        <$RowWithGap>
-          {stringGetter({ key: STRING_KEYS.MINIMUM_AMOUNT_RECEIVED })}
-          {withdrawToken && <Tag>{withdrawToken?.symbol}</Tag>}
-        </$RowWithGap>
-      ),
-      value: (
-        <Output
-          type={OutputType.Asset}
-          value={summary?.toAmountMin}
-          fractionDigits={TOKEN_DECIMALS}
-        />
-      ),
-      tooltip: 'minimum-amount-received',
     },
     showExchangeRate && {
       key: 'exchange-rate',
@@ -171,9 +149,9 @@ export const WithdrawButtonAndReceipt = ({
               },
             })}
           />
-        ) : isSkipEnabled ? (
+        ) : (
           fallbackRouteDuration
-        ) : null,
+        ),
     },
     {
       key: 'leverage',

--- a/src/views/forms/TradeForm/TradeFormInfoMessages.tsx
+++ b/src/views/forms/TradeForm/TradeFormInfoMessages.tsx
@@ -3,7 +3,7 @@ import { AlertType } from '@/constants/alerts';
 import { LocalStorageKey } from '@/constants/localStorage';
 import { STRING_KEYS } from '@/constants/localization';
 import { PREDICTION_MARKET } from '@/constants/markets';
-import { StatSigFlags } from '@/constants/statsig';
+import { StatsigFlags } from '@/constants/statsig';
 
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useAllStatsigGateValues } from '@/hooks/useStatsig';
@@ -24,7 +24,7 @@ export const TradeFormInfoMessages = ({ marketId }: { marketId: Nullable<string>
   });
 
   if (
-    featureFlags?.[StatSigFlags.ffShowPredictionMarketsUi] &&
+    featureFlags?.[StatsigFlags.ffShowPredictionMarketsUi] &&
     marketId === PREDICTION_MARKET.TRUMPWIN &&
     !hasSeenTradeFormMessageTrumpWin
   ) {


### PR DESCRIPTION
upgrades abacus and handles breaking changes.

breaking changes include:

- removal of several feature flags from the `StatsigConfig` object (evm swaps, useSkip)
- changing of clientId from number to string 


this does NOT fully clean up all squid code.