### PR TITLE
fix: truncation on withdraw dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.12.7",
     "@dydxprotocol/v4-client-js": "1.6.1",
-    "@dydxprotocol/v4-localization": "^1.1.207",
+    "@dydxprotocol/v4-localization": "^1.1.208",
     "@dydxprotocol/v4-proto": "^6.0.1",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: 1.6.1
     version: 1.6.1
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.207
-    version: 1.1.207
+    specifier: ^1.1.208
+    version: 1.1.208
   '@dydxprotocol/v4-proto':
     specifier: ^6.0.1
     version: 6.0.1
@@ -3061,8 +3061,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.207:
-    resolution: {integrity: sha512-O4lFgzeVVVIbnphOTgPysfMxF0iN2NUiTu1K7lqJjwZMMF0kAR9Jbhk7jWwxAVOlcBTRrCP0vZZR1ogEUJhpzw==}
+  /@dydxprotocol/v4-localization@1.1.208:
+    resolution: {integrity: sha512-zDKYfDznAs6XwoxYuEjyoBo4m335/muotZAsl1nGADjXnnVVmbNDxYC10p4hI46YS9ycwCI+U8BhZUchnovfPQ==}
     dev: false
 
   /@dydxprotocol/v4-proto@6.0.1:

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -171,4 +171,5 @@ const StyledBaseButton = styled(BaseButton)<StyleProps>`
       ${state[ButtonState.Loading] && buttonStateVariants(action)[ButtonState.Loading]}
       ${state[ButtonState.Disabled] && buttonStateVariants(action)[ButtonState.Disabled]}
     `}
+    }
 `;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -171,5 +171,4 @@ const StyledBaseButton = styled(BaseButton)<StyleProps>`
       ${state[ButtonState.Loading] && buttonStateVariants(action)[ButtonState.Loading]}
       ${state[ButtonState.Disabled] && buttonStateVariants(action)[ButtonState.Disabled]}
     `}
-    }
 `;

--- a/src/components/GreenCheckCircle.tsx
+++ b/src/components/GreenCheckCircle.tsx
@@ -4,6 +4,6 @@ export const GreenCheckCircle = ({ className }: { className?: string }) => (
   <Icon
     className={className}
     iconName={IconName.CheckCircle}
-    tw="h-[--icon-size] w-[--icon-size] [--icon-size:1.25rem]"
+    tw="h-[--icon-size] min-h-[--icon-size] w-[--icon-size] min-w-[--icon-size] [--icon-size:1.25rem]"
   />
 );

--- a/src/components/GreenCheckCircle.tsx
+++ b/src/components/GreenCheckCircle.tsx
@@ -1,9 +1,5 @@
 import { Icon, IconName } from '@/components/Icon';
 
 export const GreenCheckCircle = ({ className }: { className?: string }) => (
-  <Icon
-    className={className}
-    iconName={IconName.CheckCircle}
-    tw="h-[--icon-size] min-h-[--icon-size] w-[--icon-size] min-w-[--icon-size] [--icon-size:1.25rem]"
-  />
+  <Icon className={className} iconName={IconName.CheckCircle} size="1.25rem" />
 );

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -309,4 +309,6 @@ export const Icon = styled(
 )`
   width: ${({ size }) => size ?? '1em'};
   height: ${({ size }) => size ?? '1em'};
+  min-width: ${({ size }) => size ?? '1em'};
+  min-height: ${({ size }) => size ?? '1em'};
 `;

--- a/src/components/SelectMenu.tsx
+++ b/src/components/SelectMenu.tsx
@@ -48,7 +48,10 @@ export const SelectMenu = <T extends string>({
           <Value />
         )}
         {React.Children.toArray(children).length > 1 && (
-          <Icon iconName={IconName.Triangle} tw="h-0.375 w-0.625 text-color-text-0" />
+          <Icon
+            iconName={IconName.Triangle}
+            tw="h-0.375 min-h-0.375 w-0.625 min-w-0.625 text-color-text-0"
+          />
         )}
       </$Trigger>
       <Portal>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { layoutMixins } from '@/styles/layoutMixins';
