### PR TITLE
feat: toggle display unit usd <> base token/asset

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
+import { MODERATE_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -34,7 +35,7 @@ export const CopyButton = ({
 
     setCopied(true);
     navigator.clipboard.writeText(value);
-    setTimeout(() => setCopied(false), 500);
+    setTimeout(() => setCopied(false), MODERATE_DEBOUNCE_MS);
   };
 
   return buttonType === 'text' ? (

--- a/src/components/DisplayUnitTag.tsx
+++ b/src/components/DisplayUnitTag.tsx
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 
-import _ from 'lodash';
+import { debounce } from 'lodash';
 import { useDispatch } from 'react-redux';
 
+import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { DisplayUnit } from '@/constants/trade';
 
 import { useAppSelector } from '@/state/appTypes';
@@ -21,10 +22,10 @@ export const DisplayUnitTag = ({ entryPoint, assetId, className }: ElementProps)
   const displayUnit = useAppSelector(getSelectedDisplayUnit);
   const dispatch = useDispatch();
 
-  const dispatchSetDisplayUnit = _.debounce((newDisplayUnit) => {
+  const dispatchSetDisplayUnit = debounce((newDisplayUnit) => {
     if (!assetId) return;
     dispatch(setDisplayUnit({ newDisplayUnit, entryPoint, assetId }));
-  }, 300);
+  }, NORMAL_DEBOUNCE_MS);
 
   const onToggle = useCallback(() => {
     if (!assetId) return;

--- a/src/components/DisplayUnitTag.tsx
+++ b/src/components/DisplayUnitTag.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import _ from 'lodash';
 import { useDispatch } from 'react-redux';
 
 import { DisplayUnit } from '@/constants/trade';
@@ -20,18 +21,17 @@ export const DisplayUnitTag = ({ entryPoint, assetId, className }: ElementProps)
   const displayUnit = useAppSelector(getSelectedDisplayUnit);
   const dispatch = useDispatch();
 
+  const dispatchSetDisplayUnit = _.debounce((newDisplayUnit) => {
+    if (!assetId) return;
+    dispatch(setDisplayUnit({ newDisplayUnit, entryPoint, assetId }));
+  }, 300);
+
   const onToggle = useCallback(() => {
     if (!assetId) return;
 
     const newDisplayUnit = displayUnit === DisplayUnit.Asset ? DisplayUnit.Fiat : DisplayUnit.Asset;
-    dispatch(
-      setDisplayUnit({
-        newDisplayUnit,
-        assetId,
-        entryPoint,
-      })
-    );
-  }, [assetId, dispatch, displayUnit, entryPoint]);
+    dispatchSetDisplayUnit(newDisplayUnit);
+  }, [assetId, dispatchSetDisplayUnit, displayUnit]);
 
   return !assetId ? (
     <Tag className={className}>USD</Tag>

--- a/src/components/DisplayUnitTag.tsx
+++ b/src/components/DisplayUnitTag.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import { DisplayUnit } from '@/constants/trade';
+
+import { useAppSelector } from '@/state/appTypes';
+import { setDisplayUnit } from '@/state/configs';
+import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+
+import { Tag } from './Tag';
+
+type ElementProps = {
+  assetId?: string;
+  className?: string;
+  entryPoint: string;
+};
+
+export const DisplayUnitTag = ({ entryPoint, assetId, className }: ElementProps) => {
+  const displayUnit = useAppSelector(getSelectedDisplayUnit);
+  const dispatch = useDispatch();
+
+  const onToggle = useCallback(() => {
+    if (!assetId) return;
+
+    const newDisplayUnit = displayUnit === DisplayUnit.Asset ? DisplayUnit.Fiat : DisplayUnit.Asset;
+    dispatch(
+      setDisplayUnit({
+        newDisplayUnit,
+        assetId,
+        entryPoint,
+      })
+    );
+  }, [assetId, dispatch, displayUnit, entryPoint]);
+
+  return !assetId ? (
+    <Tag className={className}>USD</Tag>
+  ) : (
+    <Tag onClick={onToggle} tw="cursor-pointer" className={className}>
+      {
+        {
+          [DisplayUnit.Asset]: assetId,
+          [DisplayUnit.Fiat]: 'USD',
+        }[displayUnit]
+      }
+    </Tag>
+  );
+};

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -11,7 +11,7 @@ import type { SupportedLocales } from './localization';
 import type { DydxNetwork } from './networks';
 import { TransferNotificationTypes } from './notifications';
 import type { TradeTypes } from './trade';
-import { TradeToggleSizeInput } from './trade';
+import { DisplayUnit } from './trade';
 import type { DydxAddress, EvmAddress } from './wallets';
 
 export type AnalyticsEventTrackMeta<T extends AnalyticsEventTypes> = {
@@ -234,9 +234,10 @@ export const AnalyticsEvents = unionize(
     TradeOrderTypeSelected: ofType<{
       type: TradeTypes;
     }>(),
-    TradeAmountToggleClick: ofType<{
-      newInput: TradeToggleSizeInput;
-      market: string;
+    DisplayUnitToggled: ofType<{
+      newDisplayUnit: DisplayUnit;
+      entryPoint?: string;
+      assetId: string;
     }>(),
     TradePlaceOrder: ofType<
       HumanReadablePlaceOrderPayload & {

--- a/src/constants/candles.ts
+++ b/src/constants/candles.ts
@@ -38,6 +38,8 @@ export interface TradingViewChartBar extends TradingViewBar {
   tradeLow: number;
   tradeHigh: number;
   trades: number;
+  assetVolume: number;
+  usdVolume: number;
 }
 
 export interface TradingViewSymbol {

--- a/src/constants/debounce.ts
+++ b/src/constants/debounce.ts
@@ -1,0 +1,27 @@
+/**
+ * Quick debounce time for very frequent actions, such as keypress or input events.
+ * Prevents excessive dispatching without adding noticeable delay.
+ * Example: Search input field debounce.
+ */
+export const QUICK_DEBOUNCE_MS = 50;
+
+/**
+ * Normal debounce time for standard UI interactions, like button clicks or toggles.
+ * Helps to prevent unintentional double clicks or spamming, while maintaining a responsive feel.
+ * Example: Checkbox toggles, button click actions.
+ */
+export const NORMAL_DEBOUNCE_MS = 200;
+
+/**
+ * Moderate debounce time for actions involving moderate processing or network requests.
+ * Reduces excessive calls or renders while still responding fairly quickly.
+ * Example: API requests, form validation.
+ */
+export const MODERATE_DEBOUNCE_MS = 500;
+
+/**
+ * Heavy debounce time for expensive operations or network-heavy actions.
+ * Used sparingly for cases where performance is a concern due to complex or resource-intensive tasks.
+ * Example: Bulk data processing, heavy API calls.
+ */
+export const HEAVY_DEBOUNCE_MS = 1000;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -30,6 +30,7 @@ export enum LocalStorageKey {
   SelectedTradeLayout = 'dydx.SelectedTradeLayout',
   HasSeenLaunchIncentives = 'dydx.HasSeenLaunchIncentives',
   DefaultToAllMarketsInPositionsOrdersFills = 'dydx.DefaultToAllMarketsInPositionsOrdersFills',
+  SelectedDisplayUnit = 'dydx.SelectedDisplayUnit',
 
   // Discoverability
   HasSeenElectionBannerTRUMPWIN = 'dydx.HasSeenElectionBannerTRUMPWIN',

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -204,3 +204,8 @@ export type LocalCloseAllPositionsData = {
   failedOrderClientIds: string[];
   errorParams?: ErrorParams;
 };
+
+export enum DisplayUnit {
+  Asset = 'asset',
+  Fiat = 'fiat',
+}

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -11,13 +11,13 @@ import {
   ORDERBOOK_ROW_PADDING_RIGHT,
   ORDERBOOK_WIDTH,
 } from '@/constants/orderbook';
+import { DisplayUnit } from '@/constants/trade';
 
 import { useAppThemeAndColorModeContext } from '@/hooks/useAppThemeAndColorMode';
 
 import { OutputType, formatNumberOutput } from '@/components/Output';
 
 import { useAppSelector } from '@/state/appTypes';
-import { DisplayUnit } from '@/state/configs';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { getCurrentMarketConfig, getCurrentMarketOrderbookMap } from '@/state/perpetualsSelectors';
 

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -17,6 +17,7 @@ import { useAppThemeAndColorModeContext } from '@/hooks/useAppThemeAndColorMode'
 import { OutputType, formatNumberOutput } from '@/components/Output';
 
 import { useAppSelector } from '@/state/appTypes';
+import { DisplayUnit } from '@/state/configs';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { getCurrentMarketConfig, getCurrentMarketOrderbookMap } from '@/state/perpetualsSelectors';
 
@@ -36,7 +37,7 @@ type ElementProps = {
   data: Array<PerpetualMarketOrderbookLevel | undefined>;
   histogramRange: number;
   side: PerpetualMarketOrderbookLevel['side'];
-  displayUnit: 'fiat' | 'asset';
+  displayUnit: DisplayUnit;
 };
 
 type StyleProps = {
@@ -258,11 +259,11 @@ export const useDrawOrderbook = ({
         });
 
       // Size text
-      const displaySize = displayUnit === 'asset' ? size : sizeCost;
+      const displaySize = displayUnit === DisplayUnit.Asset ? size : sizeCost;
       if (displaySize != null) {
         ctx.fillStyle = updatedTextColor ?? textColor;
         ctx.fillText(
-          displayUnit === 'asset'
+          displayUnit === DisplayUnit.Asset
             ? getConsistentAssetSizeString(displaySize, {
                 decimalSeparator,
                 groupSeparator,
@@ -277,11 +278,11 @@ export const useDrawOrderbook = ({
       }
 
       // Depth text
-      const displayDepth = displayUnit === 'asset' ? depth : depthCost;
+      const displayDepth = displayUnit === DisplayUnit.Asset ? depth : depthCost;
       if (displayDepth != null) {
         ctx.fillStyle = textColor;
         ctx.fillText(
-          displayUnit === 'asset'
+          displayUnit === DisplayUnit.Asset
             ? getConsistentAssetSizeString(displayDepth, {
                 decimalSeparator,
                 groupSeparator,

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -18,7 +18,7 @@ import type { TvWidget } from '@/constants/tvchart';
 import { store } from '@/state/_store';
 import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { getAppColorMode, getAppTheme, getSelectedDisplayUnit } from '@/state/configsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { getCurrentMarketConfig, getCurrentMarketId } from '@/state/perpetualsSelectors';
 import { updateChartConfig } from '@/state/tradingView';
@@ -259,6 +259,15 @@ export const useTradingView = ({
     orderbookCandlesToggleOn,
     tvWidgetRef,
   ]);
+
+  const displayUnit = useAppSelector(getSelectedDisplayUnit);
+  useEffect(() => {
+    // when display unit is toggled, update bars volume to be the correct unit
+    if (tvWidgetRef.current) {
+      const chart = tvWidgetRef.current.activeChart?.();
+      chart.resetData();
+    }
+  }, [displayUnit]);
 
   return { savedResolution };
 };

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { MODERATE_DEBOUNCE_MS } from '@/constants/debounce';
+
 /**
  * https://usehooks-ts.com/react-hook/use-debounce
  * @param value
@@ -10,7 +12,7 @@ export function useDebounce<T>(value: T, delay?: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay ?? 500);
+    const timer = setTimeout(() => setDebouncedValue(value), delay ?? MODERATE_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timer);

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -56,10 +56,6 @@ class TestFlags {
     return !!this.queryParams.pml;
   }
 
-  get showCancelAll() {
-    return !!this.queryParams.cancelall;
-  }
-
   get showLimitClose() {
     return !!this.queryParams.limitclose;
   }

--- a/src/lib/tradingView/dydxfeed/index.ts
+++ b/src/lib/tradingView/dydxfeed/index.ts
@@ -19,6 +19,7 @@ import type {
 import { Candle, RESOLUTION_MAP } from '@/constants/candles';
 import { StringGetterFunction, SupportedLocales } from '@/constants/localization';
 import { DEFAULT_MARKETID } from '@/constants/markets';
+import { DisplayUnit } from '@/constants/trade';
 
 import { useDydxClient } from '@/hooks/useDydxClient';
 
@@ -209,10 +210,17 @@ export const getDydxDatafeed = (
         );
       }
 
+      const volumeUnit = store.getState().configs.displayUnit;
+
       const bars = [
         ...cachedBars,
         ...(fetchedCandles?.map(mapCandle(orderbookCandlesToggleOn)) ?? []),
-      ].reverse();
+      ]
+        .map((bar) => ({
+          ...bar,
+          volume: volumeUnit === DisplayUnit.Fiat ? bar.usdVolume : bar.assetVolume,
+        }))
+        .reverse();
 
       if (bars.length === 0) {
         onHistoryCallback([], {
@@ -244,6 +252,7 @@ export const getDydxDatafeed = (
     listenerGuid: string,
     onResetCacheNeededCallback: Function
   ) => {
+    onResetCacheNeededCallback();
     subscribeOnStream({
       symbolInfo,
       resolution,

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -74,6 +74,7 @@ export const mapCandle =
     high,
     low,
     baseTokenVolume,
+    usdVolume,
     trades,
     orderbookMidPriceOpen,
     orderbookMidPriceClose,
@@ -84,7 +85,7 @@ export const mapCandle =
     const tradeHigh = parseFloat(high);
     const orderbookOpen = orderbookMidPriceOpen ? parseFloat(orderbookMidPriceOpen) : undefined;
     const orderbookClose = orderbookMidPriceClose ? parseFloat(orderbookMidPriceClose) : undefined;
-
+    const tokenVolume = Math.ceil(Number(baseTokenVolume)); // default
     return {
       ...getOhlcValues({
         orderbookCandlesToggleOn,
@@ -97,7 +98,9 @@ export const mapCandle =
         orderbookClose,
       }),
       time: new Date(startedAt).getTime(),
-      volume: Math.ceil(Number(baseTokenVolume)),
+      volume: tokenVolume,
+      assetVolume: tokenVolume,
+      usdVolume: Math.ceil(Number(usdVolume)),
       tradeOpen,
       tradeClose,
       orderbookOpen,

--- a/src/state/configs.ts
+++ b/src/state/configs.ts
@@ -37,6 +37,11 @@ export enum OtherPreference {
   ReverseLayout = 'ReverseLayout',
 }
 
+export enum DisplayUnit {
+  Asset = 'asset',
+  Fiat = 'fiat',
+}
+
 export interface ConfigsState {
   appThemeSetting: AppThemeSetting;
   appColorMode: AppColorMode;
@@ -46,6 +51,7 @@ export interface ConfigsState {
   network?: NetworkConfigs;
   hasSeenLaunchIncentives: boolean;
   defaultToAllMarketsInPositionsOrdersFills: boolean;
+  displayUnit: DisplayUnit;
 }
 
 const { uiRefresh } = testFlags;
@@ -70,6 +76,10 @@ const initialState: ConfigsState = {
   defaultToAllMarketsInPositionsOrdersFills: getLocalStorage({
     key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
     defaultValue: true,
+  }),
+  displayUnit: getLocalStorage({
+    key: LocalStorageKey.SelectedDisplayUnit,
+    defaultValue: DisplayUnit.Asset,
   }),
 };
 
@@ -103,6 +113,10 @@ export const configsSlice = createSlice({
       setLocalStorage({ key: LocalStorageKey.HasSeenLaunchIncentives, value: true });
       state.hasSeenLaunchIncentives = true;
     },
+    setDisplayUnit: (state: ConfigsState, { payload }: PayloadAction<DisplayUnit>) => {
+      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: payload });
+      state.displayUnit = payload;
+    },
   },
 });
 
@@ -112,4 +126,5 @@ export const {
   setAppColorMode,
   setConfigs,
   markLaunchIncentivesSeen,
+  setDisplayUnit,
 } = configsSlice.actions;

--- a/src/state/configs.ts
+++ b/src/state/configs.ts
@@ -9,8 +9,11 @@ import type {
   NetworkConfigs,
   Nullable,
 } from '@/constants/abacus';
+import { AnalyticsEvents } from '@/constants/analytics';
 import { LocalStorageKey } from '@/constants/localStorage';
+import { DisplayUnit } from '@/constants/trade';
 
+import { track } from '@/lib/analytics/analytics';
 import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
 import { testFlags } from '@/lib/testFlags';
 
@@ -35,11 +38,6 @@ export enum OtherPreference {
   DisplayAllMarketsDefault = 'DisplayAllMarketsDefault',
   GasToken = 'GasToken',
   ReverseLayout = 'ReverseLayout',
-}
-
-export enum DisplayUnit {
-  Asset = 'asset',
-  Fiat = 'fiat',
 }
 
 export interface ConfigsState {
@@ -113,9 +111,26 @@ export const configsSlice = createSlice({
       setLocalStorage({ key: LocalStorageKey.HasSeenLaunchIncentives, value: true });
       state.hasSeenLaunchIncentives = true;
     },
-    setDisplayUnit: (state: ConfigsState, { payload }: PayloadAction<DisplayUnit>) => {
-      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: payload });
-      state.displayUnit = payload;
+    setDisplayUnit: (
+      state: ConfigsState,
+      {
+        payload,
+      }: PayloadAction<{
+        newDisplayUnit: DisplayUnit;
+        entryPoint: string;
+        assetId: string;
+      }>
+    ) => {
+      const { newDisplayUnit, entryPoint, assetId } = payload;
+      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: newDisplayUnit });
+      state.displayUnit = newDisplayUnit;
+      track(
+        AnalyticsEvents.DisplayUnitToggled({
+          entryPoint,
+          assetId,
+          newDisplayUnit,
+        })
+      );
     },
   },
 });

--- a/src/state/configsSelectors.ts
+++ b/src/state/configsSelectors.ts
@@ -54,3 +54,5 @@ export const getHasSeenLaunchIncentives = (state: RootState) =>
 
 export const getDefaultToAllMarketsInPositionsOrdersFills = (state: RootState) =>
   state.configs.defaultToAllMarketsInPositionsOrdersFills;
+
+export const getSelectedDisplayUnit = (state: RootState) => state.configs.displayUnit;

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useMemo, useRef } from 'react';
 
 import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
@@ -20,6 +20,7 @@ import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Tag } from '@/components/Tag';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { getSelectedDisplayUnit } from '@/state/configsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
 import { getCurrentInput } from '@/state/inputsSelectors';
 import {
@@ -131,7 +132,7 @@ export const CanvasOrderbook = forwardRef(
       [currentInput, tickSizeDecimals]
     );
 
-    const [displayUnit, setDisplayUnit] = useState<'fiat' | 'asset'>('asset');
+    const displayUnit = useAppSelector(getSelectedDisplayUnit);
 
     const { canvasRef: asksCanvasRef } = useDrawOrderbook({
       data: asksSlice,
@@ -202,14 +203,7 @@ export const CanvasOrderbook = forwardRef(
     return (
       <div ref={ref} tw="flex flex-1 flex-col overflow-hidden">
         <$OrderbookContent $isLoading={!hasOrderbook}>
-          {!hideHeader && (
-            <OrderbookControls
-              assetName={id}
-              selectedUnit={displayUnit}
-              setSelectedUnit={setDisplayUnit}
-              grouping={currentGrouping}
-            />
-          )}
+          {!hideHeader && <OrderbookControls assetName={id} grouping={currentGrouping} />}
           {!hideHeader && (
             <OrderbookRow tw="h-1.75 text-color-text-0">
               <span>

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -16,6 +16,7 @@ import { useCalculateOrderbookData } from '@/hooks/Orderbook/useOrderbookValues'
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { Canvas } from '@/components/Canvas';
+import { DisplayUnitTag } from '@/components/DisplayUnitTag';
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Tag } from '@/components/Tag';
 
@@ -150,8 +151,6 @@ export const CanvasOrderbook = forwardRef(
       side: 'bid',
     });
 
-    const usdTag = <Tag>USD</Tag>;
-    const assetTag = id ? <Tag>{id}</Tag> : undefined;
     const asksOrderbook = (
       <$OrderbookSideContainer $side="asks" $rows={rowsPerSide}>
         <$HoverRows $bottom={layout !== 'horizontal'}>
@@ -200,22 +199,23 @@ export const CanvasOrderbook = forwardRef(
         <$OrderbookCanvas ref={bidsCanvasRef} width="100%" height="100%" />
       </$OrderbookSideContainer>
     );
+
     return (
       <div ref={ref} tw="flex flex-1 flex-col overflow-hidden">
         <$OrderbookContent $isLoading={!hasOrderbook}>
-          {!hideHeader && <OrderbookControls assetName={id} grouping={currentGrouping} />}
+          {!hideHeader && <OrderbookControls assetId={id} grouping={currentGrouping} />}
           {!hideHeader && (
             <OrderbookRow tw="h-1.75 text-color-text-0">
               <span>
-                {stringGetter({ key: STRING_KEYS.PRICE })} {usdTag}
+                {stringGetter({ key: STRING_KEYS.PRICE })} <Tag>USD</Tag>
               </span>
               <span>
                 {stringGetter({ key: STRING_KEYS.SIZE })}{' '}
-                {displayUnit === 'fiat' ? usdTag : assetTag}
+                <DisplayUnitTag assetId={id} entryPoint="orderbookAssetTag" />
               </span>
               <span>
                 {stringGetter({ key: STRING_KEYS.TOTAL })}{' '}
-                {displayUnit === 'fiat' ? usdTag : assetTag}
+                <DisplayUnitTag assetId={id} entryPoint="orderbookAssetTag" />
               </span>
             </OrderbookRow>
           )}

--- a/src/views/CanvasOrderbook/OrderbookControls.tsx
+++ b/src/views/CanvasOrderbook/OrderbookControls.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { clamp } from 'lodash';
-import { shallowEqual } from 'react-redux';
+import { shallowEqual, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { MarketOrderbookGrouping, Nullable, OrderbookGrouping } from '@/constants/abacus';
@@ -13,6 +13,8 @@ import { Output, OutputType } from '@/components/Output';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 import { useAppSelector } from '@/state/appTypes';
+import { DisplayUnit, setDisplayUnit } from '@/state/configs';
+import { getSelectedDisplayUnit } from '@/state/configsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
@@ -20,18 +22,17 @@ import abacusStateManager from '@/lib/abacus';
 type OrderbookControlsProps = {
   className?: string;
   assetName?: string;
-  selectedUnit: 'fiat' | 'asset';
-  setSelectedUnit(val: 'fiat' | 'asset'): void;
   grouping: Nullable<MarketOrderbookGrouping>;
 };
 
-export const OrderbookControls = ({
-  className,
-  assetName,
-  selectedUnit,
-  setSelectedUnit,
-  grouping,
-}: OrderbookControlsProps) => {
+export const OrderbookControls = ({ className, assetName, grouping }: OrderbookControlsProps) => {
+  const displayUnit = useAppSelector(getSelectedDisplayUnit);
+  const dispatch = useDispatch();
+  const onToggleDisplayUnit = useCallback(() => {
+    const newDisplayUnit = displayUnit === DisplayUnit.Asset ? DisplayUnit.Fiat : DisplayUnit.Asset;
+    dispatch(setDisplayUnit(newDisplayUnit));
+  }, [dispatch, displayUnit]);
+
   const modifyScale = useCallback(
     (direction: number) => {
       const start = grouping?.multiplier.ordinal ?? 0;
@@ -73,12 +74,12 @@ export const OrderbookControls = ({
         </div>
         <ToggleGroup
           items={[
-            { label: assetName ?? '', value: 'asset' as const },
-            { label: 'USD', value: 'fiat' as const },
+            { label: assetName ?? '', value: DisplayUnit.Asset },
+            { label: 'USD', value: DisplayUnit.Fiat },
           ]}
           shape={ButtonShape.Rectangle}
-          value={selectedUnit}
-          onValueChange={setSelectedUnit}
+          value={displayUnit}
+          onValueChange={onToggleDisplayUnit}
         />
       </div>
     </$OrderbookControlsContainer>

--- a/src/views/CanvasOrderbook/OrderbookControls.tsx
+++ b/src/views/CanvasOrderbook/OrderbookControls.tsx
@@ -7,13 +7,14 @@ import styled from 'styled-components';
 import { MarketOrderbookGrouping, Nullable, OrderbookGrouping } from '@/constants/abacus';
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { USD_DECIMALS } from '@/constants/numbers';
+import { DisplayUnit } from '@/constants/trade';
 
 import { Button } from '@/components/Button';
 import { Output, OutputType } from '@/components/Output';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 import { useAppSelector } from '@/state/appTypes';
-import { DisplayUnit, setDisplayUnit } from '@/state/configs';
+import { setDisplayUnit } from '@/state/configs';
 import { getSelectedDisplayUnit } from '@/state/configsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
@@ -21,17 +22,13 @@ import abacusStateManager from '@/lib/abacus';
 
 type OrderbookControlsProps = {
   className?: string;
-  assetName?: string;
+  assetId?: string;
   grouping: Nullable<MarketOrderbookGrouping>;
 };
 
-export const OrderbookControls = ({ className, assetName, grouping }: OrderbookControlsProps) => {
-  const displayUnit = useAppSelector(getSelectedDisplayUnit);
+export const OrderbookControls = ({ className, assetId, grouping }: OrderbookControlsProps) => {
   const dispatch = useDispatch();
-  const onToggleDisplayUnit = useCallback(() => {
-    const newDisplayUnit = displayUnit === DisplayUnit.Asset ? DisplayUnit.Fiat : DisplayUnit.Asset;
-    dispatch(setDisplayUnit(newDisplayUnit));
-  }, [dispatch, displayUnit]);
+  const displayUnit = useAppSelector(getSelectedDisplayUnit);
 
   const modifyScale = useCallback(
     (direction: number) => {
@@ -45,7 +42,19 @@ export const OrderbookControls = ({ className, assetName, grouping }: OrderbookC
   );
   const currentMarketConfig = useAppSelector(getCurrentMarketConfig, shallowEqual);
   const tickSizeDecimals = currentMarketConfig?.tickSizeDecimals ?? USD_DECIMALS;
-
+  const onToggleDisplayUnit = useCallback(
+    (newValue: DisplayUnit) => {
+      if (!assetId) return;
+      dispatch(
+        setDisplayUnit({
+          newDisplayUnit: newValue,
+          assetId,
+          entryPoint: 'orderbookControls',
+        })
+      );
+    },
+    [dispatch, assetId]
+  );
   return (
     <$OrderbookControlsContainer className={className}>
       <div tw="flex justify-between gap-0.5">
@@ -72,15 +81,17 @@ export const OrderbookControls = ({ className, assetName, grouping }: OrderbookC
             fractionDigits={tickSizeDecimals === 1 ? 2 : tickSizeDecimals}
           />
         </div>
-        <ToggleGroup
-          items={[
-            { label: assetName ?? '', value: DisplayUnit.Asset },
-            { label: 'USD', value: DisplayUnit.Fiat },
-          ]}
-          shape={ButtonShape.Rectangle}
-          value={displayUnit}
-          onValueChange={onToggleDisplayUnit}
-        />
+        {assetId && (
+          <ToggleGroup
+            items={[
+              { label: assetId, value: DisplayUnit.Asset },
+              { label: 'USD', value: DisplayUnit.Fiat },
+            ]}
+            shape={ButtonShape.Rectangle}
+            value={displayUnit}
+            onValueChange={onToggleDisplayUnit}
+          />
+        )}
       </div>
     </$OrderbookControlsContainer>
   );

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -249,7 +249,7 @@ const DetailsItem = ({
           value={value}
           fractionDigits={useFiatDisplayUnit ? 0 : LARGE_TOKEN_DECIMALS}
           slotRight={
-            <DisplayUnitTag tw="ml-0.25" assetId={assetId} entryPoint="openInterestAssetTag" />
+            <DisplayUnitTag tw="ml-[0.5ch]" assetId={assetId} entryPoint="openInterestAssetTag" />
           }
         />
       );

--- a/src/views/charts/PnlChart.tsx
+++ b/src/views/charts/PnlChart.tsx
@@ -11,6 +11,7 @@ import {
   HistoricalPnlPeriod,
   HistoricalPnlPeriods,
 } from '@/constants/abacus';
+import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { timeUnits } from '@/constants/time';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
@@ -176,7 +177,7 @@ export const PnlChart = ({
             setSelectedPeriod(periodOptions[defaultPeriodIx]);
           }
         }
-      }, 200),
+      }, NORMAL_DEBOUNCE_MS),
     [periodOptions, msForPeriod]
   );
 

--- a/src/views/charts/TradingRewardsChart.tsx
+++ b/src/views/charts/TradingRewardsChart.tsx
@@ -15,6 +15,7 @@ import {
   tradingRewardsPeriods,
   type TradingRewardsDatum,
 } from '@/constants/charts';
+import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS } from '@/constants/numbers';
 import { timeUnits } from '@/constants/time';
@@ -171,7 +172,7 @@ export const TradingRewardsChart = ({
             setSelectedPeriod(periodOptions[predefinedPeriodIx]);
           }
         }
-      }, 200),
+      }, NORMAL_DEBOUNCE_MS),
     [periodOptions, msForPeriod]
   );
 

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -163,7 +163,7 @@ export const DepositForm = ({ onDeposit, onError }: DepositFormProps) => {
 
   const [fromAmount, setFromAmount] = useState('');
   const [slippage, setSlippage] = useState(isCctp ? 0 : 0.01); // 1% slippage
-  const debouncedAmount = useDebounce<string>(fromAmount, 500);
+  const debouncedAmount = useDebounce<string>(fromAmount);
 
   const { usdcLabel, usdcDenom } = useTokenConfigs();
 

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -100,7 +100,7 @@ export const WithdrawForm = () => {
   // User input
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [slippage, setSlippage] = useState(isCctp ? 0 : 0.01); // 0.1% slippage
-  const debouncedAmount = useDebounce<string>(withdrawAmount, 500);
+  const debouncedAmount = useDebounce<string>(withdrawAmount);
   const { usdcLabel } = useTokenConfigs();
   const { usdcWithdrawalCapacity } = useWithdrawalInfo({ transferType: 'withdrawal' });
 

--- a/src/views/forms/StakingForms/StakeForm/StakeFormInputContents.tsx
+++ b/src/views/forms/StakingForms/StakeForm/StakeFormInputContents.tsx
@@ -8,6 +8,7 @@ import { NumberFormatValues } from 'react-number-format';
 
 import { AMOUNT_RESERVED_FOR_GAS_DYDX } from '@/constants/account';
 import { AnalyticsEvents } from '@/constants/analytics';
+import { HEAVY_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign } from '@/constants/numbers';
 
@@ -89,7 +90,7 @@ export const StakeFormInputContents = ({
             validatorAddress: validator,
           })
         );
-      }, 1000),
+      }, HEAVY_DEBOUNCE_MS),
     []
   );
 

--- a/src/views/forms/StakingForms/UnstakeForm/UnstakeFormInputContents.tsx
+++ b/src/views/forms/StakingForms/UnstakeForm/UnstakeFormInputContents.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction } from '@/constants/buttons';
+import { HEAVY_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 import { NumberSign } from '@/constants/numbers';
 
@@ -68,7 +69,7 @@ export const UnstakeFormInputContents = ({
             validatorAddress: validator,
           })
         );
-      }, 1000),
+      }, HEAVY_DEBOUNCE_MS),
     []
   );
 

--- a/src/views/forms/TradeForm/LeverageSlider.tsx
+++ b/src/views/forms/TradeForm/LeverageSlider.tsx
@@ -5,6 +5,7 @@ import { debounce } from 'lodash';
 import styled, { css } from 'styled-components';
 
 import { TradeInputField } from '@/constants/abacus';
+import { QUICK_DEBOUNCE_MS } from '@/constants/debounce';
 import { PositionSide } from '@/constants/trade';
 
 import { Slider } from '@/components/Slider';
@@ -81,7 +82,7 @@ export const LeverageSlider = ({
             value: newLeverage,
             field: TradeInputField.leverage,
           }),
-        50
+        QUICK_DEBOUNCE_MS
       ),
     []
   );

--- a/src/views/forms/TradeForm/TradeFormInputs.tsx
+++ b/src/views/forms/TradeForm/TradeFormInputs.tsx
@@ -86,7 +86,7 @@ export const TradeFormInputs = () => {
           <WithTooltip tooltip="trigger-price" side="right">
             {stringGetter({ key: STRING_KEYS.TRIGGER_PRICE })}
           </WithTooltip>
-          <Tag tw="ml-0.25">USD</Tag>
+          <Tag>USD</Tag>
         </>
       ),
       onChange: ({ value }: NumberFormatValues) => {
@@ -106,7 +106,7 @@ export const TradeFormInputs = () => {
           <WithTooltip tooltip="limit-price" side="right">
             {stringGetter({ key: STRING_KEYS.LIMIT_PRICE })}
           </WithTooltip>
-          <Tag tw="ml-0.25">USD</Tag>
+          <Tag>USD</Tag>
         </>
       ),
       onChange: ({ value }: NumberFormatValues) => {

--- a/src/views/forms/TradeForm/TradeFormInputs.tsx
+++ b/src/views/forms/TradeForm/TradeFormInputs.tsx
@@ -86,7 +86,7 @@ export const TradeFormInputs = () => {
           <WithTooltip tooltip="trigger-price" side="right">
             {stringGetter({ key: STRING_KEYS.TRIGGER_PRICE })}
           </WithTooltip>
-          <Tag>USD</Tag>
+          <Tag tw="ml-0.25">USD</Tag>
         </>
       ),
       onChange: ({ value }: NumberFormatValues) => {
@@ -106,7 +106,7 @@ export const TradeFormInputs = () => {
           <WithTooltip tooltip="limit-price" side="right">
             {stringGetter({ key: STRING_KEYS.LIMIT_PRICE })}
           </WithTooltip>
-          <Tag>USD</Tag>
+          <Tag tw="ml-0.25">USD</Tag>
         </>
       ),
       onChange: ({ value }: NumberFormatValues) => {

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -7,6 +7,7 @@ import tw from 'twin.macro';
 
 import { TradeInputField } from '@/constants/abacus';
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
+import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 import { DisplayUnit, TradeSizeInput } from '@/constants/trade';
@@ -140,7 +141,7 @@ export const TradeSizeInputs = () => {
   const dispatchSetDisplayUnit = _.debounce((newDisplayUnit) => {
     if (!id) return;
     dispatch(setDisplayUnit({ newDisplayUnit, entryPoint: 'tradeAmountInput', assetId: id }));
-  }, 300);
+  }, NORMAL_DEBOUNCE_MS);
 
   const onUsdcToggle = useCallback(
     (isPressed: boolean) => {
@@ -217,7 +218,9 @@ export const TradeSizeInputs = () => {
           >
             {stringGetter({ key: STRING_KEYS.AMOUNT })}
           </WithTooltip>
-          {id && <DisplayUnitTag tw="ml-0.25" assetId={id} entryPoint="tradeAmountInputAssetTag" />}
+          {id && (
+            <DisplayUnitTag tw="ml-[0.5ch]" assetId={id} entryPoint="tradeAmountInputAssetTag" />
+          )}
         </>
       }
       slotRight={inputToggleButton()}

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
+import _ from 'lodash';
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 import tw from 'twin.macro';
@@ -136,18 +137,17 @@ export const TradeSizeInputs = () => {
     });
   };
 
+  const dispatchSetDisplayUnit = _.debounce((newDisplayUnit) => {
+    if (!id) return;
+    dispatch(setDisplayUnit({ newDisplayUnit, entryPoint: 'tradeAmountInput', assetId: id }));
+  }, 300);
+
   const onUsdcToggle = useCallback(
     (isPressed: boolean) => {
       const newDisplayUnit = isPressed ? DisplayUnit.Fiat : DisplayUnit.Asset;
-      dispatch(
-        setDisplayUnit({
-          newDisplayUnit,
-          entryPoint: 'tradeAmountInput',
-          assetId: id ?? '',
-        })
-      );
+      dispatchSetDisplayUnit(newDisplayUnit);
     },
-    [dispatch, id]
+    [dispatchSetDisplayUnit]
   );
 
   useEffect(() => {

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
-import _ from 'lodash';
+import { debounce } from 'lodash';
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 import tw from 'twin.macro';
@@ -139,7 +139,7 @@ export const TradeSizeInputs = () => {
     });
   };
 
-  const dispatchSetDisplayUnit = _.debounce((newDisplayUnit) => {
+  const dispatchSetDisplayUnit = debounce((newDisplayUnit) => {
     if (!id) return;
     dispatch(setDisplayUnit({ newDisplayUnit, entryPoint: 'tradeAmountInput', assetId: id }));
   }, NORMAL_DEBOUNCE_MS);

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -10,6 +10,7 @@ import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { STRING_KEYS } from '@/constants/localization';
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
+import { TooltipStringKeys } from '@/constants/tooltips';
 import { DisplayUnit, TradeSizeInput } from '@/constants/trade';
 
 import { useLocaleSeparators } from '@/hooks/useLocaleSeparators';
@@ -212,7 +213,7 @@ export const TradeSizeInputs = () => {
       label={
         <>
           <WithTooltip
-            tooltip={inputConfig.tooltipId}
+            tooltip={inputConfig.tooltipId as TooltipStringKeys}
             stringParams={{ SYMBOL: id ?? '' }}
             side="right"
           >

--- a/src/views/forms/TriggersForm/OrderSizeSlider.tsx
+++ b/src/views/forms/TriggersForm/OrderSizeSlider.tsx
@@ -3,6 +3,8 @@ import { useMemo } from 'react';
 import { debounce } from 'lodash';
 import styled from 'styled-components';
 
+import { QUICK_DEBOUNCE_MS } from '@/constants/debounce';
+
 import { Slider } from '@/components/Slider';
 
 import { MustBigNumber } from '@/lib/numbers';
@@ -33,7 +35,7 @@ export const OrderSizeSlider = ({
 
   // Debounced slightly to avoid excessive updates to Abacus while still providing a smooth slide
   const debouncedSetAbacusSize = useMemo(
-    () => debounce((newSize: string) => setAbacusSize(newSize), 50),
+    () => debounce((newSize: string) => setAbacusSize(newSize), QUICK_DEBOUNCE_MS),
     []
   );
 


### PR DESCRIPTION
- add global state / local storage for display unit; i.e. synced display unit for all cases
- existing cases: orderbook controls + amount input toggle
- new cases: open interest, trading view volume, asset tags on orderbook and amount input
- debounced the dispatch on amount input toggle and asset tag to prevent spamming (didn't do that on orderbook controls because you have to move your mouse)
- added debounced constants


https://github.com/user-attachments/assets/05c1b30a-e4d1-404b-ae9b-2e2220a14745

