### PR TITLE
feat: add call to prepopulate account cache when local wallet is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.11.13",
-    "@dydxprotocol/v4-client-js": "1.3.7",
+    "@dydxprotocol/v4-client-js": "1.5.0",
     "@dydxprotocol/v4-localization": "^1.1.203",
     "@dydxprotocol/v4-proto": "^6.0.1",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 1.11.13
     version: 1.11.13
   '@dydxprotocol/v4-client-js':
-    specifier: 1.3.7
-    version: 1.3.7
+    specifier: 1.5.0
+    version: 1.5.0
   '@dydxprotocol/v4-localization':
     specifier: ^1.1.203
     version: 1.1.203
@@ -3029,8 +3029,8 @@ packages:
       format-util: 1.0.5
     dev: false
 
-  /@dydxprotocol/v4-client-js@1.3.7:
-    resolution: {integrity: sha512-t5RYUf1WuGeQRoVblCXQklA5q+1sktcCzyrqzDjfWN50/9a0KPmFaapnXQwDLNzgU9+1TMmAiS7INsBV24idHQ==}
+  /@dydxprotocol/v4-client-js@1.5.0:
+    resolution: {integrity: sha512-IDnUg6AoaejoUlfVDNmFacyWS0Rl1wrlW6P1ZykXO7FmZAxfR7FV3NEQ0SNLQNZz4aTlag0CS+T5DIkAWvDNZA==}
     dependencies:
       '@cosmjs/amino': 0.32.3
       '@cosmjs/encoding': 0.32.3

--- a/src/lib/abacus/dydxChainTransactions.ts
+++ b/src/lib/abacus/dydxChainTransactions.ts
@@ -84,6 +84,7 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
 
   setLocalWallet(localWallet: LocalWallet) {
     this.localWallet = localWallet;
+    if (this.localWallet.address) this.populateAccountNumberCache(this.localWallet.address);
   }
 
   clearAccounts() {
@@ -167,6 +168,10 @@ class DydxChainTransactions implements AbacusDYDXChainTransactionsProtocol {
       this.store?.dispatch(setInitializationError(error?.message ?? 'Unknown error'));
       log('DydxChainTransactions/connectNetwork', error);
     }
+  }
+
+  populateAccountNumberCache(address: string) {
+    this.compositeClient?.populateAccountNumberCache(address);
   }
 
   setSelectedGasDenom(denom: SelectedGasDenom) {


### PR DESCRIPTION
- call the prepopulate account number cache function on setting local wallet
- so we can skip the account number fetch roundtrip when placing order

testing:
setting breakpoints and verifying that this is set (both when remember me is enabled + after connecting wallet)
![image](https://github.com/user-attachments/assets/ec98d471-2263-4e06-9cfe-920c47dbba89)

placing a short term order right away:
![image](https://github.com/user-attachments/assets/40452d6e-f741-44b7-885b-40c2523df94c)