+
 export enum TagSize {
   Small = 'Small',
   Medium = 'Medium',
@@ -34,6 +36,8 @@ export const Tag = styled.span<StyleProps>`
   color: var(--color-text-2);
   letter-spacing: 0.04em;
   line-height: 1.3;
+
+  ${layoutMixins.textTruncate}
 
   ${({ type, size }) =>
     ({

--- a/src/components/ToggleGroup.tsx
+++ b/src/components/ToggleGroup.tsx
@@ -1,11 +1,14 @@
 import { type Ref } from 'react';
 
 import { Item, Root } from '@radix-ui/react-toggle-group';
+import styled from 'styled-components';
 
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { type MenuItem } from '@/constants/menus';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
+
+import { layoutMixins } from '@/styles/layoutMixins';
 
 import { type BaseButtonProps } from '@/components/BaseButton';
 import { ToggleButton } from '@/components/ToggleButton';
@@ -67,7 +70,7 @@ export const ToggleGroup = forwardRefFn(
               {...buttonProps}
             >
               {item.slotBefore}
-              {item.label}
+              <$Label>{item.label}</$Label>
               {item.slotAfter}
             </ToggleButton>
           </Item>
@@ -76,3 +79,7 @@ export const ToggleGroup = forwardRefFn(
     );
   }
 );
+
+const $Label = styled.div`
+  ${layoutMixins.textTruncate}
+`;

--- a/src/components/WithLabel.tsx
+++ b/src/components/WithLabel.tsx
@@ -24,5 +24,6 @@ export const WithLabel = ({ label, inputID, children, className }: ElementProps 
 const $Container = styled.div`
   label {
     ${layoutMixins.textTruncate}
+    text-align: start;
   }
 `;

--- a/src/pages/token/StakingPanel.tsx
+++ b/src/pages/token/StakingPanel.tsx
@@ -122,7 +122,7 @@ export const StakingPanel = ({ className }: { className?: string }) => {
           )}
         </$BalanceRow>
         <$BalanceRow>
-          <div>
+          <div tw="min-w-px">
             <$Label>
               <WithTooltip tooltipString={estimatedAprTooltipString}>
                 {stringGetter({

--- a/src/pages/trade/TradeDialogTrigger.tsx
+++ b/src/pages/trade/TradeDialogTrigger.tsx
@@ -60,7 +60,7 @@ export const TradeDialogTrigger = () => {
           ) : (
             stringGetter({ key: STRING_KEYS.TAP_TO_TRADE })
           )}
-          <Icon iconName={IconName.Caret} tw="h-1.5 w-1.5 [rotate:0.5turn]" />
+          <Icon iconName={IconName.Caret} tw="h-1.5 min-h-1.5 w-1.5 min-w-1.5 [rotate:0.5turn]" />
         </$TradeDialogTrigger>
       }
     />

--- a/src/pages/trade/TradeDialogTrigger.tsx
+++ b/src/pages/trade/TradeDialogTrigger.tsx
@@ -60,7 +60,7 @@ export const TradeDialogTrigger = () => {
           ) : (
             stringGetter({ key: STRING_KEYS.TAP_TO_TRADE })
           )}
-          <Icon iconName={IconName.Caret} tw="h-1.5 min-h-1.5 w-1.5 min-w-1.5 [rotate:0.5turn]" />
+          <Icon iconName={IconName.Caret} size="1.5rem" tw="[rotate:0.5turn]" />
         </$TradeDialogTrigger>
       }
     />

--- a/src/pages/vaults/VaultTransactions.tsx
+++ b/src/pages/vaults/VaultTransactions.tsx
@@ -46,7 +46,7 @@ export const VaultTransactionsCard = ({ className }: { className?: string }) => 
       ) : (
         <div tw="column content-center justify-items-center p-1 text-color-text-0">
           <div>
-            <Icon iconName={IconName.OrderPending} tw="mb-0.75 h-2 w-2" />
+            <Icon iconName={IconName.OrderPending} tw="mb-0.75 h-2 min-h-2 w-2 min-w-2" />
           </div>
           <div>{stringGetter({ key: STRING_KEYS.YOU_HAVE_NO_VAULT_DEPOSITS })}</div>
         </div>

--- a/src/pages/vaults/VaultTransactions.tsx
+++ b/src/pages/vaults/VaultTransactions.tsx
@@ -46,7 +46,7 @@ export const VaultTransactionsCard = ({ className }: { className?: string }) => 
       ) : (
         <div tw="column content-center justify-items-center p-1 text-color-text-0">
           <div>
-            <Icon iconName={IconName.OrderPending} tw="mb-0.75 h-2 min-h-2 w-2 min-w-2" />
+            <Icon iconName={IconName.OrderPending} size="2rem" tw="mb-0.75" />
           </div>
           <div>{stringGetter({ key: STRING_KEYS.YOU_HAVE_NO_VAULT_DEPOSITS })}</div>
         </div>

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -914,6 +914,7 @@ export const layoutMixins = {
   textTruncate: css`
     display: inline-block;
     overflow: hidden;
+    text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 1px;

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -914,10 +914,10 @@ export const layoutMixins = {
   textTruncate: css`
     display: inline-block;
     overflow: hidden;
-    text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 1px;
+    width: min-content;
   `,
 
   textLineClamp: css`

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -917,7 +917,6 @@ export const layoutMixins = {
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 1px;
-    width: min-content;
   `,
 
   textLineClamp: css`

--- a/src/views/dialogs/DisplaySettingsDialog.tsx
+++ b/src/views/dialogs/DisplaySettingsDialog.tsx
@@ -110,7 +110,10 @@ export const DisplaySettingsDialog = ({ setIsOpen }: DialogProps<DisplaySettings
               </$AppThemeHeader>
               <img src="/chart-bars.svg" tw="z-[1] h-auto w-full" />
               <$CheckIndicator>
-                <Icon iconName={IconName.Check} tw="h-[--icon-size] w-[--icon-size]" />
+                <Icon
+                  iconName={IconName.Check}
+                  tw="h-[--icon-size] min-h-[--icon-size] w-[--icon-size] min-w-[--icon-size]"
+                />
               </$CheckIndicator>
             </$AppThemeItem>
           );

--- a/src/views/dialogs/DisplaySettingsDialog.tsx
+++ b/src/views/dialogs/DisplaySettingsDialog.tsx
@@ -110,10 +110,7 @@ export const DisplaySettingsDialog = ({ setIsOpen }: DialogProps<DisplaySettings
               </$AppThemeHeader>
               <img src="/chart-bars.svg" tw="z-[1] h-auto w-full" />
               <$CheckIndicator>
-                <Icon
-                  iconName={IconName.Check}
-                  tw="h-[--icon-size] min-h-[--icon-size] w-[--icon-size] min-w-[--icon-size]"
-                />
+                <Icon iconName={IconName.Check} size="0.5rem" />
               </$CheckIndicator>
             </$AppThemeItem>
           );

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -42,7 +42,7 @@ export const PredictionMarketIntroDialog = ({
   }) => (
     <div key={title} tw="row gap-0.75 align-middle">
       <$IconContainer>
-        <Icon iconName={icon} tw="h-1.75 w-1.75 text-color-text-0" />
+        <Icon iconName={icon} tw="h-1.75 min-h-1.75 w-1.75 min-w-1.75 text-color-text-0" />
       </$IconContainer>
       <div tw="column text-medium">
         <span tw="text-color-text-1">{title}</span>

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -42,7 +42,7 @@ export const PredictionMarketIntroDialog = ({
   }) => (
     <div key={title} tw="row gap-0.75 align-middle">
       <$IconContainer>
-        <Icon iconName={icon} tw="h-1.75 min-h-1.75 w-1.75 min-w-1.75 text-color-text-0" />
+        <Icon iconName={icon} size="1.75rem" tw="text-color-text-0" />
       </$IconContainer>
       <div tw="column text-medium">
         <span tw="text-color-text-1">{title}</span>

--- a/src/views/dialogs/StakeDialog.tsx
+++ b/src/views/dialogs/StakeDialog.tsx
@@ -10,6 +10,8 @@ import { useStakingAPR } from '@/hooks/useStakingAPR';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useTokenConfigs } from '@/hooks/useTokenConfigs';
 
+import { layoutMixins } from '@/styles/layoutMixins';
+
 import { AssetIcon } from '@/components/AssetIcon';
 import { Dialog } from '@/components/Dialog';
 import { Link } from '@/components/Link';
@@ -54,10 +56,10 @@ export const StakeDialog = ({ setIsOpen }: DialogProps<StakeDialogProps>) => {
       slotIcon={dialogProps[currentStep].slotIcon}
       slotFooter={<LegalDisclaimer />}
       title={
-        <span tw="inlineRow">
-          {dialogProps[currentStep].title}
+        <span tw="flex items-center gap-[0.5ch]">
+          <$Text>{dialogProps[currentStep].title}</$Text>
           {stakingApr && (
-            <Tag sign={TagSign.Positive} tw="inline-block">
+            <Tag sign={TagSign.Positive} tw="inline-block shrink-[2]">
               {stringGetter({
                 key: STRING_KEYS.EST_APR,
                 params: {
@@ -108,4 +110,8 @@ const LegalDisclaimer = () => {
 const $Dialog = styled(Dialog)`
   --dialog-content-paddingTop: var(--default-border-width);
   --dialog-content-paddingBottom: 1rem;
+`;
+
+const $Text = styled.div`
+  ${layoutMixins.textTruncate}
 `;

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -148,7 +148,12 @@ export const SourceSelectMenu = ({
             items: chainItems,
           },
       ].filter(isTruthy)}
-      label={label ?? (type === TransferType.deposit ? 'Source' : 'Destination')}
+      label={
+        label ??
+        stringGetter({
+          key: type === TransferType.deposit ? STRING_KEYS.SOURCE : STRING_KEYS.DEPOSIT,
+        })
+      }
     >
       <div tw="row gap-0.5 text-color-text-2 font-base-book">
         {selectedChainOption ? (

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -151,7 +151,7 @@ export const SourceSelectMenu = ({
       label={
         label ??
         stringGetter({
-          key: type === TransferType.deposit ? STRING_KEYS.SOURCE : STRING_KEYS.DEPOSIT,
+          key: type === TransferType.deposit ? STRING_KEYS.SOURCE : STRING_KEYS.DESTINATION,
         })
       }
     >

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -99,10 +99,7 @@ export const NewMarketPreviewStep = ({
         </div>
       </div>
 
-      <Icon
-        iconName={IconName.FastForward}
-        tw="mt-[1.45rem] h-[1rem] min-h-[1rem] w-[1rem] min-w-[1rem] text-color-text-0"
-      />
+      <Icon iconName={IconName.FastForward} size="1rem" tw="mt-[1.45rem] text-color-text-0" />
 
       <div tw="flex flex-col items-center justify-center gap-0.5">
         <span tw="text-small text-color-text-0">

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -99,7 +99,10 @@ export const NewMarketPreviewStep = ({
         </div>
       </div>
 
-      <Icon iconName={IconName.FastForward} tw="mt-[1.45rem] h-[1rem] w-[1rem] text-color-text-0" />
+      <Icon
+        iconName={IconName.FastForward}
+        tw="mt-[1.45rem] h-[1rem] min-h-[1rem] w-[1rem] min-w-[1rem] text-color-text-0"
+      />
 
       <div tw="flex flex-col items-center justify-center gap-0.5">
         <span tw="text-small text-color-text-0">

--- a/src/views/forms/StakingForms/shared/StakePreviewContents.tsx
+++ b/src/views/forms/StakingForms/shared/StakePreviewContents.tsx
@@ -40,7 +40,7 @@ export const StakePreviewContents = ({
         </$Row>
         <$Row>
           <$StakeBox> {slotLeft} </$StakeBox>
-          <Icon iconName={IconName.FastForward} tw="h-2.25 min-h-2.25 w-2.25 min-w-2.25" />
+          <Icon iconName={IconName.FastForward} size="2.25rem" />
           <$StakeBox> {slotRight} </$StakeBox>
         </$Row>
       </div>

--- a/src/views/forms/StakingForms/shared/StakePreviewContents.tsx
+++ b/src/views/forms/StakingForms/shared/StakePreviewContents.tsx
@@ -40,7 +40,7 @@ export const StakePreviewContents = ({
         </$Row>
         <$Row>
           <$StakeBox> {slotLeft} </$StakeBox>
-          <Icon iconName={IconName.FastForward} tw="h-2.25 w-2.25" />
+          <Icon iconName={IconName.FastForward} tw="h-2.25 min-h-2.25 w-2.25 min-w-2.25" />
           <$StakeBox> {slotRight} </$StakeBox>
         </$Row>
       </div>

--- a/src/views/forms/TradeForm/MarginModeSelector.tsx
+++ b/src/views/forms/TradeForm/MarginModeSelector.tsx
@@ -44,13 +44,15 @@ export const MarginModeSelector = ({
   }, [dispatch, openInTradeBox]);
 
   return needsMarginMode ? (
-    <$Button onClick={handleClick} className={className}>
-      {marginMode &&
-        stringGetter({
-          key: MARGIN_MODE_STRINGS[marginMode.rawValue],
-        })}
+    <Button onClick={handleClick} className={className}>
+      <$Text>
+        {marginMode &&
+          stringGetter({
+            key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+          })}
+      </$Text>
       <Icon iconName={IconName.Triangle} tw="ml-[0.5ch] rotate-[0.75turn] text-[0.4375rem]" />
-    </$Button>
+    </Button>
   ) : (
     <$WarningTooltip
       className={className}
@@ -66,12 +68,14 @@ export const MarginModeSelector = ({
         </div>
       }
     >
-      <$Button disabled>
-        {marginMode &&
-          stringGetter({
-            key: MARGIN_MODE_STRINGS[marginMode.rawValue],
-          })}
-      </$Button>
+      <Button disabled>
+        <$Text>
+          {marginMode &&
+            stringGetter({
+              key: MARGIN_MODE_STRINGS[marginMode.rawValue],
+            })}
+        </$Text>
+      </Button>
     </$WarningTooltip>
   );
 };
@@ -81,6 +85,6 @@ const $WarningTooltip = styled(WithTooltip)`
   gap: 0.5rem;
 `;
 
-const $Button = styled(Button)`
-  ${layoutMixins.textTruncate}
+const $Text = styled.div`
+  ${layoutMixins.textTruncate};
 `;

--- a/src/views/forms/TradeForm/TargetLeverageButton.tsx
+++ b/src/views/forms/TradeForm/TargetLeverageButton.tsx
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 
 import { shallowEqual } from 'react-redux';
+import styled from 'styled-components';
 
 import { DialogTypes } from '@/constants/dialogs';
 import { LEVERAGE_DECIMALS } from '@/constants/numbers';
+
+import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Button } from '@/components/Button';
 import { Output, OutputType } from '@/components/Output';
@@ -33,9 +36,13 @@ export const TargetLeverageButton = ({ className }: { className?: string }) => {
         stringParams={{ TARGET_LEVERAGE: targetLeverage?.toFixed(LEVERAGE_DECIMALS) }}
       >
         <Button onClick={handleClick}>
-          <Output type={OutputType.Multiple} value={targetLeverage} />
+          <$Output type={OutputType.Multiple} value={targetLeverage} />
         </Button>
       </WithTooltip>
     )
   );
 };
