### PR TITLE
feat: Move connected wallet data to redux-persist

### DIFF
--- a/public/tradingview/colors.css
+++ b/public/tradingview/colors.css
@@ -20,9 +20,9 @@
 
   --color-accent: #6966FF; /* ColorToken.Purple1; */
 }
-
-/* Theme: Light */
-:root.theme-light {
+  
+  /* Theme: Light */
+  :root.theme-light {
   --color-layer-0: #E9ECEE; /* ColorToken.LightGray7; */
   --color-layer-1: #ECEFF1; /* ColorToken.LightGray5; */
   --color-layer-2: #FFFFFF; /* ColorToken.White; */
@@ -41,9 +41,9 @@
 
   --color-accent: #7774FF; /* ColorToken.Purple0; */
 }
-
-/* Theme: Dark */
-:root.theme-dark {
+  
+  /* Theme: Dark */
+  :root.theme-dark {
   --color-layer-0: #000000; /* ColorToken.Black; */
   --color-layer-1: #1B1B1D; /* ColorToken.DarkGray14; */
   --color-layer-2: #212124; /* ColorToken.DarkGray11; */
@@ -62,3 +62,4 @@
 
   --color-accent: #7774FF; /* ColorToken.Purple0; */
 }
+  

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -12,7 +12,7 @@ import type { DydxNetwork } from './networks';
 import { TransferNotificationTypes } from './notifications';
 import type { TradeTypes } from './trade';
 import { TradeToggleSizeInput } from './trade';
-import type { DydxAddress, EvmAddress } from './wallets';
+import type { DydxAddress } from './wallets';
 
 export type AnalyticsEventTrackMeta<T extends AnalyticsEventTypes> = {
   detail: {
@@ -68,7 +68,7 @@ export const AnalyticsUserProperties = unionize(
     // Wallet
     WalletType: ofType<WalletType | string | null>(),
     WalletConnectorType: ofType<ConnectorType | null>(),
-    WalletAddress: ofType<EvmAddress | DydxAddress | null>(),
+    WalletAddress: ofType<string | null>(),
 
     // Account
     DydxAddress: ofType<DydxAddress | null>(),

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -76,6 +76,12 @@ export enum ConnectorType {
   PhantomSolana = 'phantomSolana',
 }
 
+export enum WalletNetworkType {
+  Evm = 'evm',
+  Cosmos = 'cosmos',
+  Solana = 'solana',
+}
+
 export type CosmosWalletInfo = {
   connectorType: ConnectorType.Cosmos;
   name: CosmosWalletType;

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -76,6 +76,16 @@ export enum ConnectorType {
   PhantomSolana = 'phantomSolana',
 }
 
+export type CosmosWalletInfo = {
+  connectorType: ConnectorType.Cosmos;
+  name: CosmosWalletType;
+};
+
+export type PhantomSolanaWalletInfo = {
+  connectorType: ConnectorType.PhantomSolana;
+  name: WalletType.Phantom;
+};
+
 // This is the type stored in localstorage, so it must consist of only serializable fields
 export type WalletInfo =
   | ({
@@ -89,10 +99,7 @@ export type WalletInfo =
         | ConnectorType.Privy;
       name: WalletType;
     }
-  | {
-      connectorType: ConnectorType.Cosmos;
-      name: CosmosWalletType;
-    }
+  | CosmosWalletInfo
   | { connectorType: ConnectorType.Test; name: WalletType.TestWallet }
   | { connectorType: ConnectorType.DownloadWallet; name: string; downloadLink: string };
 

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -80,17 +80,8 @@ export enum WalletNetworkType {
   Evm = 'evm',
   Cosmos = 'cosmos',
   Solana = 'solana',
+  Test = 'test', // for pairing with ConnectorType.Test
 }
-
-export type CosmosWalletInfo = {
-  connectorType: ConnectorType.Cosmos;
-  name: CosmosWalletType;
-};
-
-export type PhantomSolanaWalletInfo = {
-  connectorType: ConnectorType.PhantomSolana;
-  name: WalletType.Phantom;
-};
 
 // This is the type stored in localstorage, so it must consist of only serializable fields
 export type WalletInfo =
@@ -105,7 +96,10 @@ export type WalletInfo =
         | ConnectorType.Privy;
       name: WalletType;
     }
-  | CosmosWalletInfo
+  | {
+      connectorType: ConnectorType.Cosmos;
+      name: CosmosWalletType;
+    }
   | { connectorType: ConnectorType.Test; name: WalletType.TestWallet }
   | { connectorType: ConnectorType.DownloadWallet; name: string; downloadLink: string };
 

--- a/src/hooks/useAccountBalance.ts
+++ b/src/hooks/useAccountBalance.ts
@@ -5,7 +5,7 @@ import { PublicKey } from '@solana/web3.js';
 import { QueryObserverResult, RefetchOptions, useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { shallowEqual } from 'react-redux';
-import { Address, erc20Abi, formatUnits } from 'viem';
+import { erc20Abi, formatUnits } from 'viem';
 import { useBalance, useReadContracts } from 'wagmi';
 
 import {
@@ -72,7 +72,9 @@ export const useAccountBalance = ({
   const isSolanaChain = sourceAccount.chain === WalletNetworkType.Solana;
 
   const evmAddress =
-    sourceAccount.chain === WalletNetworkType.Evm ? (sourceAccount.address as Address) : undefined;
+    sourceAccount.chain === WalletNetworkType.Evm
+      ? (sourceAccount.address as EvmAddress)
+      : undefined;
   const solAddress =
     sourceAccount.chain === WalletNetworkType.Solana
       ? (sourceAccount.address as SolAddress)

--- a/src/hooks/useAccountBalance.ts
+++ b/src/hooks/useAccountBalance.ts
@@ -5,7 +5,7 @@ import { PublicKey } from '@solana/web3.js';
 import { QueryObserverResult, RefetchOptions, useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { shallowEqual } from 'react-redux';
-import { erc20Abi, formatUnits } from 'viem';
+import { Address, erc20Abi, formatUnits } from 'viem';
 import { useBalance, useReadContracts } from 'wagmi';
 
 import {
@@ -15,7 +15,7 @@ import {
   SUPPORTED_COSMOS_CHAINS,
 } from '@/constants/graz';
 import { COSMOS_GAS_RESERVE } from '@/constants/numbers';
-import { EvmAddress } from '@/constants/wallets';
+import { EvmAddress, SolAddress, WalletNetworkType } from '@/constants/wallets';
 
 import { useSolanaConnection } from '@/hooks/useSolanaConnection';
 
@@ -60,7 +60,7 @@ export const useAccountBalance = ({
   usdcBalance: number;
   refetchQuery: (options?: RefetchOptions) => Promise<QueryObserverResult>;
 } => {
-  const { evmAddress, dydxAddress, dydxAccountGraz, solAddress } = useAccounts();
+  const { sourceAccount, dydxAccountGraz } = useAccounts();
 
   const balances = useAppSelector(getBalances, shallowEqual);
   const { chainTokenDenom, usdcDenom, usdcDecimals } = useTokenConfigs();
@@ -69,7 +69,16 @@ export const useAccountBalance = ({
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
 
   const { nobleValidator, osmosisValidator, neutronValidator, validators } = useEndpointsConfig();
-  const isSolanaChain = !!solAddress;
+  const isSolanaChain = sourceAccount.chain === WalletNetworkType.Solana;
+
+  const evmAddress =
+    sourceAccount.chain === WalletNetworkType.Evm ? (sourceAccount.address as Address) : undefined;
+  const solAddress =
+    sourceAccount.chain === WalletNetworkType.Solana
+      ? (sourceAccount.address as SolAddress)
+      : undefined;
+  const dydxAddress =
+    sourceAccount.chain === WalletNetworkType.Solana ? sourceAccount.address : undefined;
 
   const isEVMnativeToken = addressOrDenom === CHAIN_DEFAULT_TOKEN_ADDRESS;
 

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -24,7 +24,6 @@ import { getSourceAccount } from '@/state/walletSelectors';
 import abacusStateManager from '@/lib/abacus';
 import { isBlockedGeo } from '@/lib/compliance';
 import { log } from '@/lib/telemetry';
-import { testFlags } from '@/lib/testFlags';
 import { sleep } from '@/lib/timeUtils';
 
 import { useDydxClient } from './useDydxClient';
@@ -152,13 +151,9 @@ const useAccountsContext = () => {
   useEffect(() => {
     (async () => {
       if (sourceAccount.walletInfo?.connectorType === ConnectorType.Test) {
-        // Get override values. Use the testFlags value if it exists, otherwise use the previously
-        // saved value where possible. If neither exist, use a default garbage value.
-        const addressOverride: DydxAddress = (testFlags.addressOverride as DydxAddress) || 'dydx1';
-
         dispatch(setOnboardingState(OnboardingState.WalletConnected));
         const wallet = new LocalWallet();
-        wallet.address = addressOverride;
+        wallet.address = sourceAccount.address;
         setLocalDydxWallet(wallet);
 
         dispatch(setOnboardingState(OnboardingState.AccountConnected));
@@ -228,21 +223,7 @@ const useAccountsContext = () => {
         dispatch(setOnboardingState(OnboardingState.Disconnected));
       }
     })();
-  }, [
-    signerWagmi,
-    isConnectedGraz,
-    sourceAccount.walletInfo?.connectorType,
-    sourceAccount.chain,
-    sourceAccount.encryptedSignature,
-    dispatch,
-    getCosmosOfflineSigner,
-    selectedDydxChainId,
-    localDydxWallet,
-    authenticated,
-    ready,
-    signMessageAsync,
-    setWalletFromSignature,
-  ]);
+  }, [signerWagmi, isConnectedGraz, sourceAccount, localDydxWallet]);
 
   // abacus
   useEffect(() => {

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -4,27 +4,22 @@ import { LocalWallet, NOBLE_BECH32_PREFIX, type Subaccount } from '@dydxprotocol
 import { usePrivy } from '@privy-io/react-auth';
 import { AES, enc } from 'crypto-js';
 
-import {
-  EvmDerivedAddresses,
-  OnboardingGuard,
-  OnboardingState,
-  SolDerivedAddresses,
-} from '@/constants/account';
+import { OnboardingGuard, OnboardingState } from '@/constants/account';
 import { getNobleChainId } from '@/constants/graz';
-import { LOCAL_STORAGE_VERSIONS, LocalStorageKey } from '@/constants/localStorage';
+import { LocalStorageKey } from '@/constants/localStorage';
 import {
   ConnectorType,
   DydxAddress,
-  EvmAddress,
   PrivateInformation,
-  SolAddress,
-  TEST_WALLET_EVM_ADDRESS,
+  WalletNetworkType,
 } from '@/constants/wallets';
 
 import { setOnboardingGuard, setOnboardingState } from '@/state/account';
 import { getGeo, getHasSubaccount } from '@/state/accountSelectors';
 import { getSelectedDydxChainId } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { clearSavedEncryptedSignature } from '@/state/wallet';
+import { getSourceAccount } from '@/state/walletSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { isBlockedGeo } from '@/lib/compliance';
@@ -56,170 +51,42 @@ const useAccountsContext = () => {
 
   // Wallet connection
   const {
-    connectedWallet,
     selectWallet,
     selectedWallet,
     selectedWalletError,
-    evmAddress,
-    solAddress,
     signerWagmi,
     publicClientWagmi,
-    dydxAddress: connectedDydxAddress,
     getCosmosOfflineSigner,
     isConnectedGraz,
     dydxAccountGraz,
   } = useWalletConnection();
 
-  // EVM wallet connection
-  const [previousEvmAddress, setPreviousEvmAddress] = useState(evmAddress);
   const hasSubAccount = useAppSelector(getHasSubaccount);
-
-  useEffect(() => {
-    // EVM Wallet accounts switched
-    if (previousEvmAddress && evmAddress && evmAddress !== previousEvmAddress) {
-      // Disconnect local wallet
-      disconnectLocalDydxWallet();
-
-      // Forget EVM signature
-      forgetEvmSignature(previousEvmAddress);
-    }
-
-    if (evmAddress) {
-      abacusStateManager.setTransfersSourceAddress(evmAddress);
-    }
-
-    setPreviousEvmAddress(evmAddress);
-    // TODO: create a better pattern than this.
-    // We only want to set the source evm address if the evm address changes
-    // OR when our connection state changes.
-    // The evm address can be cached via local storage, so it won't change when we reconnect
-    // But the hasSubAccount value will become true once you reconnect
-    // This allows us to trigger a state update and make sure abacus knows the source address
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [evmAddress, hasSubAccount]);
+  const sourceAccount = useAppSelector(getSourceAccount);
 
   const { ready, authenticated } = usePrivy();
 
-  const [previousSolAddress, setPreviousSolAddress] = useState(solAddress);
-
-  // EVM → dYdX account derivation
-  const [evmDerivedAddresses, saveEvmDerivedAddresses] = useLocalStorage({
-    key: LocalStorageKey.EvmDerivedAddresses,
-    defaultValue: { version: 'v2' } as EvmDerivedAddresses,
-  });
-
+  const [previousAddress, setPreviousAddress] = useState(sourceAccount.address);
   useEffect(() => {
-    // Clear data stored with deprecated LocalStorageKey
-    if (evmDerivedAddresses.version !== LOCAL_STORAGE_VERSIONS[LocalStorageKey.EvmDerivedAddresses])
-      saveEvmDerivedAddresses({
-        version: LOCAL_STORAGE_VERSIONS[LocalStorageKey.EvmDerivedAddresses],
-      });
-  }, []);
-
-  const saveEvmDerivedAccount = useCallback(
-    ({
-      evmAddressInner,
-      dydxAddress,
-    }: {
-      evmAddressInner: EvmAddress;
-      dydxAddress?: DydxAddress;
-    }) => {
-      saveEvmDerivedAddresses({
-        ...evmDerivedAddresses,
-        version: LOCAL_STORAGE_VERSIONS[LocalStorageKey.EvmDerivedAddresses],
-        [evmAddressInner]: {
-          ...(evmDerivedAddresses as any)[evmAddressInner],
-          dydxAddress,
-        },
-      });
-    },
-    [evmDerivedAddresses]
-  );
-
-  const saveEvmSignature = useCallback(
-    (encryptedSignature: string) => {
-      evmDerivedAddresses[evmAddress!].encryptedSignature = encryptedSignature;
-      saveEvmDerivedAddresses(evmDerivedAddresses);
-    },
-    [evmDerivedAddresses, evmAddress]
-  );
-
-  const forgetEvmSignature = useCallback(
-    (_evmAddress = evmAddress) => {
-      if (_evmAddress) {
-        delete evmDerivedAddresses[_evmAddress]?.encryptedSignature;
-        saveEvmDerivedAddresses(evmDerivedAddresses);
-      }
-    },
-    [evmAddress, evmDerivedAddresses]
-  );
-
-  // SOL → dYdX account derivation
-  const [solDerivedAddresses, saveSolDerivedAddresses] = useLocalStorage({
-    key: LocalStorageKey.SolDerivedAddresses,
-    defaultValue: {} as SolDerivedAddresses,
-  });
-
-  const saveSolDerivedAccount = useCallback(
-    ({
-      solAddressInner,
-      dydxAddress,
-    }: {
-      solAddressInner: SolAddress;
-      dydxAddress?: DydxAddress;
-    }) => {
-      saveSolDerivedAddresses({
-        ...solDerivedAddresses,
-        version: LOCAL_STORAGE_VERSIONS[LocalStorageKey.SolDerivedAddresses],
-        [solAddressInner]: {
-          ...solDerivedAddresses[solAddressInner],
-          dydxAddress,
-        },
-      });
-    },
-    [saveSolDerivedAddresses, solDerivedAddresses]
-  );
-
-  const saveSolSignature = useCallback(
-    (encryptedSignature: string) => {
-      solDerivedAddresses[solAddress!].encryptedSignature = encryptedSignature;
-      saveSolDerivedAddresses(solDerivedAddresses);
-    },
-    [solDerivedAddresses, solAddress, saveSolDerivedAddresses]
-  );
-
-  const forgetSolSignature = useCallback(
-    (_solAddress = solAddress) => {
-      if (_solAddress) {
-        delete solDerivedAddresses[_solAddress]?.encryptedSignature;
-        saveSolDerivedAddresses(solDerivedAddresses);
-      }
-    },
-    [solAddress, solDerivedAddresses, saveSolDerivedAddresses]
-  );
-
-  useEffect(() => {
-    // SOL Wallet accounts switched
-    if (previousSolAddress && solAddress && solAddress !== previousSolAddress) {
+    const { address, chain } = sourceAccount;
+    // wallet accounts switched
+    if (previousAddress && address !== previousAddress) {
       // Disconnect local wallet
       disconnectLocalDydxWallet();
-
-      // Forget SOL signature
-      forgetSolSignature(previousSolAddress);
     }
 
-    if (solAddress) {
-      abacusStateManager.setTransfersSourceAddress(solAddress);
+    if (address && (chain === WalletNetworkType.Evm || chain === WalletNetworkType.Solana)) {
+      abacusStateManager.setTransfersSourceAddress(address);
     }
 
-    setPreviousSolAddress(solAddress);
-    // We only want to set the source sol address if the sol address changes
+    setPreviousAddress(address);
+    // We only want to set the source wallet address if the address changes
     // OR when our connection state changes.
-    // The sol address can be cached via local storage, so it won't change when we reconnect
+    // The address can be cached via local storage, so it won't change when we reconnect
     // But the hasSubAccount value will become true once you reconnect
     // This allows us to trigger a state update and make sure abacus knows the source address
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [solAddress, hasSubAccount]);
+  }, [sourceAccount.address, sourceAccount.chain, hasSubAccount]);
 
   const decryptSignature = (encryptedSignature: string | undefined) => {
     const staticEncryptionKey = import.meta.env.VITE_PK_ENCRYPTION_KEY;
@@ -280,43 +147,22 @@ const useAccountsContext = () => {
     [getWalletFromSignature]
   );
 
-  useEffect(() => {
-    if (evmAddress) {
-      saveEvmDerivedAccount({ evmAddressInner: evmAddress, dydxAddress });
-    }
-  }, [evmAddress, dydxAddress]);
-
-  useEffect(() => {
-    if (solAddress) {
-      saveSolDerivedAccount({ solAddressInner: solAddress, dydxAddress });
-    }
-  }, [solAddress, dydxAddress]);
-
-  const signMessageAsync = useSignForWalletDerivation(connectedWallet);
+  const signMessageAsync = useSignForWalletDerivation(sourceAccount.walletInfo);
 
   useEffect(() => {
     (async () => {
-      if (connectedWallet?.connectorType === ConnectorType.Test) {
+      if (sourceAccount.walletInfo?.connectorType === ConnectorType.Test) {
         // Get override values. Use the testFlags value if it exists, otherwise use the previously
         // saved value where possible. If neither exist, use a default garbage value.
-        const addressOverride: DydxAddress =
-          (testFlags.addressOverride as DydxAddress) ||
-          (evmDerivedAddresses?.[TEST_WALLET_EVM_ADDRESS]?.dydxAddress as DydxAddress) ||
-          'dydx1';
+        const addressOverride: DydxAddress = (testFlags.addressOverride as DydxAddress) || 'dydx1';
 
         dispatch(setOnboardingState(OnboardingState.WalletConnected));
-
-        // Set variables.
-        saveEvmDerivedAccount({
-          evmAddressInner: TEST_WALLET_EVM_ADDRESS,
-          dydxAddress: addressOverride,
-        });
         const wallet = new LocalWallet();
         wallet.address = addressOverride;
         setLocalDydxWallet(wallet);
 
         dispatch(setOnboardingState(OnboardingState.AccountConnected));
-      } else if (connectedDydxAddress && isConnectedGraz) {
+      } else if (sourceAccount.chain === WalletNetworkType.Cosmos && isConnectedGraz) {
         try {
           const dydxOfflineSigner = await getCosmosOfflineSigner(selectedDydxChainId);
           if (dydxOfflineSigner) {
@@ -326,13 +172,15 @@ const useAccountsContext = () => {
         } catch (error) {
           log('useAccounts/setLocalDydxWallet', error);
         }
-      } else if (evmAddress) {
+      } else if (sourceAccount.chain === WalletNetworkType.Evm) {
         if (!localDydxWallet) {
           dispatch(setOnboardingState(OnboardingState.WalletConnected));
 
-          const evmDerivedAccount = evmDerivedAddresses[evmAddress];
-
-          if (connectedWallet?.connectorType === ConnectorType.Privy && authenticated && ready) {
+          if (
+            sourceAccount.walletInfo?.connectorType === ConnectorType.Privy &&
+            authenticated &&
+            ready
+          ) {
             try {
               // Give Privy a second to finish the auth flow before getting the signature
               await sleep();
@@ -342,35 +190,34 @@ const useAccountsContext = () => {
               dispatch(setOnboardingState(OnboardingState.AccountConnected));
             } catch (error) {
               log('useAccounts/decryptSignature', error);
-              forgetEvmSignature();
+              dispatch(clearSavedEncryptedSignature());
             }
-          } else if (evmDerivedAccount?.encryptedSignature) {
+          } else if (sourceAccount.encryptedSignature) {
             try {
-              const signature = decryptSignature(evmDerivedAccount.encryptedSignature);
+              const signature = decryptSignature(sourceAccount.encryptedSignature);
 
               await setWalletFromSignature(signature);
               dispatch(setOnboardingState(OnboardingState.AccountConnected));
             } catch (error) {
               log('useAccounts/decryptSignature', error);
-              forgetEvmSignature();
+              dispatch(clearSavedEncryptedSignature());
             }
           }
         } else {
           dispatch(setOnboardingState(OnboardingState.AccountConnected));
         }
-      } else if (solAddress) {
+      } else if (sourceAccount.chain === WalletNetworkType.Solana) {
         if (!localDydxWallet) {
           dispatch(setOnboardingState(OnboardingState.WalletConnected));
 
-          const solDerivedAccount = solDerivedAddresses[solAddress];
-          if (solDerivedAccount?.encryptedSignature) {
+          if (sourceAccount?.encryptedSignature) {
             try {
-              const signature = decryptSignature(solDerivedAccount.encryptedSignature);
+              const signature = decryptSignature(sourceAccount.encryptedSignature);
               await setWalletFromSignature(signature);
               dispatch(setOnboardingState(OnboardingState.AccountConnected));
             } catch (error) {
               log('useAccounts/decryptSignature', error);
-              forgetSolSignature();
+              dispatch(clearSavedEncryptedSignature());
             }
           }
         } else {
@@ -382,20 +229,27 @@ const useAccountsContext = () => {
       }
     })();
   }, [
-    evmAddress,
-    evmDerivedAddresses,
     signerWagmi,
-    solAddress,
-    solDerivedAddresses,
-    connectedDydxAddress,
     isConnectedGraz,
+    sourceAccount.walletInfo?.connectorType,
+    sourceAccount.chain,
+    sourceAccount.encryptedSignature,
+    dispatch,
+    getCosmosOfflineSigner,
+    selectedDydxChainId,
+    localDydxWallet,
+    authenticated,
+    ready,
+    signMessageAsync,
+    setWalletFromSignature,
   ]);
 
   // abacus
   useEffect(() => {
-    if (dydxAddress) abacusStateManager.setAccount(localDydxWallet, hdKey, connectedWallet);
-    else abacusStateManager.attemptDisconnectAccount();
-  }, [localDydxWallet, hdKey, dydxAddress, connectedWallet]);
+    if (dydxAddress) {
+      abacusStateManager.setAccount(localDydxWallet, hdKey, sourceAccount.walletInfo);
+    } else abacusStateManager.attemptDisconnectAccount();
+  }, [localDydxWallet, hdKey, dydxAddress, sourceAccount.walletInfo]);
 
   useEffect(() => {
     const setNobleWallet = async () => {
@@ -467,15 +321,12 @@ const useAccountsContext = () => {
   const disconnect = async () => {
     // Disconnect local wallet
     disconnectLocalDydxWallet();
-
-    // Disconnect EVM wallet
-    forgetEvmSignature();
     selectWallet(undefined);
   };
 
   return {
     // Wallet connection
-    connectedWallet,
+    sourceAccount,
 
     // Wallet selection
     selectWallet,
@@ -483,22 +334,10 @@ const useAccountsContext = () => {
     selectedWalletError,
 
     // Wallet connection (EVM)
-    evmAddress,
     signerWagmi,
     publicClientWagmi,
 
-    // Wallet connection (sol)
-    solAddress,
-
     setWalletFromSignature,
-
-    // EVM → dYdX account derivation
-    saveEvmSignature,
-    forgetEvmSignature,
-
-    // SOL → dYdX account derivation
-    saveSolSignature,
-    forgetSolSignature,
 
     // dYdX accounts
     hdKey,

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -30,7 +30,7 @@ import { useAllStatsigGateValues } from './useStatsig';
 
 export const useAnalytics = () => {
   const latestTag = import.meta.env.VITE_LAST_TAG;
-  const { connectedWallet, selectedWallet, evmAddress, dydxAddress } = useAccounts();
+  const { sourceAccount, selectedWallet, dydxAddress } = useAccounts();
   const { indexerClient } = useDydxClient();
   const statsigConfig = useAllStatsigGateValues();
   /** User properties */
@@ -92,18 +92,20 @@ export const useAnalytics = () => {
 
   // AnalyticsUserProperty.WalletType
   useEffect(() => {
-    identify(AnalyticsUserProperties.WalletType(connectedWallet?.name ?? null));
-  }, [connectedWallet?.name]);
+    identify(AnalyticsUserProperties.WalletType(sourceAccount.walletInfo?.name ?? null));
+  }, [sourceAccount.walletInfo?.name]);
 
   // AnalyticsUserProperty.WalletConnectorType
   useEffect(() => {
-    identify(AnalyticsUserProperties.WalletConnectorType(connectedWallet?.connectorType ?? null));
-  }, [connectedWallet?.connectorType]);
+    identify(
+      AnalyticsUserProperties.WalletConnectorType(sourceAccount.walletInfo?.connectorType ?? null)
+    );
+  }, [sourceAccount.walletInfo?.connectorType]);
 
   // AnalyticsUserProperty.WalletAddress
   useEffect(() => {
-    identify(AnalyticsUserProperties.WalletAddress(evmAddress ?? dydxAddress ?? null));
-  }, [evmAddress, dydxAddress]);
+    identify(AnalyticsUserProperties.WalletAddress(sourceAccount.address ?? null));
+  }, [sourceAccount.address]);
 
   // AnalyticsUserProperty.DydxAddress
   useEffect(() => {

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -32,7 +32,7 @@ const getWalletInfoFromInjectedWallet = (wallet: MipdInjectedWallet) => {
 };
 
 export const useDisplayedWallets = (): WalletInfo[] => {
-  const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr) || true;
+  const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr);
   const injectedWallets = useMipdInjectedWallets();
 
   return useMemo(() => {

--- a/src/hooks/useDisplayedWallets.ts
+++ b/src/hooks/useDisplayedWallets.ts
@@ -32,7 +32,7 @@ const getWalletInfoFromInjectedWallet = (wallet: MipdInjectedWallet) => {
 };
 
 export const useDisplayedWallets = (): WalletInfo[] => {
-  const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr);
+  const keplrEnabled = useStatsigGateValue(StatsigFlags.ffEnableKeplr) || true;
   const injectedWallets = useMipdInjectedWallets();
 
   return useMemo(() => {

--- a/src/hooks/useMatchingEvmNetwork.ts
+++ b/src/hooks/useMatchingEvmNetwork.ts
@@ -5,7 +5,7 @@ import { useAccount, useSwitchChain } from 'wagmi';
 
 import { ConnectorType } from '@/constants/wallets';
 
-import { useWalletConnection } from './useWalletConnection';
+import { useAccounts } from './useAccounts';
 
 export const useMatchingEvmNetwork = ({
   chainId,
@@ -19,22 +19,22 @@ export const useMatchingEvmNetwork = ({
   onSuccess?: () => void;
 }) => {
   const { chain } = useAccount();
-  const { connectedWallet } = useWalletConnection();
+  const { sourceAccount } = useAccounts();
   const { isPending, switchChainAsync } = useSwitchChain();
   const { wallets } = useWallets();
 
   const isMatchingNetwork = useMemo(() => {
     // In the Keplr wallet, the network will always match
-    if (connectedWallet?.connectorType === ConnectorType.Cosmos) {
+    if (sourceAccount.walletInfo?.connectorType === ConnectorType.Cosmos) {
       return true;
     }
     // If chainId is not a number, we can assume it is a non EVM compatible chain
     return Boolean(chain && chainId && typeof chainId === 'number' && chain.id === chainId);
-  }, [connectedWallet, chain, chainId]);
+  }, [sourceAccount.walletInfo, chain, chainId]);
 
   const matchNetwork = useCallback(async () => {
     if (!isMatchingNetwork) {
-      if (connectedWallet?.connectorType === ConnectorType.Privy) {
+      if (sourceAccount.walletInfo?.connectorType === ConnectorType.Privy) {
         await wallets?.[0].switchChain(Number(chainId));
       } else {
         await switchChainAsync?.({ chainId: Number(chainId) }, { onError, onSuccess });

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -72,10 +72,10 @@ export const useSubaccount = () => useContext(SubaccountContext);
 const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWallet }) => {
   const dispatch = useAppDispatch();
   const { usdcDenom, usdcDecimals, chainTokenDecimals } = useTokenConfigs();
-  const { connectedWallet } = useAccounts();
+  const { sourceAccount } = useAccounts();
   const { compositeClient, faucetClient } = useDydxClient();
 
-  const isKeplr = connectedWallet?.name === WalletType.Keplr;
+  const isKeplr = sourceAccount.walletInfo?.name === WalletType.Keplr;
 
   const { getFaucetFunds, getNativeTokens } = useMemo(
     () => ({

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -62,7 +62,7 @@ export const useWalletConnection = () => {
 
   const sourceAccount = useAppSelector(getSourceAccount);
 
-  // Save the connect wallet address in Redux so we can show source wallet details even if the user disconnects from their wallet
+  // Save the connected wallet address in Redux so we can show source wallet details even if the user disconnects from their wallet
   useEffect(() => {
     const walletInfo = sourceAccount.walletInfo;
     if (!walletInfo) return;
@@ -241,7 +241,6 @@ export const useWalletConnection = () => {
   const selectWallet = useCallback(
     async (wallet: WalletInfo | undefined) => {
       if (wallet) {
-        setSelectedWallet(undefined);
         await disconnectWallet();
         await new Promise(requestAnimationFrame);
       }
@@ -283,12 +282,13 @@ export const useWalletConnection = () => {
 
   // On page load, if testFlag.address is set, connect to the test wallet.
   useEffect(() => {
-    (async () => {
-      if (testFlags.addressOverride) {
-        dispatch(setWalletInfo({ connectorType: ConnectorType.Test, name: WalletType.TestWallet }));
-      }
-    })();
-  }, []);
+    if (testFlags.addressOverride) {
+      dispatch(setWalletInfo({ connectorType: ConnectorType.Test, name: WalletType.TestWallet }));
+      dispatch(
+        setSourceAddress({ address: testFlags.addressOverride, chain: WalletNetworkType.Test })
+      );
+    }
+  }, [dispatch]);
 
   return {
     // Wallet selection

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -235,10 +235,16 @@ export const resolveWagmiConnector = ({
   return undefined;
 };
 
+/* This method checks if the connection mechanism goes through wagmi */
 export function isWagmiConnectorType(wallet: WalletInfo | undefined): boolean {
   if (!wallet) return false;
 
   return [ConnectorType.Injected, ConnectorType.Coinbase, ConnectorType.WalletConnect].includes(
     wallet.connectorType
   );
+}
+
+/* This method checks if the resolved wallet address is returned by wagmi */
+export function isWagmiResolvedWallet(wallet: WalletInfo | undefined): boolean {
+  return isWagmiConnectorType(wallet) || wallet?.connectorType === ConnectorType.Privy;
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -9,7 +9,7 @@ import { ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { AppRoute, HistoryRoute, PortfolioRoute } from '@/constants/routes';
-import { ConnectorType, wallets } from '@/constants/wallets';
+import { ConnectorType, EvmAddress, WalletNetworkType, wallets } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
 import { useComplianceState } from '@/hooks/useComplianceState';
@@ -67,12 +67,15 @@ const Profile = () => {
   const onboardingState = useAppSelector(getOnboardingState);
   const isConnected = onboardingState !== OnboardingState.Disconnected;
 
-  const { evmAddress, dydxAddress, connectedWallet } = useAccounts();
+  const { sourceAccount, dydxAddress } = useAccounts();
   const { chainTokenLabel } = useTokenConfigs();
   const { disableConnectButton } = useComplianceState();
 
   const { data: ensName } = useEnsName({
-    address: evmAddress,
+    address:
+      sourceAccount.chain === WalletNetworkType.Evm
+        ? (sourceAccount.address as EvmAddress)
+        : undefined,
     chainId: ENS_CHAIN_ID,
   });
 
@@ -149,14 +152,14 @@ const Profile = () => {
           <h1 tw="font-extra-medium">
             {isConnected ? ensName ?? truncateAddress(dydxAddress) : '-'}
           </h1>
-          {isConnected && connectedWallet ? (
+          {isConnected && sourceAccount.walletInfo ? (
             <$SubHeader>
               <$ConnectedIcon />
               <span>{stringGetter({ key: STRING_KEYS.CONNECTED_TO })}</span>
               <span>
-                {connectedWallet.connectorType === ConnectorType.Injected
-                  ? connectedWallet.name
-                  : stringGetter({ key: wallets[connectedWallet.name].stringKey })}
+                {sourceAccount.walletInfo.connectorType === ConnectorType.Injected
+                  ? sourceAccount.walletInfo.name
+                  : stringGetter({ key: wallets[sourceAccount.walletInfo.name].stringKey })}
               </span>
             </$SubHeader>
           ) : (

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -20,6 +20,7 @@ import { notificationsSlice } from './notifications';
 import { perpetualsSlice } from './perpetuals';
 import { tradingViewSlice } from './tradingView';
 import { vaultsSlice } from './vaults';
+import { walletSlice } from './wallet';
 
 const reducers = {
   account: accountSlice.reducer,
@@ -35,6 +36,7 @@ const reducers = {
   perpetuals: perpetualsSlice.reducer,
   tradingView: tradingViewSlice.reducer,
   vaults: vaultsSlice.reducer,
+  wallet: walletSlice.reducer,
 } as const;
 
 const rootReducer = combineReducers(reducers);
@@ -43,7 +45,7 @@ const persistConfig = {
   key: 'root',
   version: 0,
   storage,
-  whitelist: ['tradingView'],
+  whitelist: ['tradingView', 'wallet'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),
 };
 

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -43,7 +43,7 @@ const rootReducer = combineReducers(reducers);
 
 const persistConfig = {
   key: 'root',
-  version: 0,
+  version: 1,
   storage,
   whitelist: ['tradingView', 'wallet'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -2,9 +2,11 @@ import { createMigrate, PersistedState, PersistMigrate } from 'redux-persist';
 import { MigrationConfig } from 'redux-persist/lib/createMigrate';
 
 import { migration0 } from './migrations/0';
+import { migration1 } from './migrations/1';
 
 export const migrations = {
   0: migration0,
+  1: migration1,
 } as const;
 
 /*

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -1,0 +1,71 @@
+import { PersistedState } from 'redux-persist';
+
+import { EvmDerivedAddresses, SolDerivedAddresses } from '@/constants/account';
+import { ConnectorType, EvmAddress, WalletInfo } from '@/constants/wallets';
+
+import { parseStorageItem } from './utils';
+
+/**
+ * Move over wallet data into redux
+ *
+ */
+export function migration1(state: PersistedState) {
+  if (!state) {
+    throw new Error('state must be defined');
+  }
+
+  const evmAddress = localStorage.getItem('dydx.EvmAddress') as EvmAddress;
+  const evmDerivedAddresses = parseStorageItem(
+    localStorage.getItem('dydx.EvmDerivedAddresses')
+  ) as EvmDerivedAddresses;
+
+  const solAddress = localStorage.getItem('dydx.SolAddress');
+  const solDerivedAddresses = parseStorageItem(
+    localStorage.getItem('dydx.SolDerivedAddresses')
+  ) as SolDerivedAddresses;
+
+  const dydxAddress = localStorage.getItem('dydx.DydxAddress');
+  const selectedWallet = parseStorageItem(localStorage.getItem('dydx.OnboardingSelectedWallet')) as
+    | WalletInfo
+    | undefined;
+
+  if (!selectedWallet) {
+    return {
+      ...state,
+      wallet: {
+        sourceAccount: undefined,
+      },
+    };
+  }
+
+  if (selectedWallet.connectorType === ConnectorType.PhantomSolana && solAddress) {
+    return {
+      ...state,
+      wallet: {
+        sourceAccount: {
+          address: solAddress,
+          chain: 'solana',
+          encryptedSignature: solDerivedAddresses[solAddress]?.encryptedSignature,
+          walletInfo: selectedWallet,
+        },
+      },
+    };
+  }
+
+  if (selectedWallet.connectorType === ConnectorType.Cosmos && dydxAddress) {
+    return {
+      ...state,
+      wallet: {
+        sourceAccount: {
+          address: dydxAddress,
+          chain: 'cosmos',
+          walletInfo: selectedWallet,
+        },
+      },
+    };
+  }
+
+  return {
+    ...state,
+  };
+}

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -7,7 +7,7 @@ import { parseStorageItem } from './utils';
 
 /**
  * Move over wallet data from localStorage into redux
- *
+ * TODO (in future migration): Remove these localStorage items
  */
 export function migration1(state: PersistedState) {
   if (!state) {

--- a/src/state/migrations/__test__/1.test.ts
+++ b/src/state/migrations/__test__/1.test.ts
@@ -1,0 +1,128 @@
+import { WalletType as CosmosWalletType } from 'graz';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ConnectorType, WalletInfo, WalletType } from '@/constants/wallets';
+
+import { migration1 } from '../1';
+
+const V0_STATE = {
+  _persist: { version: 0, rehydrated: true },
+  tradingViewConfig: undefined,
+};
+
+const MOCK_EVM_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const MOCK_EVM_SIGNATURE = 'fake_signature_woohoo';
+const MOCK_SOLANA_ADDRESS = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const MOCK_DYDX_ADDRESS = 'dydx1';
+
+const MOCK_EVM_WALLET_INFO: WalletInfo = {
+  connectorType: ConnectorType.Coinbase,
+  name: WalletType.CoinbaseWallet,
+};
+
+const MOCK_SOLANA_WALLET_INFO: WalletInfo = {
+  connectorType: ConnectorType.PhantomSolana,
+  name: WalletType.Phantom,
+};
+
+const MOCK_COSMOS_WALLET_INFO: WalletInfo = {
+  connectorType: ConnectorType.Cosmos,
+  name: CosmosWalletType.KEPLR,
+};
+
+describe('migration1', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should not set any address if no wallet info is defined', () => {
+    localStorage.setItem('dydx.EvmAddress', MOCK_EVM_ADDRESS);
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBeUndefined();
+    expect(newState.wallet.sourceAccount?.walletInfo).toBeUndefined();
+  });
+
+  it('should set evm address correctly if wallet info is evm', () => {
+    localStorage.setItem('dydx.EvmAddress', MOCK_EVM_ADDRESS);
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_EVM_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_EVM_ADDRESS);
+    expect(newState.wallet.sourceAccount?.walletInfo.connectorType).toBe(
+      MOCK_EVM_WALLET_INFO.connectorType
+    );
+  });
+
+  it('should set solana address correctly if wallet info is solana', () => {
+    localStorage.setItem('dydx.SolAddress', MOCK_SOLANA_ADDRESS);
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_SOLANA_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_SOLANA_ADDRESS);
+    expect(newState.wallet.sourceAccount?.walletInfo.connectorType).toBe(
+      MOCK_SOLANA_WALLET_INFO.connectorType
+    );
+  });
+
+  it('should set dydx address correctly if wallet info is cosmos', () => {
+    localStorage.setItem('dydx.DydxAddress', MOCK_DYDX_ADDRESS);
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_COSMOS_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_DYDX_ADDRESS);
+    expect(newState.wallet.sourceAccount?.walletInfo.connectorType).toBe(
+      MOCK_COSMOS_WALLET_INFO.connectorType
+    );
+  });
+
+  it('should set the right address even if multiple are defined in localstorage', () => {
+    localStorage.setItem('dydx.EvmAddress', MOCK_EVM_ADDRESS);
+    localStorage.setItem('dydx.SolAddress', MOCK_SOLANA_ADDRESS);
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_SOLANA_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_SOLANA_ADDRESS);
+    expect(newState.wallet.sourceAccount?.walletInfo.connectorType).toBe(
+      MOCK_SOLANA_WALLET_INFO.connectorType
+    );
+  });
+
+  it('should migrate over saved encrypted v2 signatures', () => {
+    localStorage.setItem('dydx.EvmAddress', MOCK_EVM_ADDRESS);
+    localStorage.setItem(
+      'dydx.EvmDerivedAddresses',
+      JSON.stringify({
+        version: 'v2',
+        [MOCK_EVM_ADDRESS]: { encryptedSignature: MOCK_EVM_SIGNATURE },
+      })
+    );
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_EVM_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_EVM_ADDRESS);
+    expect(newState.wallet.sourceAccount?.encryptedSignature).toBe(MOCK_EVM_SIGNATURE);
+  });
+
+  it('should not migrate over saved encrypted v1 signatures', () => {
+    localStorage.setItem('dydx.EvmAddress', MOCK_EVM_ADDRESS);
+    localStorage.setItem(
+      'dydx.EvmDerivedAddresses',
+      JSON.stringify({
+        version: 'v1',
+        [MOCK_EVM_ADDRESS]: { encryptedSignature: MOCK_EVM_SIGNATURE },
+      })
+    );
+    localStorage.setItem('dydx.OnboardingSelectedWallet', JSON.stringify(MOCK_EVM_WALLET_INFO));
+
+    const newState = migration1(V0_STATE);
+    expect(newState).toBeDefined();
+    expect(newState.wallet.sourceAccount?.address).toBe(MOCK_EVM_ADDRESS);
+    expect(newState.wallet.sourceAccount?.encryptedSignature).toBeUndefined();
+  });
+});

--- a/src/state/migrations/utils.ts
+++ b/src/state/migrations/utils.ts
@@ -1,4 +1,4 @@
-export function parseStorageItem(data: string | null) {
+export function parseStorageItem<T>(data: string | null): T | undefined {
   if (!data) return undefined;
 
   try {

--- a/src/state/wallet.ts
+++ b/src/state/wallet.ts
@@ -46,7 +46,7 @@ export const walletSlice = createSlice({
       state.sourceAccount.walletInfo = action.payload;
     },
     setSavedEncryptedSignature: (state, action: PayloadAction<string>) => {
-      if (state.sourceAccount.chain === 'cosmos') {
+      if (state.sourceAccount.chain === WalletNetworkType.Cosmos) {
         throw new Error('cosmos wallets should not require signatures for derived addresses');
       }
 

--- a/src/state/wallet.ts
+++ b/src/state/wallet.ts
@@ -1,0 +1,67 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+import {
+  CosmosWalletInfo,
+  DydxAddress,
+  EvmAddress,
+  PhantomSolanaWalletInfo,
+  SolAddress,
+  WalletInfo,
+} from '@/constants/wallets';
+
+type EvmAccount = {
+  address: EvmAddress;
+  chain: 'evm';
+  encryptedSignature?: string;
+  walletInfo: WalletInfo;
+};
+type SolanaAccount = {
+  address: SolAddress;
+  chain: 'solana';
+  encryptedSignature?: string;
+  walletInfo: PhantomSolanaWalletInfo;
+};
+type CosmosAccount = { address: DydxAddress; chain: 'cosmos'; walletInfo: CosmosWalletInfo };
+
+type SourceAccount = EvmAccount | SolanaAccount | CosmosAccount;
+
+export interface WalletState {
+  sourceAccount: SourceAccount | undefined;
+}
+
+const initialState: WalletState = {
+  sourceAccount: undefined,
+};
+
+export const walletSlice = createSlice({
+  name: 'wallet',
+  initialState,
+  reducers: {
+    setSourceAccount: (state, action: PayloadAction<SourceAccount>) => {
+      state.sourceAccount = action.payload;
+    },
+    setSavedEncryptedSignature: (state, action: PayloadAction<string>) => {
+      if (!state.sourceAccount) {
+        throw new Error('no source account set');
+      }
+
+      if (state.sourceAccount.chain === 'cosmos') {
+        throw new Error('cosmos wallets should not require signatures for derived addresses');
+      }
+
+      state.sourceAccount.encryptedSignature = action.payload;
+    },
+    clearSavedEncryptedSignature: (state) => {
+      if (!state.sourceAccount || state.sourceAccount.chain === 'cosmos') return;
+
+      state.sourceAccount.encryptedSignature = undefined;
+    },
+    clearSourceAccount: (state) => {
+      state.sourceAccount = undefined;
+    },
+  },
+});
+
+export const { setSourceAccount, setSavedEncryptedSignature, clearSourceAccount } =
+  walletSlice.actions;

--- a/src/state/walletSelectors.ts
+++ b/src/state/walletSelectors.ts
@@ -1,0 +1,6 @@
+import { RootState } from './_store';
+
+/**
+ * @returns saved wallet and account information
+ */
+export const getSourceAccount = (state: RootState) => state.wallet.sourceAccount;

--- a/src/views/dialogs/OnboardingDialog.tsx
+++ b/src/views/dialogs/OnboardingDialog.tsx
@@ -37,7 +37,7 @@ export const OnboardingDialog = ({ setIsOpen }: DialogProps<OnboardingDialogProp
   const stringGetter = useStringGetter();
   const { isMobile } = useBreakpoints();
 
-  const { selectWallet, connectedWallet } = useAccounts();
+  const { selectWallet, sourceAccount } = useAccounts();
 
   const currentOnboardingStep = useAppSelector(calculateOnboardingStep);
 
@@ -77,8 +77,8 @@ export const OnboardingDialog = ({ setIsOpen }: DialogProps<OnboardingDialogProp
           },
           [OnboardingSteps.KeyDerivation]: {
             slotIcon: {
-              [EvmDerivedAccountStatus.NotDerived]: connectedWallet && (
-                <WalletIcon wallet={connectedWallet} />
+              [EvmDerivedAccountStatus.NotDerived]: sourceAccount.walletInfo && (
+                <WalletIcon wallet={sourceAccount.walletInfo} />
               ),
               [EvmDerivedAccountStatus.Deriving]: <$Ring withAnimation value={0.25} />,
               [EvmDerivedAccountStatus.EnsuringDeterminism]: <$Ring withAnimation value={0.25} />,

--- a/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm/DepositButtonAndReceipt.tsx
@@ -10,6 +10,7 @@ import { NumberSign, TOKEN_DECIMALS } from '@/constants/numbers';
 import { SKIP_EST_TIME_DEFAULT_MINUTES } from '@/constants/skip';
 import { WalletType } from '@/constants/wallets';
 
+import { useAccounts } from '@/hooks/useAccounts';
 import { ConnectionErrorType, useApiState } from '@/hooks/useApiState';
 import { useMatchingEvmNetwork } from '@/hooks/useMatchingEvmNetwork';
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -64,8 +65,10 @@ export const DepositButtonAndReceipt = ({
 
   const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
 
-  const { connectWallet, isConnectedWagmi, connectedWallet, selectedWallet, isConnectedGraz } =
+  const { connectWallet, isConnectedWagmi, selectedWallet, isConnectedGraz } =
     useWalletConnection();
+  const { sourceAccount } = useAccounts();
+
   const { connectionError } = useApiState();
 
   const connectWagmi = async () => {
@@ -266,7 +269,9 @@ export const DepositButtonAndReceipt = ({
       />
       {!canAccountTrade ? (
         <OnboardingTriggerButton size={ButtonSize.Base} />
-      ) : !isConnectedWagmi && connectedWallet?.name !== WalletType.Phantom && !isConnectedGraz ? (
+      ) : !isConnectedWagmi &&
+        sourceAccount.walletInfo?.name !== WalletType.Phantom &&
+        !isConnectedGraz ? (
         <Button action={ButtonAction.Primary} onClick={connectWagmi}>
           {stringGetter({ key: STRING_KEYS.RECONNECT_WALLET })}
         </Button>

--- a/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/SourceSelectMenu.tsx
@@ -44,12 +44,14 @@ export const SourceSelectMenu = ({
   selectedChain,
   onSelect,
 }: ElementProps) => {
-  const { connectedWallet } = useAccounts();
+  const { sourceAccount } = useAccounts();
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
   const { CCTPWithdrawalOnly, CCTPDepositOnly: initialCCTPDepositValue } = useEnvFeatures();
   // Only CCTP deposits are supported for Phantom / Solana
   const CCTPDepositOnly =
-    connectedWallet?.connectorType === ConnectorType.PhantomSolana ? true : initialCCTPDepositValue;
+    sourceAccount.walletInfo?.connectorType === ConnectorType.PhantomSolana
+      ? true
+      : initialCCTPDepositValue;
 
   const stringGetter = useStringGetter();
   const { type, depositOptions, withdrawalOptions } =
@@ -65,7 +67,7 @@ export const SourceSelectMenu = ({
   const lowestFeeTokensByChainId = useMemo(() => getMapOfLowestFeeTokensByChainId(type), [type]);
 
   const highestFeeTokensByChainId = useMemo(() => getMapOfHighestFeeTokensByChainId(type), [type]);
-  const isKeplrWallet = connectedWallet?.name === WalletType.Keplr;
+  const isKeplrWallet = sourceAccount.walletInfo?.name === WalletType.Keplr;
 
   // withdrawals SourceSelectMenu is half width size so we must throw the decorator text
   // in the description prop (renders below the item label) instead of in the slotAfter
@@ -93,7 +95,7 @@ export const SourceSelectMenu = ({
         return selectedDydxChainId !== chain.value && SUPPORTED_COSMOS_CHAINS.includes(chain.value);
       }
       // only solana chains are supported on phantom
-      if (connectedWallet?.connectorType === ConnectorType.PhantomSolana) {
+      if (sourceAccount.walletInfo?.connectorType === ConnectorType.PhantomSolana) {
         return selectedDydxChainId !== chain.value && chain.value.startsWith(solanaChainIdPrefix);
       }
       // other wallets do not support solana
@@ -130,7 +132,7 @@ export const SourceSelectMenu = ({
   const selectedChainOption = chains.find((item) => item.type === selectedChain);
   const selectedExchangeOption = exchanges.find((item) => item.type === selectedExchange);
   const isNotPrivyDeposit =
-    type === TransferType.withdrawal || connectedWallet?.name !== WalletType.Privy;
+    type === TransferType.withdrawal || sourceAccount.walletInfo?.name !== WalletType.Privy;
   return (
     <SearchSelectMenu
       items={[

--- a/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
+++ b/src/views/forms/AccountManagementForms/TokenSelectMenu.tsx
@@ -41,12 +41,12 @@ export const TokenSelectMenu = ({ selectedToken, onSelectToken, isExchange }: El
     resources,
     chain: chainIdStr,
   } = orEmptyObj(useAppSelector(getTransferInputs, shallowEqual));
-  const { connectedWallet } = useAccounts();
+  const { sourceAccount } = useAccounts();
   const { CCTPWithdrawalOnly, CCTPDepositOnly } = useEnvFeatures();
 
   const lowestFeeTokensByDenom = useMemo(() => getMapOfLowestFeeTokensByDenom(type), [type]);
-  const isKeplrWallet = connectedWallet?.name === WalletType.Keplr;
-  const isPhantomWallet = connectedWallet?.connectorType === ConnectorType.PhantomSolana;
+  const isKeplrWallet = sourceAccount.walletInfo?.name === WalletType.Keplr;
+  const isPhantomWallet = sourceAccount.walletInfo?.connectorType === ConnectorType.PhantomSolana;
 
   const tokens =
     (type === TransferType.deposit ? depositOptions : withdrawalOptions)?.assets?.toArray() ??

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -80,7 +80,7 @@ export const WithdrawForm = () => {
   const [isLoading, setIsLoading] = useState(false);
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
 
-  const { dydxAddress, connectedWallet } = useAccounts();
+  const { dydxAddress, sourceAccount } = useAccounts();
   const { sendSkipWithdraw } = useSubaccount();
   const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
 
@@ -133,7 +133,7 @@ export const WithdrawForm = () => {
   useEffect(() => setSlippage(isCctp ? 0 : 0.01), [isCctp]);
 
   useEffect(() => {
-    if (connectedWallet?.name === WalletType.Keplr && dydxAddress) {
+    if (sourceAccount.walletInfo?.name === WalletType.Keplr && dydxAddress) {
       abacusStateManager.setTransfersSourceAddress(dydxAddress);
     }
 
@@ -145,7 +145,7 @@ export const WithdrawForm = () => {
     return () => {
       abacusStateManager.resetInputState();
     };
-  }, [dydxAddress, connectedWallet]);
+  }, [dydxAddress, sourceAccount.walletInfo]);
 
   useEffect(() => {
     const setTransferValue = async () => {
@@ -339,19 +339,19 @@ export const WithdrawForm = () => {
   }, [freeCollateralBN, setWithdrawAmount]);
 
   useEffect(() => {
-    if (connectedWallet?.name === WalletType.Privy) {
+    if (sourceAccount.walletInfo?.name === WalletType.Privy) {
       abacusStateManager.setTransferValue({
         field: TransferInputField.exchange,
         value: 'coinbase',
       });
     }
-    if (connectedWallet?.name === WalletType.Keplr) {
+    if (sourceAccount.walletInfo?.name === WalletType.Keplr) {
       abacusStateManager.setTransferValue({
         field: TransferInputField.chain,
         value: nobleChainId,
       });
     }
-  }, [connectedWallet, nobleChainId]);
+  }, [sourceAccount.walletInfo, nobleChainId]);
 
   const onSelectNetwork = useCallback(
     (name: string, type: 'chain' | 'exchange') => {

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -63,7 +63,7 @@ export const TransferForm = ({
   const stringGetter = useStringGetter();
 
   const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
-  const { dydxAddress, connectedWallet } = useAccounts();
+  const { dydxAddress, sourceAccount } = useAccounts();
   const { transfer } = useSubaccount();
   const { nativeTokenBalance, usdcBalance } = useAccountBalance();
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
@@ -118,7 +118,7 @@ export const TransferForm = ({
   };
 
   useEffect(() => {
-    if (connectedWallet?.name === WalletType.Keplr && dydxAddress) {
+    if (sourceAccount.walletInfo?.name === WalletType.Keplr && dydxAddress) {
       abacusStateManager.setTransfersSourceAddress(dydxAddress);
     }
 

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -73,13 +73,17 @@ export const AccountMenu = () => {
   const { usdcLabel, chainTokenLabel } = useTokenConfigs();
   const theme = useAppSelector(getAppTheme);
 
-  const { evmAddress, solAddress, connectedWallet, dydxAddress, hdKey } = useAccounts();
+  const {
+    sourceAccount: { walletInfo, address },
+    dydxAddress,
+    hdKey,
+  } = useAccounts();
 
-  let address: string | undefined;
-  if (connectedWallet?.name === WalletType.Phantom) {
-    address = truncateAddress(solAddress, '');
+  let displayAddress: string | undefined;
+  if (walletInfo?.name === WalletType.Phantom) {
+    displayAddress = truncateAddress(address, '');
   } else {
-    address = truncateAddress(evmAddress, '0x');
+    displayAddress = truncateAddress(address, '0x');
   }
 
   const privy = usePrivy();
@@ -96,7 +100,7 @@ export const AccountMenu = () => {
   const usedBalanceBN = MustBigNumber(usdcBalance);
 
   const showConfirmPendingDeposit =
-    connectedWallet?.name === WalletType.Keplr &&
+    walletInfo?.name === WalletType.Keplr &&
     usedBalanceBN.gt(AMOUNT_RESERVED_FOR_GAS_USDC) &&
     usedBalanceBN.minus(AMOUNT_RESERVED_FOR_GAS_USDC).toFixed(2) !== '0.00';
 
@@ -105,7 +109,7 @@ export const AccountMenu = () => {
     walletIcon = <Icon iconName={IconName.Warning} tw="text-[1.25rem] text-color-warning" />;
   } else if (
     onboardingState === OnboardingState.AccountConnected &&
-    connectedWallet?.name === WalletType.Privy
+    walletInfo?.name === WalletType.Privy
   ) {
     if (google) {
       walletIcon = <Icon iconComponent={GoogleIcon as ElementType} />;
@@ -116,8 +120,8 @@ export const AccountMenu = () => {
     } else {
       walletIcon = <Icon iconComponent={wallets[WalletType.Privy].icon as ElementType} />;
     }
-  } else if (connectedWallet) {
-    walletIcon = <WalletIcon wallet={connectedWallet} />;
+  } else if (walletInfo) {
+    walletIcon = <WalletIcon wallet={walletInfo} />;
   }
 
   return onboardingState === OnboardingState.Disconnected ? (
@@ -130,16 +134,17 @@ export const AccountMenu = () => {
             <$AddressRow>
               <AssetIcon symbol="DYDX" tw="z-[2] text-[1.75rem]" />
               <$Column>
-                {connectedWallet && connectedWallet?.name !== WalletType.Keplr ? (
+                {walletInfo && walletInfo?.name !== WalletType.Keplr ? (
                   <WithTooltip
                     slotTooltip={
                       <dl>
                         <dt>
+                          {/* TODO: Fix tooltip string here for Phantom connections */}
                           {stringGetter({
                             key: TOOLTIP_STRING_KEYS.DYDX_ADDRESS_BODY,
                             params: {
                               DYDX_ADDRESS: <strong>{truncateAddress(dydxAddress)}</strong>,
-                              EVM_ADDRESS: truncateAddress(evmAddress, '0x'),
+                              EVM_ADDRESS: truncateAddress(address, '0x'),
                             },
                           })}
                         </dt>
@@ -164,20 +169,20 @@ export const AccountMenu = () => {
                 />
               </WithTooltip>
             </$AddressRow>
-            {connectedWallet &&
-              connectedWallet.name !== WalletType.Privy &&
-              connectedWallet.name !== WalletType.Keplr && (
+            {walletInfo &&
+              walletInfo.name !== WalletType.Privy &&
+              walletInfo.name !== WalletType.Keplr && (
                 <$AddressRow>
                   <div tw="relative z-[1] rounded-[50%] bg-[#303045] p-0.375 text-[1rem] leading-[0]">
                     <Icon
                       iconName={IconName.AddressConnector}
                       tw="absolute top-[-1.625rem] h-1.75"
                     />
-                    <WalletIcon wallet={connectedWallet} />
+                    <WalletIcon wallet={walletInfo} />
                   </div>
                   <$Column>
                     <$label>{stringGetter({ key: STRING_KEYS.SOURCE_ADDRESS })}</$label>
-                    <$Address>{address}</$Address>
+                    <$Address>{displayAddress}</$Address>
                   </$Column>
                 </$AddressRow>
               )}


### PR DESCRIPTION
This PR moves over our separate localStorage variables into one atomic chunk in redux-persist. The idea is that the site should only have one "connected" account at a time, so we can combine evm/sol/dydxAddress into one variable, and combine the encryptedSignature stored in evm/solDerivedAddresses into one storage unit along with the address.

Specifically, it combines these fields:

```
EvmAddress = 'dydx.EvmAddress',
SolAddress = 'dydx.SolAddress',
DydxAddress = 'dydx.DydxAddress',
OnboardingSelectedWallet = 'dydx.OnboardingSelectedWallet',
EvmDerivedAddresses = 'dydx.EvmDerivedAddresses',
SolDerivedAddresses = 'dydx.SolDerivedAddresses',
```

into this block in redux:
```
export interface WalletState {
  sourceAccount: {
    address?: string;
    chain?: WalletNetworkType;
    encryptedSignature?: string;
    walletInfo?: WalletInfo;
  };
}
```

The data is moved over using `migration1.ts` and includes a unit test!
