### PR TITLE
chore: hide notifs on mobile web view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const Content = () => {
   useCommandMenu();
 
   const dispatch = useAppDispatch();
-  const { isTablet, isNotTablet, isNotMobile } = useBreakpoints();
+  const { isTablet, isNotTablet } = useBreakpoints();
   const { chainTokenLabel } = useTokenConfigs();
 
   const location = useLocation();
@@ -161,7 +161,7 @@ const Content = () => {
 
         {isTablet ? <FooterMobile /> : <FooterDesktop />}
 
-        {isNotMobile && <NotificationsToastArea tw="z-[2] [grid-area:Main]" />}
+        <NotificationsToastArea tw="z-[2] [grid-area:Main]" />
 
         <$DialogArea ref={dialogAreaRef}>
           <DialogManager />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const Content = () => {
   useCommandMenu();
 
   const dispatch = useAppDispatch();
-  const { isTablet, isNotTablet } = useBreakpoints();
+  const { isTablet, isNotTablet, isNotMobile } = useBreakpoints();
   const { chainTokenLabel } = useTokenConfigs();
 
   const location = useLocation();
@@ -161,7 +161,7 @@ const Content = () => {
 
         {isTablet ? <FooterMobile /> : <FooterDesktop />}
 
-        <NotificationsToastArea tw="z-[2] [grid-area:Main]" />
+        {isNotMobile && <NotificationsToastArea tw="z-[2] [grid-area:Main]" />}
 
         <$DialogArea ref={dialogAreaRef}>
           <DialogManager />

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -309,6 +309,15 @@ const useNotificationsContext = () => {
   // Menu state
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
+  // Unread
+  const hasUnreadNotifications = useMemo(
+    () =>
+      Object.values(notifications).filter(
+        (notification) => notification.status < NotificationStatus.Seen
+      ).length > 0,
+    [notifications]
+  );
+
   // Public
   return {
     notifications,
@@ -335,6 +344,9 @@ const useNotificationsContext = () => {
     // Menu state
     isMenuOpen,
     setIsMenuOpen,
+
+    // Unread
+    hasUnreadNotifications,
 
     // Notification Preferences
     notificationPreferences,

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -312,9 +312,9 @@ const useNotificationsContext = () => {
   // Unread
   const hasUnreadNotifications = useMemo(
     () =>
-      Object.values(notifications).filter(
+      Object.values(notifications).some(
         (notification) => notification.status < NotificationStatus.Seen
-      ).length > 0,
+      ),
     [notifications]
   );
 

--- a/src/layout/Footer/FooterMobile.tsx
+++ b/src/layout/Footer/FooterMobile.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_MARKETID } from '@/constants/markets';
 import { AppRoute } from '@/constants/routes';
 
 import { useComplianceState } from '@/hooks/useComplianceState';
+import { useNotifications } from '@/hooks/useNotifications';
 import { useShouldShowFooter } from '@/hooks/useShouldShowFooter';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -31,6 +32,7 @@ export const FooterMobile = () => {
   const marketId = useAppSelector(getCurrentMarketId);
 
   const { disableConnectButton } = useComplianceState();
+  const { hasUnreadNotifications } = useNotifications();
 
   if (!useShouldShowFooter()) return null;
 
@@ -78,7 +80,14 @@ export const FooterMobile = () => {
               {
                 value: 'alerts',
                 label: stringGetter({ key: STRING_KEYS.ALERTS }),
-                slotBefore: <$Icon iconComponent={BellIcon as any} />,
+                slotBefore: (
+                  <div tw="stack">
+                    <$Icon iconComponent={BellIcon as any} />
+                    {hasUnreadNotifications && (
+                      <$UnreadIndicator tw="relative right-[-0.35rem] top-[-0.55rem] place-self-center" />
+                    )}
+                  </div>
+                ),
                 href: AppRoute.Alerts,
               },
               {
@@ -187,4 +196,12 @@ const $StartIcon = styled.div<{ disabled?: boolean }>`
       background-color: var(--color-layer-2);
       color: var(--color-text-0);
     `}
+`;
+
+const $UnreadIndicator = styled.div`
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+  border: 2px solid var(--color-layer-2);
 `;

--- a/src/layout/NotificationsToastArea/index.tsx
+++ b/src/layout/NotificationsToastArea/index.tsx
@@ -81,7 +81,6 @@ const StyledToastArea = styled.div`
   pointer-events: none;
 
   @media ${breakpoints.mobile} {
-    width: 100%;
-    position: fixed;
+    display: none; // hide notifications on mobile web view
   }
 `;

--- a/src/views/menus/NotificationsMenu.tsx
+++ b/src/views/menus/NotificationsMenu.tsx
@@ -46,6 +46,8 @@ export const NotificationsMenu = ({
 
     isMenuOpen,
     setIsMenuOpen,
+
+    hasUnreadNotifications,
   } = useNotifications();
 
   const notificationsByStatus: Partial<Record<NotificationStatus, Notification[]>> = useMemo(
@@ -56,11 +58,6 @@ export const NotificationsMenu = ({
           : notification.status
       ),
     [notifications, getDisplayData]
-  );
-
-  const hasUnreadNotifications = useMemo(
-    () => notificationsByStatus[NotificationStatus.Triggered]?.length! > 0,
-    [notificationsByStatus]
   );
 
   const items: Parameters<typeof ComboboxDialogMenu>[0]['items'] = useMemo(


### PR DESCRIPTION
hide notifications on mobile web view and add an unread indicator to the mobile footer when applicable

| no new notifs | w/ new notifs |
| ---- | ---- |
| <img width="724" alt="Screenshot 2024-09-26 at 3 58 10 PM" src="https://github.com/user-attachments/assets/b692051a-5936-446a-ac1e-4e1f4d9d7576"> | <img width="735" alt="Screenshot 2024-09-26 at 3 57 47 PM" src="https://github.com/user-attachments/assets/cc3df13f-1ddc-4b9b-a3b2-0bbabf04098b"> |

