### PR TITLE
chore: refactor local orders state

### DIFF
--- a/src/hooks/tradingView/useChartLines.tsx
+++ b/src/hooks/tradingView/useChartLines.tsx
@@ -16,20 +16,19 @@ import type { ChartLine, PositionLineType, TvWidget } from '@/constants/tvchart'
 import { Icon, IconName } from '@/components/Icon';
 
 import {
-  cancelOrderConfirmed,
-  cancelOrderFailed,
-  cancelOrderSubmitted,
-  placeOrderFailed,
-  placeOrderSubmitted,
-  setLatestOrder,
-} from '@/state/account';
-import {
   getCurrentMarketOrders,
   getCurrentMarketPositionData,
   getIsAccountConnected,
 } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import {
+  cancelOrderFailed,
+  cancelOrderSubmitted,
+  placeOrderFailed,
+  placeOrderSubmitted,
+  setLatestOrder,
+} from '@/state/localOrders';
 import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
@@ -300,8 +299,6 @@ export const useChartLines = ({
         removePendingOrderAdjustment(orderPayload.clientId);
         return;
       }
-
-      dispatch(cancelOrderConfirmed(order.id));
 
       const res = await abacusStateManager.chainTransactions.placeOrderTransaction(orderPayload);
       const { error } = JSON.parse(res);

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -51,16 +51,15 @@ import { OrderStatusNotification } from '@/views/notifications/OrderStatusNotifi
 import { TradeNotification } from '@/views/notifications/TradeNotification';
 import { TransferStatusNotification } from '@/views/notifications/TransferStatusNotification';
 
+import { getSubaccountFills, getSubaccountOrders } from '@/state/accountSelectors';
+import { getSelectedDydxChainId } from '@/state/appSelectors';
+import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { openDialog } from '@/state/dialogs';
 import {
   getLocalCancelAlls,
   getLocalCancelOrders,
   getLocalPlaceOrders,
-  getSubaccountFills,
-  getSubaccountOrders,
-} from '@/state/accountSelectors';
-import { getSelectedDydxChainId } from '@/state/appSelectors';
-import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { openDialog } from '@/state/dialogs';
+} from '@/state/localOrdersSelectors';
 import { getAbacusNotifications, getCustomNotifications } from '@/state/notificationsSelectors';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 

