### PR TITLE
fix: Make sitemap generation JS, not TS, since it runs at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:inject-smartbanner": "node scripts/inject-smartbanner.js",
     "build:set-last-commit-and-tag": "sh scripts/set-last-commit-and-tag.sh",
     "build:generate-entry-points": "node scripts/generate-entry-points.js",
+    "build:generate-sitemap": "node scripts/generate-sitemap.js",
     "assets": "node scripts/check-assets.js",
     "deploy:ipfs": "node scripts/upload-ipfs.js --verbose",
     "deploy:update-ipns": "node scripts/update-ipns.js",

--- a/scripts/__test__/active-market-pairs.test.js
+++ b/scripts/__test__/active-market-pairs.test.js
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, Mock } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { fetchActiveMarketPairs } from '../markets/active-market-pairs';
 
-global.fetch = vi.fn() as Mock;
+global.fetch = vi.fn();
 
 describe('fetchActiveMarketPairs', () => {
   it('should return only active market pairs', async () => {
@@ -23,7 +23,7 @@ describe('fetchActiveMarketPairs', () => {
       pagination: {}
     };
 
-    (fetch as Mock).mockImplementation((url: string) => ({
+    fetch.mockImplementation((url) => ({
       status: 200,
       json: async () => {
         if (url.includes('market')) {
@@ -32,7 +32,7 @@ describe('fetchActiveMarketPairs', () => {
         if (url.includes('clob_pair')) {
           return url.includes('pagination.key=page2')
             ? mockClobPairsPage2
-            : mockClobPairsPage1
+            : mockClobPairsPage1;
         }
         return {};
       }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { fetchActiveMarketPairs } from './markets/active-market-pairs.ts';
+import { fetchActiveMarketPairs } from './markets/active-market-pairs.js';
 
 console.log('Generating sitemap...');
 

--- a/scripts/markets/active-market-pairs.js
+++ b/scripts/markets/active-market-pairs.js
@@ -1,4 +1,4 @@
-export async function fetchActiveMarketPairs(apiHost: string): Promise<string[]> {
+export async function fetchActiveMarketPairs(apiHost) {
     // Active market pairs are those whose IDs have a status of 'STATUS_ACTIVE' in the CLOB_PAIR_URL.
     const marketURL = `${apiHost}/dydxprotocol/prices/params/market`;
     const clobPairURL = `${apiHost}/dydxprotocol/clob/clob_pair`;
@@ -8,22 +8,19 @@ export async function fetchActiveMarketPairs(apiHost: string): Promise<string[]>
 
     const activeMarketIds = new Set(
         clobPairs
-            .filter((clobPair: { status: string }) => clobPair.status === 'STATUS_ACTIVE')
-            .map((clobPair: { id: string }) => clobPair.id)
+            .filter(clobPair => clobPair.status === 'STATUS_ACTIVE')
+            .map(clobPair => clobPair.id)
     );
 
     const activeMarketPairs = allMarkets
-        .filter((market: { id: string }) => activeMarketIds.has(market.id))
-        .map((market: { pair: string }) => market.pair);
-
-    console.log('Original number of markets:', allMarkets.length);
-    console.log('Final number of markets:', activeMarketPairs.length);
+        .filter(market => activeMarketIds.has(market.id))
+        .map(market => market.pair);
 
     return activeMarketPairs;
 }
 
-async function fetchItems(url: string, contentItemsKey: string): Promise<any[]> {
-    const items: any[] = [];
+async function fetchItems(url, contentItemsKey) {
+    const items = [];
     let key = '';
 
     do {


### PR DESCRIPTION
Sitemap generation is run in `node` and using Typescript there causes issues. For this reason this PR rewrites all sitemap generation-related code to Javascript. Additionally it plugs the sitemap generation script into `package.json` and removes some unnecessary console.log statements.