### PR TITLE
fix: label style

### DIFF
--- a/src/components/SearchSelectMenu.tsx
+++ b/src/components/SearchSelectMenu.tsx
@@ -102,6 +102,7 @@ const $WithLabel = styled(WithLabel)`
   ${formMixins.inputLabel}
 
   label {
+    display: flex;
     font: var(--font-mini-book);
   }
 `;

--- a/src/components/WithLabel.tsx
+++ b/src/components/WithLabel.tsx
@@ -24,5 +24,6 @@ export const WithLabel = ({ label, inputID, children, className }: ElementProps 
 const $Container = styled.div`
   label {
     ${layoutMixins.textTruncate}
+    display: flex;
   }
 `;

--- a/src/components/WithLabel.tsx
+++ b/src/components/WithLabel.tsx
@@ -24,6 +24,5 @@ export const WithLabel = ({ label, inputID, children, className }: ElementProps 
 const $Container = styled.div`
   label {
     ${layoutMixins.textTruncate}
-    display: flex;
   }
 `;


### PR DESCRIPTION
Recenter the labels! The text truncation added some layout styles that break the search select menu label styles


Old
<img width="520" alt="image" src="https://github.com/user-attachments/assets/91606bf1-8fc4-4109-a560-3c2af32d4ae4">


New
<img width="486" alt="image" src="https://github.com/user-attachments/assets/e784bc21-0b61-4ff7-bf7c-71eee24f0f95">