--- a/src/hooks/useOnLastOrderIndexed.ts
+++ b/src/hooks/useOnLastOrderIndexed.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { getLatestOrderClientId } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
+import { getLatestOrderClientId } from '@/state/localOrdersSelectors';
 
 /**
  * @description This hook will fire a callback when the latest order has been updated to a non-pending state from the Indexer.

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -579,8 +579,8 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         data?: Nullable<HumanReadableCancelOrderPayload>
       ) => {
         const matchedOrder = orders?.find((order) => order.id === data?.orderId);
-        // confirmed does not necessarily mean short term orders are successfully canceled
-        // therefore we only update the canceled orders count from indexer response
+        // ##OrderOnlyConfirmedCancelViaIndexer: success here does not necessarily mean orders are successfully canceled,
+        // we use indexer response as source of truth on whether the order is actually canceled
         if (!success) {
           const errorParams = getValidErrorParamsFromParsingError(parsingError);
           if (matchedOrder) {
@@ -619,6 +619,8 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         const cancelOrderPayloads = data?.cancelOrderPayloads.toArray() ?? [];
 
         if (success) {
+          // #OrderOnlyConfirmedCancelViaIndexer
+          // even though trigger orders are probably confirmed canceled, we use indexer as source of truth to trigger order status toast
           onSuccess?.();
         } else {
           const errorParams = getValidErrorParamsFromParsingError(parsingError);

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -30,21 +30,19 @@ import { QUANTUM_MULTIPLIER } from '@/constants/numbers';
 import { TradeTypes } from '@/constants/trade';
 import { DydxAddress, WalletType } from '@/constants/wallets';
 
-import {
-  cancelAllOrderConfirmed,
-  cancelAllOrderFailed,
-  cancelAllSubmitted,
-  cancelOrderConfirmed,
-  cancelOrderFailed,
-  cancelOrderSubmitted,
-  placeOrderFailed,
-  placeOrderSubmitted,
-  setHistoricalPnl,
-  setSubaccount,
-} from '@/state/account';
-import { getBalances } from '@/state/accountSelectors';
+import { clearSubaccountState } from '@/state/account';
+import { getBalances, getSubaccountOrders } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
+import {
+  cancelAllOrderFailed,
+  cancelAllSubmitted,
+  cancelOrderFailed,
+  cancelOrderSubmitted,
+  clearLocalOrders,
+  placeOrderFailed,
+  placeOrderSubmitted,
+} from '@/state/localOrders';
 
 import abacusStateManager from '@/lib/abacus';
 import { getValidErrorParamsFromParsingError } from '@/lib/errors';
@@ -275,8 +273,8 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
   const dydxAddress = localDydxWallet?.address as DydxAddress;
 
   useEffect(() => {
-    dispatch(setSubaccount(undefined));
-    dispatch(setHistoricalPnl([]));
+    dispatch(clearSubaccountState());
+    dispatch(clearLocalOrders());
   }, [dispatch, dydxAddress]);
 
   // ------ Deposit/Withdraw Methods ------ //
@@ -550,7 +548,6 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
     }) => {
       const callback = (success: boolean, parsingError?: Nullable<ParsingError>) => {
         if (success) {
-          dispatch(cancelOrderConfirmed(orderId));
           onSuccess?.();
         } else {
           const errorParams = getValidErrorParamsFromParsingError(parsingError);
@@ -570,6 +567,8 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
     [dispatch]
   );
 
+  const orders = useAppSelector(getSubaccountOrders, shallowEqual);
+
   // when marketId is provided, only cancel orders for that market, otherwise cancel globally
   const cancelAllOrders = useCallback(
     (marketId?: string) => {
@@ -579,14 +578,15 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         parsingError?: Nullable<ParsingError>,
         data?: Nullable<HumanReadableCancelOrderPayload>
       ) => {
-        if (success) {
-          if (data?.orderId) dispatch(cancelAllOrderConfirmed(data.orderId));
-        } else {
+        const matchedOrder = orders?.find((order) => order.id === data?.orderId);
+        // confirmed does not necessarily mean short term orders are successfully canceled
+        // therefore we only update the canceled orders count from indexer response
+        if (!success) {
           const errorParams = getValidErrorParamsFromParsingError(parsingError);
-          if (data?.orderId) {
+          if (matchedOrder) {
             dispatch(
               cancelAllOrderFailed({
-                orderId: data.orderId,
+                order: matchedOrder,
                 errorParams,
               })
             );
@@ -598,7 +598,7 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
       dispatch(cancelAllSubmitted({ marketId, orderIds }));
       abacusStateManager.cancelAllOrders(marketId, callback);
     },
-    [dispatch]
+    [dispatch, orders]
   );
 
   // ------ Trigger Orders Methods ------ //
@@ -620,10 +620,6 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
 
         if (success) {
           onSuccess?.();
-
-          cancelOrderPayloads.forEach((payload: HumanReadableCancelOrderPayload) => {
-            dispatch(cancelOrderConfirmed(payload.orderId));
-          });
         } else {
           const errorParams = getValidErrorParamsFromParsingError(parsingError);
           onError?.(errorParams);

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -40,8 +40,8 @@ import { DydxAddress } from '@/constants/wallets';
 import { type RootStore } from '@/state/_store';
 // TODO Fix cycle
 // eslint-disable-next-line import/no-cycle
-import { placeOrderTimeout } from '@/state/account';
 import { setInitializationError } from '@/state/app';
+import { placeOrderTimeout } from '@/state/localOrders';
 
 import { dd } from '../analytics/datadog';
 import { signComplianceSignature, signComplianceSignatureKeplr } from '../compliance';

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -38,8 +38,6 @@ import { UNCOMMITTED_ORDER_TIMEOUT_MS } from '@/constants/trade';
 import { DydxAddress } from '@/constants/wallets';
 
 import { type RootStore } from '@/state/_store';
-// TODO Fix cycle
-// eslint-disable-next-line import/no-cycle
 import { setInitializationError } from '@/state/app';
 import { placeOrderTimeout } from '@/state/localOrders';
 

--- a/src/lib/abacus/stateNotification.ts
+++ b/src/lib/abacus/stateNotification.ts
@@ -24,7 +24,6 @@ import {
   setFills,
   setFundingPayments,
   setHistoricalPnl,
-  setLatestOrder,
   setRestrictionType,
   setStakingBalances,
   setStakingDelegations,
@@ -39,6 +38,7 @@ import { setApiState } from '@/state/app';
 import { setAssets } from '@/state/assets';
 import { setConfigs } from '@/state/configs';
 import { setInputs } from '@/state/inputs';
+import { setLatestOrder, updateFilledOrders, updateOrders } from '@/state/localOrders';
 import { updateNotifications } from '@/state/notifications';
 import { setHistoricalFundings, setLiveTrades, setMarkets, setOrderbook } from '@/state/perpetuals';
 
@@ -165,6 +165,7 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
             childSubaccountUpdate[subaccountId] = subaccountData;
           } else {
             dispatch(setSubaccount(subaccountData));
+            dispatch(updateOrders(subaccountData?.orders?.toArray() ?? []));
           }
         }
 
@@ -174,6 +175,7 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
             childSubaccountUpdate[subaccountId] = { ...childSubaccountUpdate[subaccountId], fills };
           } else {
             dispatch(setFills(fills));
+            dispatch(updateFilledOrders(fills));
           }
         }
 

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -28,7 +28,6 @@ import { OrdersTable, OrdersTableColumnKey } from '@/views/tables/OrdersTable';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
 import {
-  calculateHasUncommittedOrders,
   calculateIsAccountViewOnly,
   calculateShouldRenderActionsInPositionsTable,
 } from '@/state/accountCalculators';
@@ -40,6 +39,7 @@ import {
 } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configsSelectors';
+import { getHasUncommittedOrders } from '@/state/localOrdersSelectors';
 import { getCurrentMarketAssetId, getCurrentMarketId } from '@/state/perpetualsSelectors';
 
 import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
@@ -94,7 +94,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
   const shouldRenderActions = useParameterizedSelector(
     calculateShouldRenderActionsInPositionsTable
   );
-  const isWaitingForOrderToIndex = useAppSelector(calculateHasUncommittedOrders);
+  const isWaitingForOrderToIndex = useAppSelector(getHasUncommittedOrders);
   const showCurrentMarket = isTablet || view === PanelView.CurrentMarket;
 
   const fillsTagNumber = shortenNumberForDisplay(

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -10,6 +10,7 @@ import { configsSlice } from './configs';
 import { dialogsSlice } from './dialogs';
 import { inputsSlice } from './inputs';
 import { layoutSlice } from './layout';
+import { localOrdersSlice } from './localOrders';
 import { localizationSlice } from './localization';
 import localizationMiddleware from './localizationMiddleware';
 import { notificationsSlice } from './notifications';
@@ -26,6 +27,7 @@ export const store = configureStore({
     inputs: inputsSlice.reducer,
     layout: layoutSlice.reducer,
     localization: localizationSlice.reducer,
+    localOrders: localOrdersSlice.reducer,
     notifications: notificationsSlice.reducer,
     perpetuals: perpetualsSlice.reducer,
     vaults: vaultsSlice.reducer,

--- a/src/state/accountCalculators.ts
+++ b/src/state/accountCalculators.ts
@@ -6,7 +6,6 @@ import {
   getSubaccountId,
   getSubaccountOpenOrders,
   getUnbondingDelegations,
-  getUncommittedOrderClientIds,
 } from '@/state/accountSelectors';
 import { createAppSelector } from '@/state/appTypes';
 
@@ -58,14 +57,6 @@ export const calculateIsAccountViewOnly = createAppSelector(
   [getOnboardingState, calculateCanViewAccount],
   (onboardingState: OnboardingState, canViewAccountInfo: boolean) =>
     onboardingState !== OnboardingState.AccountConnected && canViewAccountInfo
-);
-
-/**
- * @description calculate whether the subaccount has uncommitted positions
- */
-export const calculateHasUncommittedOrders = createAppSelector(
-  [getUncommittedOrderClientIds],
-  (uncommittedOrderClientIds: string[]) => uncommittedOrderClientIds.length > 0
 );
 
 /**

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -157,12 +157,6 @@ export const getSubaccountOrders = createAppSelector(
 
 /**
  * @param state
- * @returns latestOrder of the currently connected subaccount throughout this session
- */
-export const getLatestOrder = (state: RootState) => state.account?.latestOrder;
-
-/**
- * @param state
  * @returns list of order ids that user has cleared and should be hidden
  */
 export const getSubaccountClearedOrderIds = (state: RootState) => state.account.clearedOrderIds;
