### PR TITLE
feat: prefill limit price input to mid market price when available

### DIFF
--- a/src/views/forms/TradeForm/TradeFormInputs.tsx
+++ b/src/views/forms/TradeForm/TradeFormInputs.tsx
@@ -1,4 +1,4 @@
-import { Ref } from 'react';
+import { Ref, useEffect } from 'react';
 
 import { NumberFormatValues, SourceInfo } from 'react-number-format';
 import { shallowEqual } from 'react-redux';
@@ -50,6 +50,16 @@ export const TradeFormInputs = () => {
   const { limitPriceInput, triggerPriceInput, trailingPercentInput } = tradeFormInputValues;
   const { tickSizeDecimals } = useAppSelector(getCurrentMarketConfig, shallowEqual) ?? {};
   const midMarketPrice = useAppSelector(getCurrentMarketMidMarketPrice, shallowEqual);
+
+  useEffect(() => {
+    // when limit price input is empty and mid price is available, set limit price input to mid price
+    if (!midMarketPrice || !needsLimitPrice || limitPriceInput) return;
+    dispatch(
+      setTradeFormInputs({
+        limitPriceInput: MustBigNumber(midMarketPrice).toFixed(tickSizeDecimals ?? USD_DECIMALS),
+      })
+    );
+  }, [dispatch, limitPriceInput, midMarketPrice, needsLimitPrice, tickSizeDecimals]);
 
   const onMidMarketPriceClick = () => {
     if (!midMarketPrice) return;


### PR DESCRIPTION
- good to have feature
- prereq for leverage slider on limit orders

test:
- switch markets / order types; it should set limit price for all limit orders to mid market price on mount when it's available
- (won't automatically sync, but clicking "mid" updates it to the latest mid market price)