### PR TITLE
fix: fix orderbook price bucket rounding issue

### DIFF
--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -1,4 +1,5 @@
 import { OrderSide } from '@dydxprotocol/v4-client-js';
+import BigNumber from 'bignumber.js';
 import { groupBy, sum } from 'lodash';
 
 import {
@@ -17,6 +18,7 @@ import { NUM_PARENT_SUBACCOUNTS, OnboardingState } from '@/constants/account';
 import { LEVERAGE_DECIMALS } from '@/constants/numbers';
 import { EMPTY_ARR } from '@/constants/objects';
 
+import { MustBigNumber } from '@/lib/numbers';
 import {
   getAverageFillPrice,
   getHydratedTradingData,
@@ -343,20 +345,23 @@ export const getSubaccountOpenOrdersForCurrentMarket = createAppSelector(
 export const getSubaccountOrderSizeBySideAndOrderbookLevel = createAppSelector(
   [getSubaccountOpenOrdersForCurrentMarket, getCurrentMarketOrderbook],
   (openOrders = [], book = undefined) => {
-    const tickSize = book?.grouping?.tickSize;
+    const tickSize = MustBigNumber(book?.grouping?.tickSize);
     const orderSizeBySideAndPrice: Partial<Record<OrderSide, Record<number, number>>> = {};
     openOrders.forEach((order: SubaccountOrder) => {
       const side = ORDER_SIDES[order.side.name];
       const byPrice = (orderSizeBySideAndPrice[side] ??= {});
 
       const priceOrderbookLevel = (() => {
-        if (tickSize == null) {
+        if (tickSize.isEqualTo(0)) {
           return order.price;
         }
-        const tickLevelUnrounded = order.price / tickSize;
+        const tickLevelUnrounded = MustBigNumber(order.price).div(tickSize);
         const tickLevel =
-          side === OrderSide.BUY ? Math.floor(tickLevelUnrounded) : Math.ceil(tickLevelUnrounded);
-        return tickLevel * tickSize;
+          side === OrderSide.BUY
+            ? tickLevelUnrounded.decimalPlaces(0, BigNumber.ROUND_FLOOR)
+            : tickLevelUnrounded.decimalPlaces(0, BigNumber.ROUND_CEIL);
+
+        return tickLevel.times(tickSize).toNumber();
       })();
       byPrice[priceOrderbookLevel] = (byPrice[priceOrderbookLevel] ?? 0) + order.size;
     });


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
just some good ol javascript precision rounding errors // should fix [this](https://dydx-team.slack.com/archives/C03GKH23YAZ/p1724834105334999) and [this](https://dydx-team.slack.com/archives/C03GKH23YAZ/p1726594059040329)

<!-- Overall purpose of the PR -->

ok maybe I could pull out into a public helper for testing purposes but felt like it wasn't super worth testing (issue is mainly that we didn't use our BigNumber library) but if anyone feels strongly I'll do it 🫠 

tested locally by using the vals:
- order.price = 0.0744
- side = "BUY" 
- tickSize = 0.0001
and verifying that the output is 0.0744 instead of 0.0743 (which is what it was before the update)

