### PR TITLE
feat: Custom notifications and order modification price validation

### DIFF
--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -14,6 +14,7 @@ export enum NotificationType {
   MarketUpdate = 'MarketUpdate',
   MarketWindDown = 'MarketWindDown',
   FeedbackRequest = 'FeedbackRequest',
+  Custom = 'Custom', // custom notifications triggered by components eg user input errors
 }
 
 export enum NotificationCategoryPreferences {
@@ -38,6 +39,7 @@ export const NotificationTypeCategory: {
   [NotificationType.MarketUpdate]: NotificationCategoryPreferences.MustSee,
   [NotificationType.MarketWindDown]: NotificationCategoryPreferences.MustSee,
   [NotificationType.FeedbackRequest]: NotificationCategoryPreferences.MustSee,
+  [NotificationType.Custom]: NotificationCategoryPreferences.MustSee,
 };
 
 export const SingleSessionNotificationTypes = [
@@ -45,6 +47,7 @@ export const SingleSessionNotificationTypes = [
   NotificationType.ApiError,
   NotificationType.ComplianceAlert,
   NotificationType.OrderStatus,
+  NotificationType.Custom,
 ];
 
 export const SingleSessionAbacusNotificationTypes = ['order', 'blockReward'];
@@ -191,6 +194,11 @@ export type NotificationDisplayData = {
   toastDuration?: number;
 
   withClose?: boolean; // Show close button for Notification
+};
+
+export type CustomNotification = {
+  id: string;
+  displayData: NotificationDisplayData;
 };
 
 export enum TransferNotificationTypes {

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -7,6 +7,7 @@ import { HumanReadablePlaceOrderPayload, ORDER_SIDES, SubaccountOrder } from '@/
 import { TOGGLE_ACTIVE_CLASS_NAME } from '@/constants/charts';
 import { DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS } from '@/constants/errors';
 import { STRING_KEYS } from '@/constants/localization';
+import { StatsigFlags } from '@/constants/statsig';
 import { ORDER_TYPE_STRINGS, TradeTypes, type OrderType } from '@/constants/trade';
 import type { ChartLine, PositionLineType, TvWidget } from '@/constants/tvchart';
 
@@ -38,7 +39,6 @@ import {
 import { isOrderStatusOpen } from '@/lib/orders';
 import { getChartLineColors } from '@/lib/tradingView/utils';
 
-import { StatsigFlags } from '@/constants/statsig';
 import { useCustomNotification } from '../useCustomNotification';
 import { useStatsigGateValue } from '../useStatsig';
 import { useStringGetter } from '../useStringGetter';
@@ -241,6 +241,7 @@ export const useChartLines = ({
       const newPrice = orderLine.getPrice();
 
       if (!isNewOrderPriceValid(order, newPrice)) {
+        // TODO: Add final copy with localization here
         notify({
           title: 'Bad price!!!',
           body: 'Dont cross the book price pls',

--- a/src/hooks/tradingView/useChartLines.ts
+++ b/src/hooks/tradingView/useChartLines.ts
@@ -38,7 +38,9 @@ import {
 import { isOrderStatusOpen } from '@/lib/orders';
 import { getChartLineColors } from '@/lib/tradingView/utils';
 
+import { StatsigFlags } from '@/constants/statsig';
 import { useCustomNotification } from '../useCustomNotification';
+import { useStatsigGateValue } from '../useStatsig';
 import { useStringGetter } from '../useStringGetter';
 
 const CHART_LINE_FONT = 'bold 10px Satoshi';
@@ -78,7 +80,7 @@ export const useChartLines = ({
     shallowEqual
   );
 
-  const canModifyOrdersFromChart = true; // useStatsigGateValue(StatsigFlags.ffOrderModificationFromChart);
+  const canModifyOrdersFromChart = useStatsigGateValue(StatsigFlags.ffOrderModificationFromChart);
 
   const runOnChartReady = useCallback(
     (callback: () => void) => {

--- a/src/hooks/useCustomNotification.ts
+++ b/src/hooks/useCustomNotification.ts
@@ -19,7 +19,6 @@ export const useCustomNotification = () => {
       dispatch(
         addCustomNotification({
           id: uniqueId(),
-
           displayData: {
             toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
             groupKey: NotificationType.Custom,

--- a/src/hooks/useCustomNotification.ts
+++ b/src/hooks/useCustomNotification.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react';
 
-import { uniqueId } from 'lodash';
-
 import {
   DEFAULT_TOAST_AUTO_CLOSE_MS,
   NotificationDisplayData,
@@ -18,7 +16,7 @@ export const useCustomNotification = () => {
     (customNotification: Omit<NotificationDisplayData, 'groupKey'>) => {
       dispatch(
         addCustomNotification({
-          id: uniqueId(),
+          id: Date.now().toString(),
           displayData: {
             toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
             groupKey: NotificationType.Custom,

--- a/src/hooks/useCustomNotification.ts
+++ b/src/hooks/useCustomNotification.ts
@@ -2,7 +2,11 @@ import { useCallback } from 'react';
 
 import { uniqueId } from 'lodash';
 
-import { NotificationDisplayData, NotificationType } from '@/constants/notifications';
+import {
+  DEFAULT_TOAST_AUTO_CLOSE_MS,
+  NotificationDisplayData,
+  NotificationType,
+} from '@/constants/notifications';
 
 import { useAppDispatch } from '@/state/appTypes';
 import { addCustomNotification } from '@/state/notifications';
@@ -15,7 +19,12 @@ export const useCustomNotification = () => {
       dispatch(
         addCustomNotification({
           id: uniqueId(),
-          displayData: { ...customNotification, groupKey: NotificationType.Custom },
+
+          displayData: {
+            toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
+            groupKey: NotificationType.Custom,
+            ...customNotification,
+          },
         })
       );
     },

--- a/src/hooks/useCustomNotification.ts
+++ b/src/hooks/useCustomNotification.ts
@@ -1,10 +1,6 @@
 import { useCallback } from 'react';
 
-import {
-  DEFAULT_TOAST_AUTO_CLOSE_MS,
-  NotificationDisplayData,
-  NotificationType,
-} from '@/constants/notifications';
+import { DEFAULT_TOAST_AUTO_CLOSE_MS, NotificationDisplayData } from '@/constants/notifications';
 
 import { useAppDispatch } from '@/state/appTypes';
 import { addCustomNotification } from '@/state/notifications';
@@ -14,12 +10,13 @@ export const useCustomNotification = () => {
 
   const notify = useCallback(
     (customNotification: Omit<NotificationDisplayData, 'groupKey'>) => {
+      const id = Date.now().toString();
       dispatch(
         addCustomNotification({
-          id: Date.now().toString(),
+          id,
           displayData: {
             toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
-            groupKey: NotificationType.Custom,
+            groupKey: id,
             ...customNotification,
           },
         })

--- a/src/hooks/useCustomNotification.ts
+++ b/src/hooks/useCustomNotification.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+import { uniqueId } from 'lodash';
+
+import { NotificationDisplayData, NotificationType } from '@/constants/notifications';
+
+import { useAppDispatch } from '@/state/appTypes';
+import { addCustomNotification } from '@/state/notifications';
+
+export const useCustomNotification = () => {
+  const dispatch = useAppDispatch();
+
+  const notify = useCallback(
+    (customNotification: Omit<NotificationDisplayData, 'groupKey'>) => {
+      dispatch(
+        addCustomNotification({
+          id: uniqueId(),
+          displayData: { ...customNotification, groupKey: NotificationType.Custom },
+        })
+      );
+    },
+    [dispatch]
+  );
+
+  return notify;
+};

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -59,7 +59,7 @@ import {
 import { getSelectedDydxChainId } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
-import { getAbacusNotifications } from '@/state/notificationsSelectors';
+import { getAbacusNotifications, getCustomNotifications } from '@/state/notificationsSelectors';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
 import { formatSeconds } from '@/lib/timeUtils';
@@ -750,11 +750,23 @@ export const notificationTypes: NotificationTypeConfig[] = [
         }
       }, [dydxAddress]);
     },
+
     useNotificationAction: () => {
       const { getInTouch } = useURLConfigs();
       return () => {
         window.open(getInTouch, '_blank', 'noopener, noreferrer');
       };
+    },
+  },
+  {
+    type: NotificationType.Custom,
+    useTrigger: ({ trigger }) => {
+      const customNotifications = useAppSelector(getCustomNotifications);
+      useEffect(() => {
+        customNotifications.forEach((notification) => {
+          trigger(notification.id, notification.displayData);
+        });
+      }, [customNotifications, trigger]);
     },
   },
 ];

--- a/src/lib/orderModification.ts
+++ b/src/lib/orderModification.ts
@@ -118,6 +118,6 @@ export const isNewOrderPriceValid = (order: SubaccountOrder, newPrice: number) =
 
   const oldPrice = order.triggerPrice ?? order.price;
 
-  // Ensure newPrice makes the order remain on the same side of bookPrice
+  // Ensure newPrice makes the order remain on the same side of the book
   return newPrice !== bookPrice && oldPrice - bookPrice > 0 === newPrice - bookPrice > 0;
 };

--- a/src/lib/orderModification.ts
+++ b/src/lib/orderModification.ts
@@ -109,3 +109,15 @@ export const cancelOrderAsync = (
     });
   });
 };
+
+export const isNewOrderPriceValid = (order: SubaccountOrder, newPrice: number) => {
+  const bookPrice = abacusStateManager.stateManager.state?.marketOrderbook(
+    order.marketId
+  )?.midPrice;
+  if (!bookPrice) return true;
+
+  const oldPrice = order.triggerPrice ?? order.price;
+
+  // Ensure newPrice makes the order remain on the same side of bookPrice
+  return newPrice !== bookPrice && oldPrice - bookPrice > 0 === newPrice - bookPrice > 0;
+};

--- a/src/state/notifications.ts
+++ b/src/state/notifications.ts
@@ -2,13 +2,16 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 import { AbacusNotification } from '@/constants/abacus';
+import { CustomNotification } from '@/constants/notifications';
 
 export interface NotificationsState {
   abacusNotifications: AbacusNotification[];
+  customNotifications: CustomNotification[];
 }
 
 const initialState: NotificationsState = {
   abacusNotifications: [],
+  customNotifications: [],
 };
 
 export const notificationsSlice = createSlice({
@@ -18,7 +21,11 @@ export const notificationsSlice = createSlice({
     updateNotifications: (state, action: PayloadAction<AbacusNotification[]>) => {
       state.abacusNotifications = action.payload;
     },
+    addCustomNotification: (state, action: PayloadAction<CustomNotification>) => {
+      const newNotification = action.payload;
+      state.customNotifications = [...state.customNotifications, newNotification];
+    },
   },
 });
 
-export const { updateNotifications } = notificationsSlice.actions;
+export const { updateNotifications, addCustomNotification } = notificationsSlice.actions;

--- a/src/state/notificationsSelectors.ts
+++ b/src/state/notificationsSelectors.ts
@@ -1,3 +1,5 @@
 import { type RootState } from './_store';
 
 export const getAbacusNotifications = (state: RootState) => state.notifications.abacusNotifications;
+
+export const getCustomNotifications = (state: RootState) => state.notifications.customNotifications;


### PR DESCRIPTION
This PR introduces a new way to fire one-off notifications and its first example usage is for the error notification when you're modifying an order from the TV chart with an invalid price.