### PR TITLE
feat: phantom noti + positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.11.6",
     "@dydxprotocol/v4-client-js": "1.3.7",
-    "@dydxprotocol/v4-localization": "^1.1.200",
+    "@dydxprotocol/v4-localization": "^1.1.203",
     "@dydxprotocol/v4-proto": "^6.0.1",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ dependencies:
     specifier: 1.3.7
     version: 1.3.7
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.200
-    version: 1.1.200
+    specifier: ^1.1.203
+    version: 1.1.203
   '@dydxprotocol/v4-proto':
     specifier: ^6.0.1
     version: 6.0.1
@@ -3110,8 +3110,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.200:
-    resolution: {integrity: sha512-JNMpoMigJTSLiyVmDWjpovQYg5P6HDNZzVUUJJG3RuSnpRiHq9dLActkW6+00IrwmE7lzMBc6NsaJKe4t1sAbA==}
+  /@dydxprotocol/v4-localization@1.1.203:
+    resolution: {integrity: sha512-U9l0gzM9A/MvzSVh0iy7yjqzdzuO+VVDakoPltgqTU6/b/0wDrjIJpuoxn8Tr2AKVx/ZkJdChGM8EiJwueaicA==}
     dev: false
 
   /@dydxprotocol/v4-proto@6.0.1:

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -229,6 +229,7 @@ export enum ReleaseUpdateNotificationIds {
   Twitter200BVolume = 'twitter-200b-volume',
   IncentivesS6Ended = 'incentives-s6-ended',
   KeplrSupport = 'keplr-support',
+  PhantomSupport = 'phantom-support',
 }
 
 // Incentives Season

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -51,7 +51,8 @@ export const useDisplayedWallets = (): WalletInfo[] => {
           }) as WalletInfo
       );
 
-    // Phantom wallet must be in the 2nd slot.
+    // If Phantom wallet is detected, it must be in the 2nd slot.
+    // If there are no injected wallets, splice will just put it as the only item in the array.
     if (phantomDetected) {
       enabledInjectedWallets.splice(1, 0, {
         connectorType: ConnectorType.PhantomSolana,

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -51,6 +51,14 @@ export const useDisplayedWallets = (): WalletInfo[] => {
           }) as WalletInfo
       );
 
+    // Phantom wallet must be in the 2nd slot.
+    if (phantomDetected) {
+      enabledInjectedWallets.splice(1, 0, {
+        connectorType: ConnectorType.PhantomSolana,
+        name: WalletType.Phantom,
+      });
+    }
+
     return [
       // If the user does not have any injected wallets installed, show Metamask as the first option
       // with a download link since it the recommended wallet
@@ -61,11 +69,6 @@ export const useDisplayedWallets = (): WalletInfo[] => {
       },
 
       ...enabledInjectedWallets,
-
-      phantomDetected && {
-        connectorType: ConnectorType.PhantomSolana,
-        name: WalletType.Phantom,
-      },
 
       keplrEnabled && {
         connectorType: ConnectorType.Cosmos,

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -35,7 +35,7 @@ import { DydxChainAsset } from '@/constants/wallets';
 
 import { useLocalNotifications } from '@/hooks/useLocalNotifications';
 
-import { KeplrIcon } from '@/icons';
+import { KeplrIcon, PhantomIcon } from '@/icons';
 
 import { AssetIcon } from '@/components/AssetIcon';
 import { Icon, IconName } from '@/components/Icon';
@@ -369,6 +369,20 @@ export const notificationTypes: NotificationTypeConfig[] = [
             []
           );
         }
+
+        trigger(
+          ReleaseUpdateNotificationIds.PhantomSupport,
+          {
+            icon: <PhantomIcon />,
+            title: stringGetter({ key: STRING_KEYS.PHANTOM_SUPPORT_TITLE }),
+            body: stringGetter({
+              key: STRING_KEYS.PHANTOM_SUPPORT_BODY,
+            }),
+            toastSensitivity: 'foreground',
+            groupKey: ReleaseUpdateNotificationIds.KeplrSupport,
+          },
+          []
+        );
       }, [stringGetter]);
 
       const { dydxAddress } = useAccounts();

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -370,19 +370,23 @@ export const notificationTypes: NotificationTypeConfig[] = [
           );
         }
 
-        trigger(
-          ReleaseUpdateNotificationIds.PhantomSupport,
-          {
-            icon: <PhantomIcon />,
-            title: stringGetter({ key: STRING_KEYS.PHANTOM_SUPPORT_TITLE }),
-            body: stringGetter({
-              key: STRING_KEYS.PHANTOM_SUPPORT_BODY,
-            }),
-            toastSensitivity: 'foreground',
-            groupKey: ReleaseUpdateNotificationIds.KeplrSupport,
-          },
-          []
-        );
+        const phantomNotificationExpirationDate = new Date('2024-10-07T15:00:29.517926238Z');
+
+        if (currentDate < phantomNotificationExpirationDate) {
+          trigger(
+            ReleaseUpdateNotificationIds.PhantomSupport,
+            {
+              icon: <PhantomIcon />,
+              title: stringGetter({ key: STRING_KEYS.PHANTOM_SUPPORT_TITLE }),
+              body: stringGetter({
+                key: STRING_KEYS.PHANTOM_SUPPORT_BODY,
+              }),
+              toastSensitivity: 'foreground',
+              groupKey: ReleaseUpdateNotificationIds.KeplrSupport,
+            },
+            []
+          );
+        }
       }, [stringGetter]);
 
       const { dydxAddress } = useAccounts();


### PR DESCRIPTION
adds phantom notification
<img width="334" alt="image" src="https://github.com/user-attachments/assets/6f956517-12c6-40e3-8f4c-b763c3352422">

moves phantom to 2nd position
<img width="567" alt="image" src="https://github.com/user-attachments/assets/462c9db7-c58a-425f-aed5-0f96aaaffd25">


the way we move phantom to the 2nd position is by splicing it into index 1 of the injected wallets list if we detect it.
this will ensure it is either:
- 2nd position (if there is at least 1 other detected injected wallet)
- 1st position (if there are no other detected injected wallets) 