### PR TITLE
feat: sort wallets [OTE-825]

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -1,7 +1,7 @@
 {
    "apps": {
       "ios": {
-         "scheme": "dydxv4"
+         "scheme": "dydx-t-v4"
       }
    },
    "tokens": {
@@ -35,11 +35,11 @@
             "image": "/currencies/usdc.png"
          }
       },
-      "dydx-mainnet-1": {
-         "comment": "Mainnet",
+      "[mainnet chain id]": {
+         "comment": "Change according to mainnet release",
          "chain": {
-            "name": "DYDX",
-            "denom": "adydx",
+            "name": "TokenName",
+            "denom": "tokenDenom",
             "decimals": 18,
             "image": "/currencies/dydx.png"
          },
@@ -61,6 +61,7 @@
          "blogs": "https://www.dydx.foundation/blog",
          "foundation": "https://www.dydx.foundation",
          "help": "https://help.dydx.exchange/",
+         "vaultLearnMore": "https://help.dydx.exchange",
          "reduceOnlyLearnMore": "https://help.dydx.exchange/articles/6345793-reduce-only-orders",
          "mintscanBase": "https://mintscan.io/dydx-testnet",
          "documentation": "https://docs.dydx.exchange/",
@@ -73,7 +74,7 @@
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
          "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
-         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
+         "adjustTargetLeverageLearnMore": "",
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/concepts-trading/rewards_fees_and_parameters",
          "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
@@ -102,6 +103,7 @@
          "blogs": "https://www.dydx.foundation/blog",
          "foundation": "https://www.dydx.foundation",
          "help": "https://help.dydx.exchange/",
+         "vaultLearnMore": "https://help.dydx.exchange",
          "reduceOnlyLearnMore": "https://help.dydx.exchange/articles/6345793-reduce-only-orders",
          "mintscanBase": "https://mintscan.io/dydx-testnet",
          "governanceLearnMore": "https://help.dydx.exchange",
@@ -110,7 +112,7 @@
          "keplrDashboard": "https://testnet.keplr.app/",
          "strideZoneApp": "https://testnet.stride.zone",
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
-         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
+         "adjustTargetLeverageLearnMore": "",
          "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
          "launchIncentive": "https://cloud.chaoslabs.co",
@@ -130,46 +132,45 @@
          "dydxLearnMore": "https://www.mintscan.io/dydx",
          "affiliateProgram": ""
       },
-      "dydx-mainnet-1": {
-         "tos": "https://dydx.trade/terms",
-         "privacy": "https://dydx.trade/privacy",
-         "statusPage": "https://status.dydx.trade/",
-         "mintscan": "https://www.mintscan.io/dydx/tx/{tx_hash}",
-         "mintscanBase": "https://www.mintscan.io/dydx",
-         "feedback": "",
-         "blogs": "https://www.dydx.foundation/blog",
-         "foundation": "https://www.dydx.foundation",
-         "reduceOnlyLearnMore": "https://help.dydx.trade/en/articles/8607918-reduce-only-order",
-         "documentation": "https://docs.dydx.exchange/",
-         "community": "https://discord.com/invite/dydx",
-         "help": "https://help.dydx.trade/",
-         "governanceLearnMore": "https://help.dydx.trade/en/collections/6936883-governance-staking",
-         "newMarketProposalLearnMore": "https://dydx.exchange/blog/new-market-proposals",
-         "stakingLearnMore": "https://help.dydx.trade/en/articles/8581388-accessing-governance-and-staking-on-dydx-chain",
-         "keplrDashboard": "https://wallet.keplr.app/chains/dydx?tab=staking",
-         "strideZoneApp": "https://app.stride.zone/?chain=DYDX",
-         "accountExportLearnMore": "https://help.dydx.trade/en/articles/8581269-secret-phrase-on-dydx-chain",
-         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
-         "walletLearnMore": "https://help.dydx.trade/en/articles/166997-supported-default-wallets-on-dydx-chain",
-         "withdrawalGateLearnMore": "https://help.dydx.trade/en/articles/9004706-withdrawals-on-dydx-chain#h_e61f043370",
-         "launchIncentive": "https://cloud.chaoslabs.co",
-         "tradingRewardsLearnMore": "https://docs.dydx.exchange/concepts-trading/rewards_fees_and_parameters",
-         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
-         "initialMarginFractionLearnMore": "https://docs.dydx.exchange/governance/functionalities#liquidity-tiers",
-         "equityTiersLearnMore": "https://help.dydx.trade/en/articles/171918-equity-tiers-and-rate-limits",
-         "fetAgixMarketWindDownProposal": "https://www.mintscan.io/dydx/proposals/61",
-         "contractLossMechanismLearnMore": "https://help.dydx.trade/en/articles/166973-contract-loss-mechanisms-on-dydx-chain",
-         "isolatedMarginLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
-         "mintscanValidatorsLearnMore": "https://www.mintscan.io/dydx/validators",
-         "protocolStaking": "https://protocolstaking.info/",
-         "stakingAndClaimingRewardsLearnMore": "https://help.dydx.trade/en/articles/178571-staking-and-unstaking-dydx-and-claiming-staking-rewards",
-         "rndrParamProposal": "https://www.mintscan.io/dydx/proposals/126",
-         "predictionMarketLearnMore": "https://help.dydx.trade/en",
-         "discoveryProgram": "https://www.dydx.foundation/blog/dydx-discovery-user-interviews?utm_source=dYdXTelegram&utm_medium=GlobalSocial&utm_campaign=GlobalSocial",
-         "getInTouch": "https://t.me/+amt-yoIUwDplN2I5",
-         "deployerTermsAndConditions": "https://www.dydx.trade/terms",
-         "dydxLearnMore": "https://www.mintscan.io/dydx",
-         "affiliateProgram": ""
+      "[mainnet chain id]": {
+         "tos": "[HTTP link to TOS]",
+         "privacy": "[HTTP link to Privacy Policy]",
+         "statusPage": "[HTTP link to status page]",
+         "mintscan": "[HTTP link to Mintscan, with {tx_hash} placeholder]",
+         "mintscanBase": "[HTTP link to TOS mintscan base url]",
+         "feedback": "[HTTP link to feedback form, can be null]",
+         "blogs": "[HTTP link to blogs, can be null]",
+         "foundation": "[HTTP link to foundation, can be null]",
+         "reduceOnlyLearnMore": "[HTTP link to reduce-only learn more, can be null]",
+         "documentation": "[HTTP link to documentation, can be null]",
+         "community": "[HTTP link to community, can be null]",
+         "help": "[HTTP link to help page, can be null]",
+         "vaultLearnMore": "[HTTP link to help page, can be null]",
+         "governanceLearnMore": "[HTTP link to governance learn more, can be null]",
+         "newMarketProposalLearnMore": "[HTTP link to new market proposal learn more, can be null]",
+         "stakingLearnMore": "[HTTP link to staking learn more, can be null]",
+         "keplrDashboard": "[HTTP link to keplr dashboard, can be null]",
+         "strideZoneApp": "[HTTP link to stride zone app, can be null]",
+         "accountExportLearnMore": "[HTTP link to account export learn more, can be null]",
+         "adjustTargetLeverageLearnMore": "[HTTP link to adjust target leverage learn more, can be null]",
+         "walletLearnMore": "[HTTP link to wallet learn more, can be null]",
+         "withdrawalGateLearnMore": "[HTTP link to withdrawal gate learn more, can be null]",
+         "launchIncentive": "[HTTP link to launch incentive host, can be null]",
+         "tradingRewardsLearnMore": "[HTTP link to trading rewards learn more, can be null]",
+         "exchangeStats": "[HTTP link to exchange stats, can be null]",
+         "initialMarginFractionLearnMore": "[HTTP link to governance functionalities liquidity tiers, can be null]",
+         "equityTiersLearnMore": "[HTTP link to equity tiers learn more, can be null]",
+         "contractLossMechanismLearnMore": "[HTTP link to documentation on contract loss mechanisms]",
+         "isolatedMarginLearnMore": "[HTTP link to documentation on isolated margin]",
+         "mintscanValidatorsLearnMore": "[HTTP link to mintscan info on validators]",
+         "protocolStaking": "[HTTP link to protocol staking info]",
+         "stakingAndClaimingRewardsLearnMore": "[HTTP link to staking and claiming rewards learn more]",
+         "predictionMarketLearnMore": "[HTTP link to prediction market learn more]",
+         "discoveryProgram": "[HTTP link to discovery program learn more]",
+         "getInTouch": "[HTTP link to get in touch with traders]",
+         "deployerTermsAndConditions": "[HTTP link to terms and conditions, can be null]",
+         "dydxLearnMore": "[HTTP link to information about the dYdX blockchain]",
+         "affiliateProgram": "[HTTP link to information about the affiliate program]"
       }
    },
    "wallets": {
@@ -209,21 +210,21 @@
          "signTypedDataAction": "dYdX Chain Onboarding",
          "signTypedDataDomainName": "dYdX Chain"
       },
-      "dydx-mainnet-1": {
+      "[mainnet chain id]": {
          "walletconnect": {
             "client": {
-               "name": "dYdX v4",
-               "description": "dYdX v4 App",
-               "iconUrl": "/logos/dydx-x.png"
+               "name": "[Name of the app]",
+               "description": "[Description of the app]",
+               "iconUrl": "[Relative URL of the icon URL]"
             },
             "v2": {
-               "projectId": "fd67e5fbec90c07b6012699738d4a487"
+               "projectId": "[Project ID]"
             }
          },
          "walletSegue": {
-            "callbackUrl": "/walletsegue"
+            "callbackUrl": "[Relative callback URL for WalletSegue, should match apple-app-site-association]"
          },
-         "images": "/wallets/",
+         "images": "[Relative URL for wallet images]",
          "signTypedDataAction": "dYdX Chain Onboarding",
          "signTypedDataDomainName": "dYdX Chain"
       }
@@ -243,11 +244,11 @@
             "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
          }
       },
