### PR TITLE
fix: add logic to clear or sync limit order input states to abacus

### DIFF
--- a/src/hooks/useTradeFormInputs.ts
+++ b/src/hooks/useTradeFormInputs.ts
@@ -4,14 +4,41 @@ import { shallowEqual } from 'react-redux';
 
 import { TradeInputField } from '@/constants/abacus';
 
+import { getIsAccountConnected } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
-import { getTradeFormInputs } from '@/state/inputsSelectors';
+import {
+  getInputTradeData,
+  getInputTradeOptions,
+  getTradeFormInputs,
+} from '@/state/inputsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { orEmptyObj } from '@/lib/typeUtils';
 
 export const useTradeFormInputs = () => {
   const tradeFormInputValues = useAppSelector(getTradeFormInputs, shallowEqual);
   const { limitPriceInput, triggerPriceInput, trailingPercentInput } = tradeFormInputValues;
+
+  const isAccountConnected = useAppSelector(getIsAccountConnected);
+  const { needsLimitPrice } = orEmptyObj(useAppSelector(getInputTradeOptions, shallowEqual));
+  const abacusInput = useAppSelector(getInputTradeData, shallowEqual);
+
+  const shouldResyncLimitPrice =
+    isAccountConnected &&
+    needsLimitPrice &&
+    limitPriceInput !== '' &&
+    !abacusInput?.price && // when abacus price has not been set
+    abacusInput?.size; // but abacus size has been set
+
+  useEffect(() => {
+    // limit price should always be prefilled with mid price if available
+    // resync when abacus size input has been updated (i.e. when user has changed size and abacus input is editable)
+    if (shouldResyncLimitPrice)
+      abacusStateManager.setTradeValue({
+        value: limitPriceInput,
+        field: TradeInputField.limitPrice,
+      });
+  }, [shouldResyncLimitPrice, limitPriceInput]);
 
   useEffect(() => {
     abacusStateManager.setTradeValue({

--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -167,7 +167,7 @@ class AbacusStateManager {
   clearTradeInputValues = ({ shouldResetSize }: { shouldResetSize?: boolean } = {}) => {
     const state = this.store?.getState();
 
-    const { needsTriggerPrice, needsTrailingPercent, needsLeverage, needsLimitPrice } =
+    const { needsTriggerPrice, needsTrailingPercent, needsLimitPrice } =
       (state && getInputTradeOptions(state)) ?? {};
 
     if (needsTrailingPercent) {
@@ -184,15 +184,21 @@ class AbacusStateManager {
     this.store?.dispatch(setTradeFormInputs(CLEARED_TRADE_INPUTS));
 
     if (shouldResetSize) {
-      this.setTradeValue({ value: null, field: TradeInputField.size });
-      this.setTradeValue({ value: null, field: TradeInputField.usdcSize });
-
-      if (needsLeverage) {
-        this.setTradeValue({ value: null, field: TradeInputField.leverage });
-      }
-
-      this.store?.dispatch(setTradeFormInputs(CLEARED_SIZE_INPUTS));
+      this.clearTradeInputSizeValues();
     }
+  };
+
+  clearTradeInputSizeValues = () => {
+    const state = this.store?.getState();
+    const { needsLeverage } = (state && getInputTradeOptions(state)) ?? {};
+    this.setTradeValue({ value: null, field: TradeInputField.size });
+    this.setTradeValue({ value: null, field: TradeInputField.usdcSize });
+
+    if (needsLeverage) {
+      this.setTradeValue({ value: null, field: TradeInputField.leverage });
+    }
+
+    this.store?.dispatch(setTradeFormInputs(CLEARED_SIZE_INPUTS));
   };
 
   clearClosePositionInputValues = ({

--- a/src/views/forms/TradeForm/TradeFormInputs.tsx
+++ b/src/views/forms/TradeForm/TradeFormInputs.tsx
@@ -53,7 +53,7 @@ export const TradeFormInputs = () => {
 
   useEffect(() => {
     // when limit price input is empty and mid price is available, set limit price input to mid price
-    if (!midMarketPrice || !needsLimitPrice || limitPriceInput) return;
+    if (!midMarketPrice || !needsLimitPrice || limitPriceInput !== '') return;
     dispatch(
       setTradeFormInputs({
         limitPriceInput: MustBigNumber(midMarketPrice).toFixed(tickSizeDecimals ?? USD_DECIMALS),

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -25,6 +25,7 @@ import { Tag } from '@/components/Tag';
 import { ToggleButton } from '@/components/ToggleButton';
 import { WithTooltip } from '@/components/WithTooltip';
 
+import { getIsAccountConnected } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
@@ -63,6 +64,13 @@ export const TradeSizeInputs = () => {
     getTradeFormInputs,
     shallowEqual
   );
+
+  const isAccountConnected = useAppSelector(getIsAccountConnected);
+
+  useEffect(() => {
+    // reset size inputs since abacus size is not properly synced/edited before account connection
+    abacusStateManager.clearTradeInputSizeValues();
+  }, [isAccountConnected]);
 
   // Update State variables if their inputs are not being source of calculations
   // Or if they have been reset to null


### PR DESCRIPTION
https://linear.app/dydx/issue/CT-1232/fe-doesnt-detect-that-defaulted-limit-price-to-mid-price-is-a-filled

bug: when remember me is not enabled and user is in logged out state (i.e. sees "recover keys" cta), after setting limit price or amount on the trade form and clicking recover keys, none of those values are actually set in abacus.

cause: this is a limitation introduced after isolated markets abacus refactor -- somehow we can't edit input states until there's a proper subaccount. the trade input states we have on FE are not synced to abacus, and there's not really a way to detect when abacus is ready to have their input state be editable.

fix: 
- reset input sizes when account is connected -- so even if user fills an amount, that will just get cleared after recovering keys
- syncs the limit price value from local input -> abacus input on some trigger (i.e. when account connected + abacus size is set); this is hacky but works

https://github.com/user-attachments/assets/c10ff882-381e-4d4f-8e74-01c149c499f7

