### PR TITLE
fix: revert enum value for skiptransfer

### DIFF
--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -3,7 +3,10 @@ import { SkipStatusResponse } from './skip';
 /** implemented in useNotificationTypes */
 export enum NotificationType {
   AbacusGenerated = 'AbacusGenerated',
-  SkipTransfer = 'SkipTransfer',
+  // Until we have migrations enabled, we need to keep underlying values the same
+  // So the notifications don't get retriggered
+  // It's pretty scary getting a bunch of unexpected withdrawal notifications
+  SkipTransfer = 'SquidTransfer',
   TriggerOrder = 'TriggerOrder',
   ReleaseUpdates = 'ReleaseUpdates',
   ApiError = 'ApiError',


### PR DESCRIPTION
https://dydx-team.slack.com/archives/C03GKH23YAZ/p1727249969119469

while cleaning up squid code, we updated the [notification type enum value](https://github.com/dydxprotocol/v4-web/pull/1040/files#diff-8241d76f654c8fbfc7a5d8e8e66be6b952adfcd5539b3d1543048cf483c50bf2L8).
this changed the expected caching key which caused the frontend to register all transfers as new notifications.

This caused panic for some users as they saw several unexpected "your withdrawal has been completed" notifications, making them think someone may have drained their account.