### PR TITLE
fix: vaults error flickering on submit

### DIFF
--- a/src/hooks/vaultsHooks.ts
+++ b/src/hooks/vaultsHooks.ts
@@ -229,7 +229,14 @@ export const useLoadedVaultAccountTransfers = () => {
 const VAULT_FORM_AMOUNT_DEBOUNCE_MS = 500;
 const useVaultFormAmountDebounced = () => {
   const amount = useAppSelector((state) => state.vaults.vaultForm.amount);
-  return useDebounce(amount, VAULT_FORM_AMOUNT_DEBOUNCE_MS);
+  const debouncedAmount = useDebounce(amount, VAULT_FORM_AMOUNT_DEBOUNCE_MS);
+  // if the user goes back to the beginning, use that value for calculations
+  // this fixes an issue where the validation logic would show an error for a second after submission
+  // when we reset the value
+  if (amount === '') {
+    return amount;
+  }
+  return debouncedAmount;
 };
 
 export const useVaultFormSlippage = () => {

--- a/src/pages/vaults/VaultDepositWithdrawForm.tsx
+++ b/src/pages/vaults/VaultDepositWithdrawForm.tsx
@@ -41,6 +41,7 @@ import { getSubaccount } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getVaultForm } from '@/state/vaultSelectors';
 import {
+  resetVaultForm,
   setVaultFormAmount,
   setVaultFormConfirmationStep,
   setVaultFormOperation,
@@ -201,9 +202,7 @@ export const VaultDepositWithdrawForm = ({
       } else {
         assertNever(operation);
       }
-      setOperation('DEPOSIT');
-      setAmountState('');
-      dispatch(setVaultFormConfirmationStep(false));
+      dispatch(resetVaultForm());
 
       onSuccess?.();
     } catch (e) {

--- a/src/state/vaults.ts
+++ b/src/state/vaults.ts
@@ -35,6 +35,14 @@ export const vaultsSlice = createSlice({
     setVaultFormOperation: (state, action: PayloadAction<VaultForm['operation']>) => {
       state.vaultForm.operation = action.payload;
     },
+    resetVaultForm: (state) => {
+      state.vaultForm = {
+        amount: '',
+        confirmationStep: false,
+        slippageAck: false,
+        operation: 'DEPOSIT',
+      };
+    },
   },
 });
 
@@ -43,4 +51,5 @@ export const {
   setVaultFormOperation,
   setVaultFormConfirmationStep,
   setVaultFormSlippageAck,
+  resetVaultForm,
 } = vaultsSlice.actions;


### PR DESCRIPTION
The debounce change is the one that matters, the new action is just nice to have (and more correct!). 