### PR TITLE
chore: update leverage buttons to go up to max market leverage

### DIFF
--- a/src/lib/leverage.ts
+++ b/src/lib/leverage.ts
@@ -1,0 +1,14 @@
+import { BigNumber } from 'bignumber.js';
+
+export const getLeverageOptionsForMaxLeverage = (maxLeverageBN: BigNumber) => {
+  if (maxLeverageBN.lte(5)) {
+    return [1, 2, 3, 4, 5];
+  }
+  if (maxLeverageBN.lte(10)) {
+    return [1, 2, 3, 5, 10];
+  }
+  if (maxLeverageBN.lte(20)) {
+    return [1, 5, 10, 15, 20];
+  }
+  return [1, 10, 25, 50, 100];
+};

--- a/src/views/forms/AdjustTargetLeverageForm.tsx
+++ b/src/views/forms/AdjustTargetLeverageForm.tsx
@@ -30,6 +30,7 @@ import { getInputTradeTargetLeverage } from '@/state/inputsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { getLeverageOptionsForMaxLeverage } from '@/lib/leverage';
 import { calculateMarketMaxLeverage } from '@/lib/marketsHelpers';
 import { MustBigNumber } from '@/lib/numbers';
 import { orEmptyObj } from '@/lib/typeUtils';
@@ -98,11 +99,13 @@ export const AdjustTargetLeverageForm = ({
       </$InputContainer>
 
       <$ToggleGroup
-        items={[1, 2, 3, 5, 10].map((leverageAmount: number) => ({
-          label: `${leverageAmount}×`,
-          value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
-          disabled: leverageAmount > maxLeverage,
-        }))}
+        items={getLeverageOptionsForMaxLeverage(MustBigNumber(maxLeverage)).map(
+          (leverageAmount: number) => ({
+            label: `${leverageAmount}×`,
+            value: MustBigNumber(leverageAmount).toFixed(LEVERAGE_DECIMALS),
+            disabled: leverageAmount > maxLeverage,
+          })
+        )}
         value={leverageBN.abs().toFixed(LEVERAGE_DECIMALS)} // sign agnostic
         onValueChange={(value: string) => setLeverage(value)}
         shape={ButtonShape.Rectangle}

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -25,6 +25,7 @@ import { getInputTradeData, getInputTradeOptions } from '@/state/inputsSelectors
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { getLeverageOptionsForMaxLeverage } from '@/lib/leverage';
 import { BIG_NUMBERS, MustBigNumber } from '@/lib/numbers';
 import { getSelectedOrderSide, hasPositionSideChanged } from '@/lib/tradeData';
 
@@ -58,10 +59,10 @@ export const MarketLeverageInput = ({
   });
 
   const preferredIMF = effectiveInitialMarginFraction ?? initialMarginFraction;
-  const maxLeverageFallback = preferredIMF ? BIG_NUMBERS.ONE.div(preferredIMF) : MustBigNumber(10);
-  const maxLeverageBN = MustBigNumber(maxLeverage ?? maxLeverageFallback).abs();
+  const maxMarketLeverageBN = preferredIMF ? BIG_NUMBERS.ONE.div(preferredIMF) : MustBigNumber(10);
+  const maxLeverageBN = MustBigNumber(maxLeverage ?? maxMarketLeverageBN).abs();
 
-  const leverageOptions = maxLeverageBN.lt(10) ? [1, 2, 3, 4, 5] : [1, 2, 3, 5, 10];
+  const leverageOptions = getLeverageOptionsForMaxLeverage(maxMarketLeverageBN);
   const leveragePosition = postOrderLeverage ? newPositionSide : currentPositionSide;
 
   const getSignedLeverage = (newLeverage: string | number) => {


### PR DESCRIPTION
| cross 20x | isolated 20x | cross 10x |
| ---- | ---- | ---- | 
| <img width="1268" alt="Screenshot 2024-09-17 at 5 12 49 PM" src="https://github.com/user-attachments/assets/971d5e94-4d12-434e-b68e-e4d812eba880"> | <img width="1041" alt="Screenshot 2024-09-17 at 5 13 03 PM" src="https://github.com/user-attachments/assets/6474479f-d67d-430e-af06-9262678f2398"> | <img width="1269" alt="Screenshot 2024-09-17 at 5 13 20 PM" src="https://github.com/user-attachments/assets/278e2040-8267-40f3-ba62-4bc7e3763f89"> |


