### PR TITLE
fix: fix positions table last row being stickied incorrectly

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -682,7 +682,7 @@ const $TableWrapper = styled.div<{
   --tableStickyRow-textColor: var(--color-text-0, inherit);
   --tableStickyRow-backgroundColor: inherit;
   --table-header-height: 2rem;
-  --table-footer-height: 2.75rem;
+  --table-footer-height: 0;
 
   --tableRow-hover-backgroundColor: var(--color-layer-3);
   --tableRow-backgroundColor: ;

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -682,7 +682,7 @@ const $TableWrapper = styled.div<{
   --tableStickyRow-textColor: var(--color-text-0, inherit);
   --tableStickyRow-backgroundColor: inherit;
   --table-header-height: 2rem;
-  --table-footer-height: 0;
+  --table-footer-height: 0rem;
 
   --tableRow-hover-backgroundColor: var(--color-layer-3);
   --tableRow-backgroundColor: ;

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -26,7 +26,6 @@ import { NavigationMenu } from '@/components/NavigationMenu';
 import { Tag, TagType } from '@/components/Tag';
 import { WithSidebar } from '@/components/WithSidebar';
 import { FillsTable, FillsTableColumnKey } from '@/views/tables/FillsTable';
-import { FundingPaymentsTable } from '@/views/tables/FundingPaymentsTable';
 import { TransferHistoryTable } from '@/views/tables/TransferHistoryTable';
 
 import { getOnboardingState, getSubaccount, getTradeInfoNumbers } from '@/state/accountSelectors';
@@ -115,6 +114,7 @@ const PortfolioPage = () => {
               />
             }
           />
+          {/* TODO - TRCL-1693
           <Route
             path={HistoryRoute.Payments}
             element={
@@ -123,7 +123,7 @@ const PortfolioPage = () => {
                 withOuterBorder={isNotTablet}
               />
             }
-          />
+          /> */}
         </Route>
         <Route path="*" element={<Navigate to={PortfolioRoute.Overview} replace />} />
       </Routes>


### PR DESCRIPTION
idk why it was 2.75 at any point. tested in:
- TradePage: Positions/Fills/OrdersTable
- TradePage: LiveTradesTable

(only applies to `withFocusStickyRows`). FundingPaymentsTable does not appear to be rendered anywhere so didn't test

Also removed `Payments` route from the `Portfolio` history tab because it's disabled everywhere else

https://github.com/user-attachments/assets/aaf27d82-dce4-40c1-98eb-b840fb4724a3


