### PR TITLE
feat: add datadog proxy url [OTE-827]

### DIFF
--- a/src/lib/analytics/datadog.ts
+++ b/src/lib/analytics/datadog.ts
@@ -15,6 +15,7 @@ if (CLIENT_TOKEN) {
     forwardErrorsToLogs: true,
     sessionSampleRate: 100,
     env: CURRENT_MODE,
+    proxy: import.meta.env.VITE_DATADOG_PROXY_URL,
   });
 }
 


### PR DESCRIPTION
enables deployers to use a proxy url in case they want to send logs somewhere else other than directly to a DD instance.

for example, if a deployer would like to send them to a proxy url that sends the logs to multiple destinations.