@@ -368,43 +362,6 @@ export const getSubaccountOrderSizeBySideAndOrderbookLevel = createAppSelector(
     return orderSizeBySideAndPrice;
   }
 );
-
-/**
- * @returns the clientId of the latest order
- */
-export const getLatestOrderClientId = createAppSelector(
-  [getLatestOrder],
-  (order) => order?.clientId
-);
-
-/**
- * @returns the rawValue status of the latest order
- */
-export const getLatestOrderStatus = createAppSelector(
-  [getLatestOrder],
-  (order) => order?.status.rawValue
-);
-
-/**
- * @returns a list of clientIds belonging to uncommmited orders
- */
-export const getUncommittedOrderClientIds = (state: RootState) =>
-  state.account.uncommittedOrderClientIds;
-
-/**
- * @returns a list of locally placed orders for the current FE session
- */
-export const getLocalPlaceOrders = (state: RootState) => state.account.localPlaceOrders;
-
-/**
- * @returns a list of locally canceled orders for the current FE session
- */
-export const getLocalCancelOrders = (state: RootState) => state.account.localCancelOrders;
-
-/**
- * @returns a list of locally batch canceled orders for the current FE session
- */
-export const getLocalCancelAlls = (state: RootState) => state.account.localCancelAlls;
 
 /**
  * @param orderId

--- a/src/state/localOrders.ts
+++ b/src/state/localOrders.ts
@@ -1,0 +1,265 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import _ from 'lodash';
+
+import { Nullable, SubaccountFill, SubaccountOrder } from '@/constants/abacus';
+import { DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS, ErrorParams } from '@/constants/errors';
+import {
+  CANCEL_ALL_ORDERS_KEY,
+  CancelOrderStatuses,
+  LocalCancelAllData,
+  LocalCancelOrderData,
+  LocalPlaceOrderData,
+  PlaceOrderStatuses,
+  TradeTypes,
+} from '@/constants/trade';
+
+import { isTruthy } from '@/lib/isTruthy';
+import { isOrderStatusCanceled } from '@/lib/orders';
+
+export interface LocalOrdersState {
+  localPlaceOrders: LocalPlaceOrderData[];
+  localCancelOrders: LocalCancelOrderData[];
+  localCancelAlls: Record<string, LocalCancelAllData>;
+  latestOrder?: Nullable<SubaccountOrder>;
+}
+
+const initialState: LocalOrdersState = {
+  localPlaceOrders: [],
+  localCancelOrders: [],
+  localCancelAlls: {},
+  latestOrder: undefined,
+};
+
+export const localOrdersSlice = createSlice({
+  name: 'LocalOrders',
+  initialState,
+  reducers: {
+    clearLocalOrders: () => {
+      return initialState;
+    },
+    updateOrders: (state, action: PayloadAction<SubaccountOrder[]>) => {
+      const canceledOrderIdsInPayload = action.payload
+        .filter((order) => isOrderStatusCanceled(order.status))
+        .map((order) => order.id);
+
+      if (!canceledOrderIdsInPayload) return state;
+
+      // ignore locally canceled orders since it's intentional and already handled
+      // by local cancel tracking and notification
+      const isOrderCanceledByBackend = (orderId: string) =>
+        canceledOrderIdsInPayload.includes(orderId) &&
+        !state.localCancelOrders.some((order) => order.orderId === orderId);
+
+      const getNewCanceledOrderIds = (batch: LocalCancelAllData) => {
+        const newCanceledOrderIds = _.intersection(batch.orderIds, canceledOrderIdsInPayload);
+        return _.uniq([...(batch.canceledOrderIds ?? []), ...newCanceledOrderIds]);
+      };
+
+      return {
+        ...state,
+        localPlaceOrders: state.localPlaceOrders.map((order) =>
+          order.orderId &&
+          canceledOrderIdsInPayload.includes(order.orderId) &&
+          isOrderCanceledByBackend(order.orderId)
+            ? {
+                ...order,
+                submissionStatus: PlaceOrderStatuses.Canceled,
+              }
+            : order
+        ),
+        localCancelOrders: state.localCancelOrders.map((order) =>
+          canceledOrderIdsInPayload.includes(order.orderId)
+            ? { ...order, submissionStatus: CancelOrderStatuses.Canceled }
+            : order
+        ),
+        localCancelAlls: _.mapValues(state.localCancelAlls, (batch) => ({
+          ...batch,
+          canceledOrderIds: getNewCanceledOrderIds(batch),
+        })),
+      };
+    },
+    updateFilledOrders: (state, action: PayloadAction<SubaccountFill[]>) => {
+      const filledOrderIds = action.payload.map((fill) => fill.orderId).filter(isTruthy);
+      if (!filledOrderIds) return state;
+
+      const getFailedToCancelOrderIds = (batch: LocalCancelAllData) => {
+        const newFailedCancelOrderIds = _.intersection(batch.orderIds, filledOrderIds);
+        return _.uniq([...(batch.failedOrderIds ?? []), ...newFailedCancelOrderIds]);
+      };
+
+      return {
+        ...state,
+        localPlaceOrders: state.localPlaceOrders.map((order) =>
+          order.submissionStatus < PlaceOrderStatuses.Filled &&
+          order.orderId &&
+          filledOrderIds.includes(order.orderId)
+            ? {
+                ...order,
+                submissionStatus: PlaceOrderStatuses.Filled,
+              }
+            : order
+        ),
+        localCancelOrders: state.localCancelOrders.filter(
+          (order) => !filledOrderIds.includes(order.orderId)
+        ),
+        localCancelAlls: _.mapValues(state.localCancelAlls, (batch) => ({
+          ...batch,
+          failedOrderIds: getFailedToCancelOrderIds(batch),
+        })),
+      };
+    },
+    setLatestOrder: (state, action: PayloadAction<Nullable<SubaccountOrder>>) => {
+      const { clientId, id } = action.payload ?? {};
+      state.latestOrder = action.payload;
+
+      if (clientId) {
+        state.localPlaceOrders = state.localPlaceOrders.map((order) =>
+          order.clientId === clientId && order.submissionStatus < PlaceOrderStatuses.Placed
+            ? {
+                ...order,
+                orderId: id,
+                submissionStatus: PlaceOrderStatuses.Placed,
+              }
+            : order
+        );
+      }
+    },
+    placeOrderSubmitted: (
+      state,
+      action: PayloadAction<{ marketId: string; clientId: string; orderType: TradeTypes }>
+    ) => {
+      state.localPlaceOrders.push({
+        ...action.payload,
+        submissionStatus: PlaceOrderStatuses.Submitted,
+      });
+    },
+    placeOrderFailed: (
+      state,
+      action: PayloadAction<{ clientId: string; errorParams: ErrorParams }>
+    ) => {
+      state.localPlaceOrders = state.localPlaceOrders.map((order) =>
+        order.clientId === action.payload.clientId
+          ? {
+              ...order,
+              errorParams: action.payload.errorParams,
+            }
+          : order
+      );
+    },
+    placeOrderTimeout: (state, action: PayloadAction<string>) => {
+      const uncommitedOrders = state.localPlaceOrders
+        .filter(
+          (order) => order.submissionStatus === PlaceOrderStatuses.Submitted && !order.errorParams
+        )
+        .map((order) => order.clientId);
+      if (uncommitedOrders.includes(action.payload)) {
+        placeOrderFailed({
+          clientId: action.payload,
+          errorParams: DEFAULT_SOMETHING_WENT_WRONG_ERROR_PARAMS,
+        });
+      }
+    },
+    cancelOrderSubmitted: (state, action: PayloadAction<string>) => {
+      state.localCancelOrders.push({
+        orderId: action.payload,
+        submissionStatus: CancelOrderStatuses.Submitted,
+      });
+    },
+    cancelOrderFailed: (
+      state,
+      action: PayloadAction<{ orderId: string; errorParams: ErrorParams }>
+    ) => {
+      state.localCancelOrders = state.localCancelOrders.map((order) =>
+        order.orderId === action.payload.orderId
+          ? {
+              ...order,
+              errorParams: action.payload.errorParams,
+            }
+          : order
+      );
+    },
+    cancelAllSubmitted: (
+      state,
+      action: PayloadAction<{ marketId?: string; orderIds: string[] }>
+    ) => {
+      const { marketId, orderIds } = action.payload;
+      // when marketId is undefined, it means cancel all orders globally
+      const cancelAllKey = marketId ?? CANCEL_ALL_ORDERS_KEY;
+
+      state.localCancelAlls[cancelAllKey] = {
+        key: cancelAllKey,
+        orderIds,
+      };
+
+      state.localCancelOrders = [
+        ...state.localCancelOrders,
+        ...orderIds.map((orderId) => ({
+          orderId,
+          submissionStatus: CancelOrderStatuses.Submitted,
+          isSubmittedThroughCancelAll: true, // track this to skip certain notifications
+        })),
+      ];
+    },
+    cancelAllOrderFailed: (
+      state,
+      action: PayloadAction<{
+        order: SubaccountOrder;
+        errorParams?: ErrorParams;
+      }>
+    ) => {
+      const { order, errorParams } = action.payload;
+      updateCancelAllOrderIds(state, order.id, 'failedOrderIds', order.marketId);
+      if (errorParams) cancelOrderFailed({ orderId: order.id, errorParams });
+    },
+  },
+});
+
+export const {
+  clearLocalOrders,
+
+  updateOrders,
+  updateFilledOrders,
+
+  setLatestOrder,
+
+  placeOrderSubmitted,
+  placeOrderFailed,
+  placeOrderTimeout,
+
+  cancelOrderSubmitted,
+  cancelOrderFailed,
+
+  cancelAllSubmitted,
+  cancelAllOrderFailed,
+} = localOrdersSlice.actions;
+
+// helper functions
+const updateCancelAllOrderIds = (
+  state: LocalOrdersState,
+  orderId: string,
+  key: 'canceledOrderIds' | 'failedOrderIds',
+  cancelAllKey: string
+) => {
+  const getNewOrderIds = (cancelAll: LocalCancelAllData) => {
+    const existingOrderIds = cancelAll[key] ?? [];
+    return cancelAll.orderIds.includes(orderId) && !existingOrderIds.includes(orderId)
+      ? [...existingOrderIds, orderId]
+      : existingOrderIds;
+  };
+
+  const updateKey = (currentKey: string) => ({
+    ...state.localCancelAlls[currentKey],
+    [key]: getNewOrderIds(state.localCancelAlls[currentKey]),
+  });
+
+  state.localCancelAlls = {
+    ...state.localCancelAlls,
+    ...(state.localCancelAlls[CANCEL_ALL_ORDERS_KEY] && {
+      [CANCEL_ALL_ORDERS_KEY]: updateKey(CANCEL_ALL_ORDERS_KEY),
+    }),
+    ...(state.localCancelAlls[cancelAllKey] && {
+      [cancelAllKey]: updateKey(cancelAllKey),
+    }),
+  };
+};

--- a/src/state/localOrdersSelectors.ts
+++ b/src/state/localOrdersSelectors.ts
@@ -1,0 +1,42 @@
+import { PlaceOrderStatuses } from '@/constants/trade';
+
+import { type RootState } from './_store';
+import { createAppSelector } from './appTypes';
+
+/**
+ * @param state
+ * @returns latestOrder of the currently connected subaccount throughout this session
+ */
+export const getLatestOrder = (state: RootState) => state.localOrders?.latestOrder;
+
+/**
+ * @returns the clientId of the latest order
+ */
+export const getLatestOrderClientId = createAppSelector(
+  [getLatestOrder],
+  (order) => order?.clientId
+);
+
+/**
+ * @returns a list of locally placed orders for the current FE session
+ */
+export const getLocalPlaceOrders = (state: RootState) => state.localOrders.localPlaceOrders;
+
+/**
+ * @returns a list of locally canceled orders for the current FE session
+ */
+export const getLocalCancelOrders = (state: RootState) => state.localOrders.localCancelOrders;
+
+/**
+ * @returns a list of locally batch canceled orders for the current FE session
+ */
+export const getLocalCancelAlls = (state: RootState) => state.localOrders.localCancelAlls;
+
+/**
+ * @returns whether the subaccount has uncommitted orders (local orders that are only submitted and not placed)
+ */
+export const getHasUncommittedOrders = createAppSelector([getLocalPlaceOrders], (placeOrders) =>
+  placeOrders.some(
+    (order) => order.submissionStatus === PlaceOrderStatuses.Submitted && !order.errorParams
+  )
+);

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -27,8 +27,9 @@ import { OrderStatusIcon } from '@/views/OrderStatusIcon';
 
 import { clearOrder } from '@/state/account';
 import { calculateIsAccountViewOnly } from '@/state/accountCalculators';