-      "dydx-mainnet-1": {
+      "[mainnet chain id]": {
          "newMarketProposal": {
-            "initialDepositAmount": 2000000000000000000000,
-            "delayBlocks": 3600,
-            "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1046uSR2sltA6siZGnvBlgUp4xlPNM7dPFvUgdACgTy4/edit?usp=sharing"
+            "initialDepositAmount": 0,
+            "delayBlocks": 0,
+            "newMarketsMethodology": "[URL to spreadsheet or document that explains methodology]"
          }
       }
    },
@@ -300,7 +301,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -313,7 +313,6 @@
             "validators": [
                "https://validator.v4dev.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -340,7 +339,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -353,7 +351,6 @@
             "validators": [
                "http://dev2-validator-lb-58813722.us-east-2.elb.amazonaws.com"
             ],
-            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -378,7 +375,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -391,7 +387,6 @@
             "validators": [
                "http://validator-dev3-lb-1393802013.us-east-2.elb.amazonaws.com"
             ],
-            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -418,7 +413,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -431,7 +425,6 @@
             "validators": [
                "https://validator.v4dev4.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -458,7 +451,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -471,7 +463,6 @@
             "validators": [
                "http://18.223.78.50:26657"
             ],
-            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -496,7 +487,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -510,7 +500,6 @@
             "validators": [
                "https://validator.v4staging.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -535,7 +524,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -549,7 +537,6 @@
             "validators": [
                "https://validator.v4staging.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -561,7 +548,7 @@
             "ios": {
                "minimalVersion": "1.0",
                "build": 40000,
-               "url": "https://apps.apple.com/app/dydx/id6475599596"
+               "url": "https://apps.apple.com/app/dydx/id1564787350"
             },
             "android": {
                "minimalVersion": "1.1",
@@ -586,7 +573,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -600,7 +586,6 @@
             "validators": [
                "https://validator-uswest1.v4staging.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -619,13 +604,12 @@
          }
       },
       "dydxprotocol-testnet": {
-         "name": "Testnet",
+         "name": "v4 Public Testnet",
          "ethereumChainId": "11155111",
          "dydxChainId": "dydx-testnet-4",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -642,7 +626,6 @@
                "https://test-dydx.kingnodes.com",
                "https://dydx-rpc.liquify.com/api=8878132/dydx"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -672,7 +655,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -685,7 +667,6 @@
             "validators": [
                "https://validator.v4testnet.dydx.exchange"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -712,7 +693,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -725,7 +705,6 @@
             "validators": [
                "https://dydx-testnet.nodefleet.org"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -752,7 +731,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -765,7 +743,6 @@
             "validators": [
                "https://test-dydx.kingnodes.com"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -792,7 +769,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -805,7 +781,6 @@
             "validators": [
                "https://dydx-rpc.liquify.com/api=8878132/dydx"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -832,7 +807,6 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
-         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -845,7 +819,6 @@
             "validators": [
                "https://dydx-testnet-rpc.polkachu.com/"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -871,7 +844,6 @@
          "dydxChainId": "dydx-testnet-4",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
-         "squidIntegratorId": "dYdX-api",
          "deployerName": "dYdX",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
@@ -885,7 +857,6 @@
             "validators": [
                "https://dydx-testnet-full-rpc.public.blastapi.io/"
             ],
-            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -906,77 +877,39 @@
          }
       },
       "dydxprotocol-mainnet": {
-         "name": "Mainnet",
+         "name": "v4",
          "ethereumChainId": "1",
-         "dydxChainId": "dydx-mainnet-1",
+         "dydxChainId": "[mainnet chain id]",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
-         "deployerName": "dYdX Ops subDAO",
+         "deployerName": "[deployer name]",
          "rewardsHistoryStartDateMs": "1706486400000",
-         "squidIntegratorId": "dYdX-api",
          "isMainNet": true,
          "endpoints": {
             "indexers": [
                {
-                  "api": "https://indexer.v4mainnet.dydx.exchange",
-						"socket": "wss://indexer.v4mainnet.dydx.exchange"
+                  "api": "[REST endpoint]",
+                  "socket": "[Websocket endpoint]"
                }
             ],
             "validators": [
-               "https://dydx-dao-rpc.polkachu.com",
-               "https://dydx-mainnet-full-rpc.public.blastapi.io",
-               "https://dydx-ops-rpc.kingnodes.com"
+               "[Validator endpoint 1",
+               "[Validator endpoint n]"
             ],
-            "0xsquid": "https://api.squidrouter.com",
-            "skip": "https://api.skip.money",
-            "nobleValidator": "https://noble-rpc.polkachu.com/",
-            "geo": "https://api.dydx.exchange/v4/geo",
-            "stakingAPR": "https://apybara-proxy-web-mainnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
-            "solanaRpcUrl": "https://falling-crimson-violet.solana-mainnet.quiknode.pro/33d146e02bb33f996515f57faa3e7e1c3b8dd429",
-            "osmosisValidator": "https://rpc.osmosis.zone",
-            "neutronValidator": "https://neutron-rpc.publicnode.com"
+            "skip": "[Skip endpoint for mainnet]",
+            "solanaRpcUrl": "[Solana rpc url for mainnet]",
+            "nobleValidator": "[noble validator endpoint for mainnet]",
+            "osmosisValidator": "[osmosis validator endpoint for mainnet]",
+            "neutronValidator": "[neutron validator endpoint for mainnet]",
+            "geo": "[geo endpoint for mainnet]",
+            "stakingAPR": "[staking APR endpoint for mainnet]"
          },
-         "ios": {
-            "minimalVersion": "1.4.2",
-            "build": 31055,
-            "url": "https://apps.apple.com/app/id6475599596"
-         },
-         "android": {
-            "minimalVersion": "1.9.0",
-            "build": 54,
-            "url": "https://play.google.com/store/apps/details?id=trade.opsdao.dydxchain&pli=1"
-         },
-         "apps": {
-            "ios": {
-               "minimalVersion": "1.4.2",
-               "build": 31055,
-               "url": "https://apps.apple.com/app/id6475599596"
-            },
-            "android": {
-               "minimalVersion": "1.9.0",
-               "build": 54,
-               "url": "https://play.google.com/store/apps/details?id=trade.opsdao.dydxchain&pli=1"
-            }
-         },
-         "stakingValidators": [
-           "dydxvaloper15xgxv2j45uc4er8z9tfz5m0f0e74ymv6xj9l9d",
-           "dydxvaloper1cpz0jtj6rkezzs7z8k5gy6py05sxdkmyvggvvh",
-           "dydxvaloper199fjq4rnfvz24cktl8cervx8h8e90ruk3yrrdn",
-           "dydxvaloper1mwhwf9rqh64ktr8t8xnz37nhg7vvy42ec56jwe",
-           "dydxvaloper140l6y2gp3gxvay6qtn70re7z2s0gn57zq7tkd8",
-           "dydxvaloper1y6ncfxx8x9sqec97pehjw0k32slw63850ltjrn",
-           "dydxvaloper15wphegl8esn7r2rgj9j3xf870v78lxg8yfjn95",
-           "dydxvaloper1t8hjjca8kecjtuhs2qy83maurj78fq2z5c44z5",
-           "dydxvaloper1j4ljutnh66r55a29jydgca7pfmhd40e3nlcfa4"
-         ],
+         "stakingValidators": [],
          "featureFlags": {
             "checkForGeo": false,
-            "reduceOnlySupported": true,
-            "usePessimisticCollateralCheck": false,
-            "useOptimisticCollateralCheck": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": false,
-            "CCTPDepositOnly": false,
+            "CCTPWithdrawalOnly": true,
+            "CCTPDepositOnly": true,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false
          }

--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -1,7 +1,7 @@
 {
    "apps": {
       "ios": {
-         "scheme": "dydx-t-v4"
+         "scheme": "dydxv4"
       }
    },
    "tokens": {
@@ -35,11 +35,11 @@
             "image": "/currencies/usdc.png"
          }
       },
-      "[mainnet chain id]": {
-         "comment": "Change according to mainnet release",
+      "dydx-mainnet-1": {
+         "comment": "Mainnet",
          "chain": {
-            "name": "TokenName",
-            "denom": "tokenDenom",
+            "name": "DYDX",
+            "denom": "adydx",
             "decimals": 18,
             "image": "/currencies/dydx.png"
          },
@@ -61,7 +61,6 @@
          "blogs": "https://www.dydx.foundation/blog",
          "foundation": "https://www.dydx.foundation",
          "help": "https://help.dydx.exchange/",
-         "vaultLearnMore": "https://help.dydx.exchange",
          "reduceOnlyLearnMore": "https://help.dydx.exchange/articles/6345793-reduce-only-orders",
          "mintscanBase": "https://mintscan.io/dydx-testnet",
          "documentation": "https://docs.dydx.exchange/",
@@ -74,7 +73,7 @@
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
          "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
-         "adjustTargetLeverageLearnMore": "",
+         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
          "launchIncentive": "https://cloud.chaoslabs.co",
          "tradingRewardsLearnMore": "https://docs.dydx.exchange/concepts-trading/rewards_fees_and_parameters",
          "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
@@ -103,7 +102,6 @@
          "blogs": "https://www.dydx.foundation/blog",
          "foundation": "https://www.dydx.foundation",
          "help": "https://help.dydx.exchange/",
-         "vaultLearnMore": "https://help.dydx.exchange",
          "reduceOnlyLearnMore": "https://help.dydx.exchange/articles/6345793-reduce-only-orders",
          "mintscanBase": "https://mintscan.io/dydx-testnet",
          "governanceLearnMore": "https://help.dydx.exchange",
@@ -112,7 +110,7 @@
          "keplrDashboard": "https://testnet.keplr.app/",
          "strideZoneApp": "https://testnet.stride.zone",
          "accountExportLearnMore": "https://help.dydx.exchange/en/articles/8565867-secret-phrase-on-dydx-chain",
-         "adjustTargetLeverageLearnMore": "",
+         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
          "walletLearnMore": "https://www.dydx.academy/video/defi-wallet",
          "withdrawalGateLearnMore": "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
          "launchIncentive": "https://cloud.chaoslabs.co",
@@ -132,45 +130,46 @@
          "dydxLearnMore": "https://www.mintscan.io/dydx",
          "affiliateProgram": ""
       },
-      "[mainnet chain id]": {
-         "tos": "[HTTP link to TOS]",
-         "privacy": "[HTTP link to Privacy Policy]",
-         "statusPage": "[HTTP link to status page]",
-         "mintscan": "[HTTP link to Mintscan, with {tx_hash} placeholder]",
-         "mintscanBase": "[HTTP link to TOS mintscan base url]",
-         "feedback": "[HTTP link to feedback form, can be null]",
-         "blogs": "[HTTP link to blogs, can be null]",
-         "foundation": "[HTTP link to foundation, can be null]",
-         "reduceOnlyLearnMore": "[HTTP link to reduce-only learn more, can be null]",
-         "documentation": "[HTTP link to documentation, can be null]",
-         "community": "[HTTP link to community, can be null]",
-         "help": "[HTTP link to help page, can be null]",
-         "vaultLearnMore": "[HTTP link to help page, can be null]",
-         "governanceLearnMore": "[HTTP link to governance learn more, can be null]",
-         "newMarketProposalLearnMore": "[HTTP link to new market proposal learn more, can be null]",
-         "stakingLearnMore": "[HTTP link to staking learn more, can be null]",
-         "keplrDashboard": "[HTTP link to keplr dashboard, can be null]",
-         "strideZoneApp": "[HTTP link to stride zone app, can be null]",
-         "accountExportLearnMore": "[HTTP link to account export learn more, can be null]",
-         "adjustTargetLeverageLearnMore": "[HTTP link to adjust target leverage learn more, can be null]",
-         "walletLearnMore": "[HTTP link to wallet learn more, can be null]",
-         "withdrawalGateLearnMore": "[HTTP link to withdrawal gate learn more, can be null]",
-         "launchIncentive": "[HTTP link to launch incentive host, can be null]",
-         "tradingRewardsLearnMore": "[HTTP link to trading rewards learn more, can be null]",
-         "exchangeStats": "[HTTP link to exchange stats, can be null]",
-         "initialMarginFractionLearnMore": "[HTTP link to governance functionalities liquidity tiers, can be null]",
-         "equityTiersLearnMore": "[HTTP link to equity tiers learn more, can be null]",
-         "contractLossMechanismLearnMore": "[HTTP link to documentation on contract loss mechanisms]",
-         "isolatedMarginLearnMore": "[HTTP link to documentation on isolated margin]",
-         "mintscanValidatorsLearnMore": "[HTTP link to mintscan info on validators]",
-         "protocolStaking": "[HTTP link to protocol staking info]",
-         "stakingAndClaimingRewardsLearnMore": "[HTTP link to staking and claiming rewards learn more]",
-         "predictionMarketLearnMore": "[HTTP link to prediction market learn more]",
-         "discoveryProgram": "[HTTP link to discovery program learn more]",
-         "getInTouch": "[HTTP link to get in touch with traders]",
-         "deployerTermsAndConditions": "[HTTP link to terms and conditions, can be null]",
-         "dydxLearnMore": "[HTTP link to information about the dYdX blockchain]",
-         "affiliateProgram": "[HTTP link to information about the affiliate program]"
+      "dydx-mainnet-1": {
+         "tos": "https://dydx.trade/terms",
+         "privacy": "https://dydx.trade/privacy",
+         "statusPage": "https://status.dydx.trade/",
+         "mintscan": "https://www.mintscan.io/dydx/tx/{tx_hash}",
+         "mintscanBase": "https://www.mintscan.io/dydx",
+         "feedback": "",
+         "blogs": "https://www.dydx.foundation/blog",
+         "foundation": "https://www.dydx.foundation",
+         "reduceOnlyLearnMore": "https://help.dydx.trade/en/articles/8607918-reduce-only-order",
+         "documentation": "https://docs.dydx.exchange/",
+         "community": "https://discord.com/invite/dydx",
+         "help": "https://help.dydx.trade/",
+         "governanceLearnMore": "https://help.dydx.trade/en/collections/6936883-governance-staking",
+         "newMarketProposalLearnMore": "https://dydx.exchange/blog/new-market-proposals",
+         "stakingLearnMore": "https://help.dydx.trade/en/articles/8581388-accessing-governance-and-staking-on-dydx-chain",
+         "keplrDashboard": "https://wallet.keplr.app/chains/dydx?tab=staking",
+         "strideZoneApp": "https://app.stride.zone/?chain=DYDX",
+         "accountExportLearnMore": "https://help.dydx.trade/en/articles/8581269-secret-phrase-on-dydx-chain",
+         "adjustTargetLeverageLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
+         "walletLearnMore": "https://help.dydx.trade/en/articles/166997-supported-default-wallets-on-dydx-chain",
+         "withdrawalGateLearnMore": "https://help.dydx.trade/en/articles/9004706-withdrawals-on-dydx-chain#h_e61f043370",
+         "launchIncentive": "https://cloud.chaoslabs.co",
+         "tradingRewardsLearnMore": "https://docs.dydx.exchange/concepts-trading/rewards_fees_and_parameters",
+         "exchangeStats": "https://app.mode.com/dydx_eng/reports/58822121650d?secret_key=391d9214fe6aefec35b7d35c",
+         "initialMarginFractionLearnMore": "https://docs.dydx.exchange/governance/functionalities#liquidity-tiers",
+         "equityTiersLearnMore": "https://help.dydx.trade/en/articles/171918-equity-tiers-and-rate-limits",
+         "fetAgixMarketWindDownProposal": "https://www.mintscan.io/dydx/proposals/61",
+         "contractLossMechanismLearnMore": "https://help.dydx.trade/en/articles/166973-contract-loss-mechanisms-on-dydx-chain",
+         "isolatedMarginLearnMore": "https://help.dydx.trade/en/articles/172975-isolated-margin",
+         "mintscanValidatorsLearnMore": "https://www.mintscan.io/dydx/validators",
+         "protocolStaking": "https://protocolstaking.info/",
+         "stakingAndClaimingRewardsLearnMore": "https://help.dydx.trade/en/articles/178571-staking-and-unstaking-dydx-and-claiming-staking-rewards",
+         "rndrParamProposal": "https://www.mintscan.io/dydx/proposals/126",
+         "predictionMarketLearnMore": "https://help.dydx.trade/en",
+         "discoveryProgram": "https://www.dydx.foundation/blog/dydx-discovery-user-interviews?utm_source=dYdXTelegram&utm_medium=GlobalSocial&utm_campaign=GlobalSocial",
+         "getInTouch": "https://t.me/+amt-yoIUwDplN2I5",
+         "deployerTermsAndConditions": "https://www.dydx.trade/terms",
+         "dydxLearnMore": "https://www.mintscan.io/dydx",
+         "affiliateProgram": ""
       }
    },
    "wallets": {
@@ -210,21 +209,21 @@
          "signTypedDataAction": "dYdX Chain Onboarding",
          "signTypedDataDomainName": "dYdX Chain"
       },
-      "[mainnet chain id]": {
+      "dydx-mainnet-1": {
          "walletconnect": {
             "client": {
-               "name": "[Name of the app]",
-               "description": "[Description of the app]",
-               "iconUrl": "[Relative URL of the icon URL]"
+               "name": "dYdX v4",
+               "description": "dYdX v4 App",
+               "iconUrl": "/logos/dydx-x.png"
             },
             "v2": {
-               "projectId": "[Project ID]"
+               "projectId": "fd67e5fbec90c07b6012699738d4a487"
             }
          },
          "walletSegue": {
-            "callbackUrl": "[Relative callback URL for WalletSegue, should match apple-app-site-association]"
+            "callbackUrl": "/walletsegue"
          },
-         "images": "[Relative URL for wallet images]",
+         "images": "/wallets/",
          "signTypedDataAction": "dYdX Chain Onboarding",
          "signTypedDataDomainName": "dYdX Chain"
       }
@@ -244,11 +243,11 @@
             "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
          }
       },
-      "[mainnet chain id]": {
+      "dydx-mainnet-1": {
          "newMarketProposal": {
-            "initialDepositAmount": 0,
-            "delayBlocks": 0,
-            "newMarketsMethodology": "[URL to spreadsheet or document that explains methodology]"
+            "initialDepositAmount": 2000000000000000000000,
+            "delayBlocks": 3600,
+            "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1046uSR2sltA6siZGnvBlgUp4xlPNM7dPFvUgdACgTy4/edit?usp=sharing"
          }
       }
    },
@@ -301,6 +300,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -313,6 +313,7 @@
             "validators": [
                "https://validator.v4dev.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -339,6 +340,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -351,6 +353,7 @@
             "validators": [
                "http://dev2-validator-lb-58813722.us-east-2.elb.amazonaws.com"
             ],
+            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -375,6 +378,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -387,6 +391,7 @@
             "validators": [
                "http://validator-dev3-lb-1393802013.us-east-2.elb.amazonaws.com"
             ],
+            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -413,6 +418,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -425,6 +431,7 @@
             "validators": [
                "https://validator.v4dev4.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -451,6 +458,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -463,6 +471,7 @@
             "validators": [
                "http://18.223.78.50:26657"
             ],
+            "0xsquid": "https://testnet.api.0xsquid.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -487,6 +496,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -500,6 +510,7 @@
             "validators": [
                "https://validator.v4staging.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -524,6 +535,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -537,6 +549,7 @@
             "validators": [
                "https://validator.v4staging.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -548,7 +561,7 @@
             "ios": {
                "minimalVersion": "1.0",
                "build": 40000,
-               "url": "https://apps.apple.com/app/dydx/id1564787350"
+               "url": "https://apps.apple.com/app/dydx/id6475599596"
             },
             "android": {
                "minimalVersion": "1.1",
@@ -573,6 +586,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -586,6 +600,7 @@
             "validators": [
                "https://validator-uswest1.v4staging.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -604,12 +619,13 @@
          }
       },
       "dydxprotocol-testnet": {
-         "name": "v4 Public Testnet",
+         "name": "Testnet",
          "ethereumChainId": "11155111",
          "dydxChainId": "dydx-testnet-4",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -626,6 +642,7 @@
                "https://test-dydx.kingnodes.com",
                "https://dydx-rpc.liquify.com/api=8878132/dydx"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -655,6 +672,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -667,6 +685,7 @@
             "validators": [
                "https://validator.v4testnet.dydx.exchange"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -693,6 +712,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -705,6 +725,7 @@
             "validators": [
                "https://dydx-testnet.nodefleet.org"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -731,6 +752,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -743,6 +765,7 @@
             "validators": [
                "https://test-dydx.kingnodes.com"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -769,6 +792,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -781,6 +805,7 @@
             "validators": [
                "https://dydx-rpc.liquify.com/api=8878132/dydx"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -807,6 +832,7 @@
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
          "deployerName": "dYdX",
+         "squidIntegratorId": "dYdX-api",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
          "endpoints": {
@@ -819,6 +845,7 @@
             "validators": [
                "https://dydx-testnet-rpc.polkachu.com/"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -844,6 +871,7 @@
          "dydxChainId": "dydx-testnet-4",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
+         "squidIntegratorId": "dYdX-api",
          "deployerName": "dYdX",
          "rewardsHistoryStartDateMs": "1704844800000",
          "isMainNet": false,
@@ -857,6 +885,7 @@
             "validators": [
                "https://dydx-testnet-full-rpc.public.blastapi.io/"
             ],
+            "0xsquid": "https://testnet.api.squidrouter.com",
             "skip": "https://api.skip.money",
             "solanaRpcUrl": "https://api.mainnet-beta.solana.com/",
             "nobleValidator": "https://noble-testnet-rpc.polkachu.com/",
@@ -877,39 +906,77 @@
          }
       },
       "dydxprotocol-mainnet": {
-         "name": "v4",
+         "name": "Mainnet",
          "ethereumChainId": "1",
-         "dydxChainId": "[mainnet chain id]",
+         "dydxChainId": "dydx-mainnet-1",
          "chainName": "dYdX Chain",
          "chainLogo": "/dydx-chain.png",
-         "deployerName": "[deployer name]",
+         "deployerName": "dYdX Ops subDAO",
          "rewardsHistoryStartDateMs": "1706486400000",
+         "squidIntegratorId": "dYdX-api",
          "isMainNet": true,
          "endpoints": {
             "indexers": [
                {
-                  "api": "[REST endpoint]",
-                  "socket": "[Websocket endpoint]"
+                  "api": "https://indexer.v4mainnet.dydx.exchange",
+						"socket": "wss://indexer.v4mainnet.dydx.exchange"
                }
             ],
             "validators": [
-               "[Validator endpoint 1",
-               "[Validator endpoint n]"
+               "https://dydx-dao-rpc.polkachu.com",
+               "https://dydx-mainnet-full-rpc.public.blastapi.io",
+               "https://dydx-ops-rpc.kingnodes.com"
             ],
-            "skip": "[Skip endpoint for mainnet]",
-            "solanaRpcUrl": "[Solana rpc url for mainnet]",
-            "nobleValidator": "[noble validator endpoint for mainnet]",
-            "osmosisValidator": "[osmosis validator endpoint for mainnet]",
-            "neutronValidator": "[neutron validator endpoint for mainnet]",
-            "geo": "[geo endpoint for mainnet]",
-            "stakingAPR": "[staking APR endpoint for mainnet]"
+            "0xsquid": "https://api.squidrouter.com",
+            "skip": "https://api.skip.money",
+            "nobleValidator": "https://noble-rpc.polkachu.com/",
+            "geo": "https://api.dydx.exchange/v4/geo",
+            "stakingAPR": "https://apybara-proxy-web-mainnet.infrastructure-34d.workers.dev/v0/protocols/dydx",
+            "solanaRpcUrl": "https://falling-crimson-violet.solana-mainnet.quiknode.pro/33d146e02bb33f996515f57faa3e7e1c3b8dd429",
+            "osmosisValidator": "https://rpc.osmosis.zone",
+            "neutronValidator": "https://neutron-rpc.publicnode.com"
          },
-         "stakingValidators": [],
+         "ios": {
+            "minimalVersion": "1.4.2",
+            "build": 31055,
+            "url": "https://apps.apple.com/app/id6475599596"
+         },
+         "android": {
+            "minimalVersion": "1.9.0",
+            "build": 54,
+            "url": "https://play.google.com/store/apps/details?id=trade.opsdao.dydxchain&pli=1"
+         },
+         "apps": {
+            "ios": {
+               "minimalVersion": "1.4.2",
+               "build": 31055,
+               "url": "https://apps.apple.com/app/id6475599596"
+            },
+            "android": {
+               "minimalVersion": "1.9.0",
+               "build": 54,
+               "url": "https://play.google.com/store/apps/details?id=trade.opsdao.dydxchain&pli=1"
+            }
+         },
+         "stakingValidators": [
+           "dydxvaloper15xgxv2j45uc4er8z9tfz5m0f0e74ymv6xj9l9d",
+           "dydxvaloper1cpz0jtj6rkezzs7z8k5gy6py05sxdkmyvggvvh",
+           "dydxvaloper199fjq4rnfvz24cktl8cervx8h8e90ruk3yrrdn",
+           "dydxvaloper1mwhwf9rqh64ktr8t8xnz37nhg7vvy42ec56jwe",
+           "dydxvaloper140l6y2gp3gxvay6qtn70re7z2s0gn57zq7tkd8",
+           "dydxvaloper1y6ncfxx8x9sqec97pehjw0k32slw63850ltjrn",
+           "dydxvaloper15wphegl8esn7r2rgj9j3xf870v78lxg8yfjn95",
+           "dydxvaloper1t8hjjca8kecjtuhs2qy83maurj78fq2z5c44z5",
+           "dydxvaloper1j4ljutnh66r55a29jydgca7pfmhd40e3nlcfa4"
+         ],
          "featureFlags": {
             "checkForGeo": false,
+            "reduceOnlySupported": true,
+            "usePessimisticCollateralCheck": false,
+            "useOptimisticCollateralCheck": true,
             "withdrawalSafetyEnabled": true,
-            "CCTPWithdrawalOnly": true,
-            "CCTPDepositOnly": true,
+            "CCTPWithdrawalOnly": false,
+            "CCTPDepositOnly": false,
             "isSlTpEnabled": true,
             "isSlTpLimitOrdersEnabled": false
          }

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -181,6 +181,7 @@ export const COINBASE_MIPD_RDNS = 'com.coinbase.wallet';
 export const METAMASK_MIPD_RDNS = 'io.metamask';
 
 export const METAMASK_DOWNLOAD_LINK = 'https://metamask.io/download/';
+export const PHANTOM_DOWNLOAD_LINK = 'https://phantom.app/download';
 export const KEPLR_DOWNLOAD_LINK = 'https://www.keplr.app/get';
 
 // TODO: export this type from abacus instead

--- a/src/constants/window.d.ts
+++ b/src/constants/window.d.ts
@@ -3,5 +3,7 @@ import { Keplr } from '@keplr-wallet/types';
 declare global {
   interface Window {
     keplr?: Keplr;
+    // need to add web3-react-phantom to get Phantom wallet import
+    phantom?: any;
   }
 }

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -6,9 +6,12 @@ import { StatsigFlags } from '@/constants/statsig';
 import {
   COINBASE_MIPD_RDNS,
   ConnectorType,
+  KEPLR_DOWNLOAD_LINK,
   KEPLR_MIPD_RDNS,
   METAMASK_DOWNLOAD_LINK,
+  METAMASK_MIPD_RDNS,
   OKX_MIPD_RDNS,
+  PHANTOM_DOWNLOAD_LINK,
   PHANTOM_MIPD_RDNS,
   WalletInfo,
   WalletType,
@@ -24,15 +27,21 @@ export const useDisplayedWallets = (): WalletInfo[] => {
   const injectedWallets = useMipdInjectedWallets();
 
   return useMemo(() => {
-    const phantomDetected =
-      injectedWallets.findIndex((wallet) => wallet.detail.info.rdns === PHANTOM_MIPD_RDNS) !== -1;
+    const phantomDetected = Boolean(window.phantom?.solana);
+    const keplrDetected = Boolean(window.keplr);
 
     const okxDetected =
       injectedWallets.findIndex((wallet) => wallet.detail.info.rdns === OKX_MIPD_RDNS) !== -1;
 
+    const injectedMetaMask = injectedWallets.find(
+      (wallet) => wallet.detail.info.rdns === METAMASK_MIPD_RDNS
+    );
+
     const enabledInjectedWallets = injectedWallets
       .filter(
         (wallet) =>
+          // Remove Metamask. We will show it no matter what at the front of
+          wallet.detail.info.rdns !== METAMASK_MIPD_RDNS &&
           // Remove Phantom EVM support, but enable Phantom Solana support based on EIP-6963 detection
           wallet.detail.info.rdns !== PHANTOM_MIPD_RDNS &&
           // Remove Keplr EVM support since Keplr Cosmos is supported
@@ -51,45 +60,60 @@ export const useDisplayedWallets = (): WalletInfo[] => {
           }) as WalletInfo
       );
 
-    // If Phantom wallet is detected, it must be in the 2nd slot.
-    // If there are no injected wallets, splice will just put it as the only item in the array.
-    if (phantomDetected) {
-      enabledInjectedWallets.splice(1, 0, {
-        connectorType: ConnectorType.PhantomSolana,
-        name: WalletType.Phantom,
-      });
-    }
+    const metamaskWallet = injectedMetaMask
+      ? {
+          connectorType: ConnectorType.Injected,
+          icon: injectedMetaMask.detail.info.icon,
+          name: injectedMetaMask.detail.info.name,
+          rdns: injectedMetaMask.detail.info.rdns,
+        }
+      : {
+          connectorType: ConnectorType.DownloadWallet,
+          name: WalletType.MetaMask,
+          downloadLink: METAMASK_DOWNLOAD_LINK,
+        };
+
+    const phantomWallet = phantomDetected
+      ? {
+          connectorType: ConnectorType.PhantomSolana,
+          name: WalletType.Phantom,
+        }
+      : {
+          connectorType: ConnectorType.DownloadWallet,
+          name: WalletType.Phantom,
+          downloadLink: PHANTOM_DOWNLOAD_LINK,
+        };
+
+    const keplrWallet = keplrDetected
+      ? {
+          connectorType: ConnectorType.Cosmos,
+          name: CosmosWalletType.KEPLR,
+        }
+      : {
+          connectorType: ConnectorType.DownloadWallet,
+          name: WalletType.Keplr,
+          downloadLink: KEPLR_DOWNLOAD_LINK,
+        };
 
     return [
       // If the user does not have any injected wallets installed, show Metamask as the first option
       // with a download link since it the recommended wallet
-      !enabledInjectedWallets.length && {
-        connectorType: ConnectorType.DownloadWallet,
-        name: WalletType.MetaMask,
-        downloadLink: METAMASK_DOWNLOAD_LINK,
-      },
+      metamaskWallet,
+      phantomWallet,
+      keplrEnabled && keplrWallet,
+      { connectorType: ConnectorType.WalletConnect, name: WalletType.WalletConnect2 },
 
       ...enabledInjectedWallets,
 
-      keplrEnabled && {
-        connectorType: ConnectorType.Cosmos,
-        name: CosmosWalletType.KEPLR,
-      },
-
-      { connectorType: ConnectorType.WalletConnect, name: WalletType.WalletConnect2 },
-
       { connectorType: ConnectorType.Coinbase, name: WalletType.CoinbaseWallet },
-
-      // No need to special-case an OKX WalletConnect option if the OKX extension wallet is already detected.
-      // Note that OKX mobile app users can still connect through the generic WalletConnect option
-      !okxDetected && { connectorType: ConnectorType.WalletConnect, name: WalletType.OkxWallet },
-
       Boolean(import.meta.env.VITE_PRIVY_APP_ID) && {
         connectorType: ConnectorType.Privy,
         name: WalletType.Privy,
       },
 
-      { connectorType: ConnectorType.WalletConnect, name: WalletType.OtherWallet },
+      // No need to special-case an OKX WalletConnect option if the OKX extension wallet is already detected.
+      // Note that OKX mobile app users can still connect through the generic WalletConnect option
+      !okxDetected && { connectorType: ConnectorType.WalletConnect, name: WalletType.OkxWallet },
     ].filter(isTruthy) as WalletInfo[];
   }, [injectedWallets, keplrEnabled]);
 };

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -19,8 +19,17 @@ import {
 
 import { isTruthy } from '@/lib/isTruthy';
 
-import { useMipdInjectedWallets } from './useMipdInjectedWallets';
+import { MipdInjectedWallet, useMipdInjectedWallets } from './useMipdInjectedWallets';
 import { useStatsigGateValue } from './useStatsig';
+
+const getWalletInfoFromInjectedWallet = (wallet: MipdInjectedWallet) => {
+  return {
+    connectorType: ConnectorType.Injected,
+    icon: wallet.detail.info.icon,
+    name: wallet.detail.info.name,
+    rdns: wallet.detail.info.rdns,
+  } as WalletInfo;
+};
 
 export const useDisplayedWallets = (): WalletInfo[] => {
   const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr);
@@ -40,7 +49,7 @@ export const useDisplayedWallets = (): WalletInfo[] => {
     const enabledInjectedWallets = injectedWallets
       .filter(
         (wallet) =>
-          // Remove Metamask. We will show it no matter what at the front of
+          // Remove Metamask. We will always show it at the first spot regardless of detection
           wallet.detail.info.rdns !== METAMASK_MIPD_RDNS &&
           // Remove Phantom EVM support, but enable Phantom Solana support based on EIP-6963 detection
           wallet.detail.info.rdns !== PHANTOM_MIPD_RDNS &&
@@ -50,23 +59,10 @@ export const useDisplayedWallets = (): WalletInfo[] => {
           // handling switching between injected/mobile/smart account
           wallet.detail.info.rdns !== COINBASE_MIPD_RDNS
       )
-      .map(
-        (wallet) =>
-          ({
-            connectorType: ConnectorType.Injected,
-            icon: wallet.detail.info.icon,
-            name: wallet.detail.info.name,
-            rdns: wallet.detail.info.rdns,
-          }) as WalletInfo
-      );
+      .map(getWalletInfoFromInjectedWallet);
 
     const metamaskWallet = injectedMetaMask
-      ? {
-          connectorType: ConnectorType.Injected,
-          icon: injectedMetaMask.detail.info.icon,
-          name: injectedMetaMask.detail.info.name,
-          rdns: injectedMetaMask.detail.info.rdns,
-        }
+      ? getWalletInfoFromInjectedWallet(injectedMetaMask)
       : {
           connectorType: ConnectorType.DownloadWallet,
           name: WalletType.MetaMask,

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -23,7 +23,6 @@ import {
   ConnectorType,
   type DydxAddress,
   type EvmAddress,
-  KEPLR_DOWNLOAD_LINK,
   SolAddress,
   WalletInfo,
   WalletType,
@@ -169,9 +168,7 @@ export const useWalletConnection = () => {
             login();
           }
         } else if (wallet.connectorType === ConnectorType.Cosmos) {
-          if (!window.keplr) {
-            window.open(KEPLR_DOWNLOAD_LINK, '_blank');
-          } else if (!isConnectedGraz) {
+          if (!isConnectedGraz) {
             await connectGraz({
               chainId: SUPPORTED_COSMOS_CHAINS,
               walletType: wallet.name,


### PR DESCRIPTION
sorts wallets according to spec https://linear.app/dydx/issue/OTE-825/sort-for-wallets-show-default-wallets-and

- metamask
- phantom
- keplr
^ these three will go first and default to a download link if the extension isn't already installed

- walletconnect
- coinbase
- email or social (privy)
- coinbase
- okx wallet
  - if the okx wallet is not installed, we'll still show the logo and just route it through the walletconnect option. if it is installed, we'll display as part of injected wallets. this isn't exactly how it was outlined in the spec so will want to get confirmation that this is acceptable behavior


<img width="490" alt="image" src="https://github.com/user-attachments/assets/cae7300c-d163-4aed-ab80-b4c18ce4cfb7">

https://www.loom.com/share/01711f85a43045fc9e252f91ccf3b352