### PR TITLE
feat: market close all

### DIFF
--- a/src/constants/abacus.ts
+++ b/src/constants/abacus.ts
@@ -209,6 +209,8 @@ export const AbacusMarginMode = Abacus.exchange.dydx.abacus.output.input.MarginM
 
 export type HumanReadablePlaceOrderPayload =
   Abacus.exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload;
+export type HumanReadableCloseAllPositionsPayload =
+  Abacus.exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload;
 export type HumanReadableCancelOrderPayload =
   Abacus.exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload;
 export type HumanReadableTriggerOrdersPayload =

--- a/src/constants/dialogs.ts
+++ b/src/constants/dialogs.ts
@@ -17,6 +17,7 @@ export type AdjustIsolatedMarginDialogProps = {
 };
 export type AdjustTargetLeverageDialogProps = {};
 export type ClosePositionDialogProps = {};
+export type CloseAllPositionsConfirmationDialogProps = {};
 export type CancelAllOrdersConfirmationDialogProps = { marketId?: string };
 export type CancelPendingOrdersDialogProps = { marketId: string };
 export type ComplianceConfigDialogProps = {};
@@ -101,6 +102,7 @@ export const DialogTypes = unionize(
     AdjustTargetLeverage: ofType<AdjustTargetLeverageDialogProps>(),
     CancelAllOrdersConfirmation: ofType<CancelAllOrdersConfirmationDialogProps>(),
     CancelPendingOrders: ofType<CancelPendingOrdersDialogProps>(),
+    CloseAllPositionsConfirmation: ofType<CloseAllPositionsConfirmationDialogProps>(),
     ClosePosition: ofType<ClosePositionDialogProps>(),
     ComplianceConfig: ofType<ComplianceConfigDialogProps>(),
     ConfirmPendingDeposit: ofType<ConfirmPendingDepositDialogProps>(),

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -195,3 +195,10 @@ export type LocalCancelAllData = {
   failedOrderIds?: string[];
   errorParams?: ErrorParams;
 };
+
+export type LocalCloseAllPositionsData = {
+  submittedOrderClientIds: string[];
+  filledOrderClientIds: string[];
+  failedOrderClientIds: string[];
+  errorParams?: ErrorParams;
+};

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -44,6 +44,7 @@ import { Output, OutputType } from '@/components/Output';
 // eslint-disable-next-line import/no-cycle
 import { BlockRewardNotification } from '@/views/notifications/BlockRewardNotification';
 import { CancelAllNotification } from '@/views/notifications/CancelAllNotification';
+import { CloseAllPositionsNotification } from '@/views/notifications/CloseAllPositionsNotification';
 import { IncentiveSeasonDistributionNotification } from '@/views/notifications/IncentiveSeasonDistributionNotification';
 import { MarketLaunchTrumpwinNotification } from '@/views/notifications/MarketLaunchTrumpwinNotification';
 import { OrderCancelNotification } from '@/views/notifications/OrderCancelNotification';
@@ -58,6 +59,7 @@ import { openDialog } from '@/state/dialogs';
 import {
   getLocalCancelAlls,
   getLocalCancelOrders,
+  getLocalCloseAllPositions,
   getLocalPlaceOrders,
 } from '@/state/localOrdersSelectors';
 import { getAbacusNotifications, getCustomNotifications } from '@/state/notificationsSelectors';
@@ -664,6 +666,7 @@ export const notificationTypes: NotificationTypeConfig[] = [
       const localPlaceOrders = useAppSelector(getLocalPlaceOrders, shallowEqual);
       const localCancelOrders = useAppSelector(getLocalCancelOrders, shallowEqual);
       const localCancelAlls = useAppSelector(getLocalCancelAlls, shallowEqual);
+      const localCloseAllPositions = useAppSelector(getLocalCloseAllPositions, shallowEqual);
 
       const allOrders = useAppSelector(getSubaccountOrders, shallowEqual);
       const stringGetter = useStringGetter();
@@ -754,6 +757,31 @@ export const notificationTypes: NotificationTypeConfig[] = [
           );
         }
       }, [localCancelAlls]);
