### PR TITLE
fix: lockdown e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up pnpm
+      uses: dydxprotocol/setup-pnpm@v2.0.0
+
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: pnpm
+
+    - run: pnpm install --ignore-scripts
+
+    - run: pnpm exec vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         node-version: 18
         cache: pnpm
 
-    - run: pnpm install --ignore-scripts
+    - run: |
+        pnpm install --ignore-scripts --frozen-lockfile
+        tar -xzC public -f tradingview/tradingview.tgz # manually inline postinstall script
 
     - run: pnpm exec vitest run

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -36,10 +36,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.check_env.outputs.should_run_tests == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm install --loglevel warn
+          pnpm install --loglevel warn --ignore-scripts
+          tar -xzC public -f tradingview/tradingview.tgz # manually inline postinstall script
 
       - name: Run e2e tests
         if: steps.check_env.outputs.should_run_tests == 'true'
@@ -48,4 +47,4 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           E2E_ENVIRONMENT_PASSWORD: ${{ secrets.E2E_ENVIRONMENT_PASSWORD }}
           E2E_ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
-        run: pnpm run wdio
+        run: pnpm exec wdio run ./wdio.conf.ts

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         if: steps.check_env.outputs.should_run_tests == 'true'
         run: |
-          pnpm install --loglevel warn --ignore-scripts
+          pnpm install --loglevel warn --ignore-scripts --frozen-lockfile
           tar -xzC public -f tradingview/tradingview.tgz # manually inline postinstall script
 
       - name: Run e2e tests

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "eslint --ext .ts,.tsx src/",
     "fix-lint": "eslint --fix --ext .ts,.tsx src/",
     "tag": "node scripts/generate-tag.js",
-    "test": "VITE_DISABLE_STATSIG=true vitest run",
+    "test": "vitest run",
     "tsc": "tsc",
     "postinstall": "tar -xzC public -f tradingview/tradingview.tgz",
     "prepare": "husky",

--- a/src/lib/statsig.ts
+++ b/src/lib/statsig.ts
@@ -28,8 +28,8 @@ export const initStatsigAsync = async () => {
       // TODO: create a top level settings.ts file to coerce boolean env vars to actual boolean
       import.meta.env.VITE_TEST_USER_ID === 'true' ? { userID: 'test-id' } : {},
       {
-        disableLogging: import.meta.env.VITE_DISABLE_STATSIG,
-        disableStorage: import.meta.env.VITE_DISABLE_STATSIG,
+        disableLogging: process.env.VITEST === 'true',
+        disableStorage: process.env.VITEST === 'true',
         environment: { tier: STATSIG_ENVIRONMENT_TIER },
       }
     );


### PR DESCRIPTION
Three changes here:

1. We should use `--ignore-scripts` when running `pnpm install`. This helps prevent attacks from contributors directly adding pre/post install scripts to our package.json as well as supply-chain attacks from dependencies.
2. We should never use `pnpm run`. Always inline via `pnpm exec.`
3. An NPM token shouldn't be necessary for simply installing packages.