+
+const $Output = styled(Output)`
+  ${layoutMixins.textTruncate};
+`;

--- a/src/views/forms/TradeForm/TradeSideToggle.tsx
+++ b/src/views/forms/TradeForm/TradeSideToggle.tsx
@@ -10,8 +10,6 @@ import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import { layoutMixins } from '@/styles/layoutMixins';
-
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 import { useAppSelector } from '@/state/appTypes';
@@ -67,7 +65,6 @@ const $ToggleContainer = styled(ToggleGroup)<ToggleContainerStyleProps>`
   position: relative;
 
   > button {
-    ${layoutMixins.textTruncate}
     --button-toggle-on-border: none;
     --button-toggle-off-border: none;
     --button-toggle-off-backgroundColor: transparent;
@@ -77,6 +74,7 @@ const $ToggleContainer = styled(ToggleGroup)<ToggleContainerStyleProps>`
     flex: 1;
     z-index: 1;
     outline: none;
+    min-width: 1px;
   }
 
   &::before {


### PR DESCRIPTION
fixes issues where text is aligned into the middle instead of start (by adding `text-align: start` to `WithLabel` and then some other polishes cuz I went down a rabbit hole:
- Updated icons to have `min-w` and `min-h` in addition to `w` and `h` so that they don't shrink on truncation
- Added text truncation to `Tag`s
- Fixed truncation in `StakingPanel` and `StakeDialog` on long languages
- Localized `Source` and `Destination` on `SourceSelectMenu`

long languages still don't look perfect, but it's getting better

<img width="548" alt="Screenshot 2024-10-01 at 12 31 48 PM" src="https://github.com/user-attachments/assets/d5889ef5-7557-4471-835a-098416109bb1">
<img width="532" alt="Screenshot 2024-10-01 at 12 31 40 PM" src="https://github.com/user-attachments/assets/76be5abb-28ff-4719-99ea-d498b9e8ac4c">