+
+      useEffect(() => {
+        if (!localCloseAllPositions) return;
+        const localCloseAllKey = localCloseAllPositions.submittedOrderClientIds.join('-');
+        // eslint-disable-next-line no-restricted-syntax
+        trigger(
+          localCloseAllKey,
+          {
+            icon: null,
+            title: stringGetter({ key: STRING_KEYS.CLOSE_ALL_POSITIONS }),
+            toastSensitivity: 'background',
+            groupKey: localCloseAllKey,
+            toastDuration: DEFAULT_TOAST_AUTO_CLOSE_MS,
+            renderCustomBody: ({ isToast, notification }) => (
+              <CloseAllPositionsNotification
+                isToast={isToast}
+                localCloseAllPositions={localCloseAllPositions}
+                notification={notification}
+              />
+            ),
+          },
+          [localCloseAllPositions],
+          true
+        );
+      }, [localCloseAllPositions]);
     },
     useNotificationAction: () => {
       const dispatch = useAppDispatch();

--- a/src/layout/DialogManager.tsx
+++ b/src/layout/DialogManager.tsx
@@ -6,6 +6,7 @@ import { AdjustIsolatedMarginDialog } from '@/views/dialogs/AdjustIsolatedMargin
 import { AdjustTargetLeverageDialog } from '@/views/dialogs/AdjustTargetLeverageDialog';
 import { CancelAllOrdersConfirmationDialog } from '@/views/dialogs/CancelAllOrdersConfirmationDialog';
 import { CancelPendingOrdersDialog } from '@/views/dialogs/CancelPendingOrdersDialog';
+import { CloseAllPositionsConfirmationDialog } from '@/views/dialogs/CloseAllPositionsConfirmationDialog';
 import { ClosePositionDialog } from '@/views/dialogs/ClosePositionDialog';
 import { ComplianceConfigDialog } from '@/views/dialogs/ComplianceConfigDialog';
 import { ConfirmPendingDepositDialog } from '@/views/dialogs/ConfirmPendingDepositDialog';
@@ -69,6 +70,9 @@ export const DialogManager = () => {
     AdjustIsolatedMargin: (args) => <AdjustIsolatedMarginDialog {...args} {...modalProps} />,
     AdjustTargetLeverage: (args) => <AdjustTargetLeverageDialog {...args} {...modalProps} />,
     ClosePosition: (args) => <ClosePositionDialog {...args} {...modalProps} />,
+    CloseAllPositionsConfirmation: (args) => (
+      <CloseAllPositionsConfirmationDialog {...args} {...modalProps} />
+    ),
     CancelAllOrdersConfirmation: (args) => (
       <CancelAllOrdersConfirmationDialog {...args} {...modalProps} />
     ),

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -8,6 +8,7 @@ import type {
   HistoricalTradingRewardsPeriod,
   HistoricalTradingRewardsPeriods,
   HumanReadableCancelOrderPayload,
+  HumanReadableCloseAllPositionsPayload,
   HumanReadablePlaceOrderPayload,
   HumanReadableSubaccountTransferPayload,
   HumanReadableTriggerOrdersPayload,
@@ -401,6 +402,15 @@ class AbacusStateManager {
       data: Nullable<HumanReadablePlaceOrderPayload>
     ) => void
   ): Nullable<HumanReadablePlaceOrderPayload> => this.stateManager.commitClosePosition(callback);
+
+  closeAllPositions = (
+    callback: (
+      success: boolean,
+      parsingError: Nullable<ParsingError>,
+      data: Nullable<HumanReadablePlaceOrderPayload>
+    ) => void
+  ): Nullable<HumanReadableCloseAllPositionsPayload> =>
+    this.stateManager.closeAllPositions(callback);
 
   cancelOrder = (
     orderId: string,

--- a/src/state/localOrdersSelectors.ts
+++ b/src/state/localOrdersSelectors.ts
@@ -33,6 +33,12 @@ export const getLocalCancelOrders = (state: RootState) => state.localOrders.loca
 export const getLocalCancelAlls = (state: RootState) => state.localOrders.localCancelAlls;
 
 /**
+ * @returns the local close all positions data for the current FE session
+ */
+export const getLocalCloseAllPositions = (state: RootState) =>
+  state.localOrders.localCloseAllPositions;
+
+/**
  * @returns whether the subaccount has uncommitted orders (local orders that are only submitted and not placed)
  */
 export const getHasUncommittedOrders = createAppSelector([getLocalPlaceOrders], (placeOrders) =>

--- a/src/views/dialogs/CloseAllPositionsConfirmationDialog.tsx
+++ b/src/views/dialogs/CloseAllPositionsConfirmationDialog.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+
+import { ButtonAction, ButtonType } from '@/constants/buttons';
+import { CloseAllPositionsConfirmationDialogProps, DialogProps } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+import { useSubaccount } from '@/hooks/useSubaccount';
+
+import { Button } from '@/components/Button';
+import { Dialog } from '@/components/Dialog';
+
+export const CloseAllPositionsConfirmationDialog = ({
+  setIsOpen,
+}: DialogProps<CloseAllPositionsConfirmationDialogProps>) => {
+  const stringGetter = useStringGetter();
+  const { closeAllPositions } = useSubaccount();
+
+  const onSubmit = useCallback(() => {
+    closeAllPositions();
+    setIsOpen?.(false);
+  }, [closeAllPositions, setIsOpen]);
+
+  return (
+    <Dialog isOpen setIsOpen={setIsOpen} title={stringGetter({ key: STRING_KEYS.CONFIRM })}>
+      <form onSubmit={onSubmit} tw="flex flex-col gap-0.75">
+        <div>{stringGetter({ key: STRING_KEYS.ARE_YOU_SURE_CLOSE_MULTI_POSITION_ALL })}</div>
+        <Button action={ButtonAction.Destroy} type={ButtonType.Submit} tw="w-full">
+          {stringGetter({ key: STRING_KEYS.CLOSE_ALL_POSITIONS })}
+        </Button>
+      </form>
+    </Dialog>
+  );
+};

--- a/src/views/notifications/CloseAllPositionsNotification.tsx
+++ b/src/views/notifications/CloseAllPositionsNotification.tsx
@@ -28,9 +28,12 @@ export const CloseAllPositionsNotification = ({
   const stringGetter = useStringGetter();
   const { closeAllPositions } = useSubaccount();
 
-  const numPositions = localCloseAllPositions.submittedOrderClientIds.length;
-  const numClosed = localCloseAllPositions.filledOrderClientIds.length;
-  const numFailed = localCloseAllPositions.failedOrderClientIds.length;
+  const { submittedOrderClientIds, filledOrderClientIds, failedOrderClientIds } =
+    localCloseAllPositions;
+
+  const numPositions = submittedOrderClientIds.length;
+  const numClosed = filledOrderClientIds.length;
+  const numFailed = failedOrderClientIds.length;
 
   const isPending = numClosed + numFailed < numPositions;
   const allFilled = numClosed === numPositions;

--- a/src/views/notifications/CloseAllPositionsNotification.tsx
+++ b/src/views/notifications/CloseAllPositionsNotification.tsx
@@ -1,0 +1,114 @@
+import styled from 'styled-components';
+
+import { AbacusOrderStatus } from '@/constants/abacus';
+import { ButtonAction, ButtonSize } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+import { LocalCloseAllPositionsData } from '@/constants/trade';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+import { useSubaccount } from '@/hooks/useSubaccount';
+
+import { Button } from '@/components/Button';
+import { Details } from '@/components/Details';
+import { LoadingSpinner } from '@/components/Loading/LoadingSpinner';
+// eslint-disable-next-line import/no-cycle
+import { Notification, NotificationProps } from '@/components/Notification';
+
+import { OrderStatusIcon } from '../OrderStatusIcon';
+
+type ElementProps = {
+  localCloseAllPositions: LocalCloseAllPositionsData;
+};
+
+export const CloseAllPositionsNotification = ({
+  isToast,
+  localCloseAllPositions,
+  notification,
+}: NotificationProps & ElementProps) => {
+  const stringGetter = useStringGetter();
+  const { closeAllPositions } = useSubaccount();
+
+  const numPositions = localCloseAllPositions.submittedOrderClientIds.length;
+  const numClosed = localCloseAllPositions.filledOrderClientIds.length;
+  const numFailed = localCloseAllPositions.failedOrderClientIds.length;
+
+  const isPending = numClosed + numFailed < numPositions;
+  const allFilled = numClosed === numPositions;
+  const allCanceled = numFailed === numPositions;
+
+  let closePositionsStatus = <LoadingSpinner tw="text-color-accent [--spinner-width:0.9375rem]" />;
+  if (!isPending) {
+    let [statusStringKey, statusForIcon] = [
+      STRING_KEYS.PARTIALLY_FILLED,
+      AbacusOrderStatus.PartiallyCanceled.rawValue,
+    ];
+    if (allFilled) {
+      [statusStringKey, statusForIcon] = [
+        STRING_KEYS.ORDER_FILLED,
+        AbacusOrderStatus.Filled.rawValue,
+      ];
+    } else if (allCanceled) {
+      [statusStringKey, statusForIcon] = [STRING_KEYS.CANCELED, AbacusOrderStatus.Pending.rawValue];
+    }
+
+    closePositionsStatus = (
+      <span tw="row gap-[0.5ch] text-color-text-0 font-small-book">
+        {stringGetter({ key: statusStringKey })}
+        <OrderStatusIcon status={statusForIcon} />
+      </span>
+    );
+  }
+
+  const showTryAgain = !isPending && numFailed > 0;
+  const tryAgainAction = (
+    <Button
+      tw="w-full"
+      size={ButtonSize.Small}
+      onClick={closeAllPositions}
+      action={ButtonAction.Secondary}
+    >
+      {stringGetter({ key: STRING_KEYS.TRY_AGAIN })}
+    </Button>
+  );
+
+  const customContent = (
+    <$Details
+      items={[
+        {
+          key: 'positions-closed',
+          label: (
+            <span tw="row gap-[0.5ch]">{stringGetter({ key: STRING_KEYS.POSITIONS_CLOSED })}</span>
+          ),
+          value: (
+            <span>
+              <$Highlighted>{numClosed}</$Highlighted> / {numPositions}
+            </span>
+          ),
+        },
+      ]}
+    />
+  );
+
+  return (
+    <Notification
+      isToast={isToast}
+      notification={notification}
+      slotTitle={stringGetter({ key: STRING_KEYS.CLOSE_ALL_POSITIONS })}
+      slotTitleRight={closePositionsStatus}
+      slotCustomContent={customContent}
+      slotAction={showTryAgain ? tryAgainAction : undefined}
+    />
+  );
+};
+
+const $Details = styled(Details)`
+  --details-item-height: 1rem;
+
+  div {
+    padding: 0.25rem 0 0;
+  }
+`;
+
+const $Highlighted = styled.span`
+  color: var(--color-text-2);
+`;

--- a/src/views/tables/OrdersTable/CancelOrClearAllOrdersButton.tsx
+++ b/src/views/tables/OrdersTable/CancelOrClearAllOrdersButton.tsx
@@ -46,7 +46,7 @@ export const CancelOrClearAllOrdersButton = ({ marketId }: ElementProps) => {
 };
 
 const $ActionTextButton = styled(Button)<{ isHighlighted?: boolean }>`
-  --button-textColor: ${({ isHighlighted }) => (isHighlighted ? 'var(--color-accent)' : 'initial')};
+  --button-textColor: ${({ isHighlighted }) => (isHighlighted ? 'var(--color-red)' : 'initial')};
   --button-height: var(--item-height);
   --button-padding: 0 0.25rem;
   --button-backgroundColor: transparent;

--- a/src/views/tables/PositionsTable/CloseAllPositionsButton.tsx
+++ b/src/views/tables/PositionsTable/CloseAllPositionsButton.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
+
+import { ButtonAction, ButtonSize } from '@/constants/buttons';
+import { DialogTypes } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { Button } from '@/components/Button';
+
+import { openDialog } from '@/state/dialogs';
+
+export const CloseAllPositionsButton = () => {
+  const stringGetter = useStringGetter();
+  const dispatch = useDispatch();
+
+  const onCloseAllClick = useCallback(() => {
+    dispatch(openDialog(DialogTypes.CloseAllPositionsConfirmation()));
+  }, [dispatch]);
+
+  return (
+    <$ActionTextButton
+      action={ButtonAction.Primary}
+      size={ButtonSize.XSmall}
+      onClick={onCloseAllClick}
+    >
+      {stringGetter({ key: STRING_KEYS.CLOSE_ALL })}
+    </$ActionTextButton>
+  );
+};
+
+const $ActionTextButton = styled(Button)`
+  --button-textColor: var(--color-red);
+  --button-height: var(--item-height);
+  --button-padding: 0 0.25rem;
+  --button-backgroundColor: transparent;
+  --button-border: none;
+  pointer-events: auto;
+`;


### PR DESCRIPTION
enable "close all" button on positions table that close all positions with market orders
- the functionality is added to abacus, so FE only needs to call that function. market price = oracle price +/- slippage
- it adds tracking similar to cancel all, so we can have a separate toast to keep count of number of positions closed. we'll still emit the fill notifications since they are relevant.
- when a position isn't closed (i.e. order is canceled / not filled), we have a try again option

![image](https://github.com/user-attachments/assets/38339fd6-3912-42a9-b32f-eb035fd5d2b8)
![image](https://github.com/user-attachments/assets/778b4852-4be0-4c7b-bf1f-6b7a82ece8cb)
![image](https://github.com/user-attachments/assets/3719d06a-28c5-4cc3-9b5c-f19bb7fb3f16)

![image](https://github.com/user-attachments/assets/1da27050-1886-4ea8-916f-23c0601cdff7)
![image](https://github.com/user-attachments/assets/ad06358a-a6f8-4cc5-9e2b-ab31bedabaf9)
![image](https://github.com/user-attachments/assets/f517934e-0eb0-4c04-9dcd-ef392ade4d27)

