### PR TITLE
fix: forward fix misaligned tag + label

### DIFF
--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -37,8 +37,6 @@ export const Tag = styled.span<StyleProps>`
   letter-spacing: 0.04em;
   line-height: 1.3;
 
-  ${layoutMixins.textTruncate}
-
   ${({ type, size }) =>
     ({
       [TagSize.Small]: css`

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,7 +1,5 @@
 import styled, { css } from 'styled-components';
 
-import { layoutMixins } from '@/styles/layoutMixins';
-
 export enum TagSize {
   Small = 'Small',
   Medium = 'Medium',

--- a/src/components/WithLabel.tsx
+++ b/src/components/WithLabel.tsx
@@ -25,5 +25,8 @@ const $Container = styled.div`
   label {
     ${layoutMixins.textTruncate}
     text-align: start;
+    > *:not(:last-child) {
+      margin-right: 0.5ch;
+    }
   }
 `;


### PR DESCRIPTION
remove truncation from tags until I have more time to better review all the cases T.T and add back missing spacing between tags and labels
<img width="559" alt="Screenshot 2024-10-01 at 2 05 52 PM" src="https://github.com/user-attachments/assets/21b2ccff-1593-402e-9906-7325f2638ef9">
<img width="442" alt="Screenshot 2024-10-01 at 2 05 46 PM" src="https://github.com/user-attachments/assets/7f5dd49e-5f21-403f-b913-8e07ba1653ba">
<img width="1319" alt="Screenshot 2024-10-01 at 2 05 38 PM" src="https://github.com/user-attachments/assets/a11ecc4d-12f8-4330-8055-54e3aea7069b">
<img width="540" alt="Screenshot 2024-10-01 at 2 05 29 PM" src="https://github.com/user-attachments/assets/4651aea6-3bd2-4669-b1f0-74bc142ac704">
<img width="554" alt="Screenshot 2024-10-01 at 2 05 24 PM" src="https://github.com/user-attachments/assets/3b450f6a-03f7-45f1-ab1a-fcb96130699d">
<img width="335" alt="Screenshot 2024-10-01 at 2 05 15 PM" src="https://github.com/user-attachments/assets/3bb942cb-a02e-4cb0-807b-c9e0181af8cf">
<img width="421" alt="Screenshot 2024-10-01 at 2 04 37 PM" src="https://github.com/user-attachments/assets/869c8fdf-2482-4e7b-a08e-e39ff250a009">
<img width="361" alt="Screenshot 2024-10-01 at 2 04 35 PM" src="https://github.com/user-attachments/assets/1076cce4-809b-4e9f-9af9-2e1147d3c029">