-import { getLocalCancelOrders, getOrderDetails } from '@/state/accountSelectors';
+import { getOrderDetails } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { getLocalCancelOrders } from '@/state/localOrdersSelectors';
 
 import { MustBigNumber } from '@/lib/numbers';
 import { isMarketOrderType, isOrderStatusClearable } from '@/lib/orders';


### PR DESCRIPTION
motivation: local orders placement/canceling tracking are getting more complicated, before i add close all positions (which has another notification / tracking), refactoring this away from account state so it's clearer what it's doing

changes/ improvements:
- moved local orders state tracking (i.e. placing/canceling order submitted -> confirmed -> filled/canceled/failed) to a new slice `localOrders`
- removed `uncommittedOrderClientIds` tracking because `localPlaceOrders` does kinda the same thing

fixed some bugs:
- `cancelOrderConfirmed`: confirmed a canceling transaction isn't doing what it thinks it's doing -- it's just confirming the transaction went through, but not that the order is confirmed canceled (esp apparent with short term orders). removing this and using indexer as source of truth instead. this is accurate but could seem to add some lag for success case.
- `clearSubaccountState`: disconnecting wallet wasn't clearing relevant subaccount state: transfers/trade history etc. weren't cleared

testing:
- place short term orders (market order + IOC order with limit price that might fail), observe order status toasts
- cancel short term orders via cancel button and cancel all (this most likely fails, observe that it should reflect that)
- place long term order and cancel them