### PR TITLE
feat(details): Add Launchable market details

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -777,13 +777,17 @@ const isAssetSymbol = (symbol: Nullable<string>): symbol is AssetSymbol =>
   symbol != null && Object.hasOwn(assetIcons, symbol);
 
 export const AssetIcon = ({
+  logoUrl,
   symbol,
   className,
 }: {
+  logoUrl?: string;
   symbol?: Nullable<string>;
   className?: string;
 }) =>
-  isAssetSymbol(symbol) ? (
+  logoUrl ? (
+    <img src={logoUrl} className={className} alt="" tw="h-[1em] w-auto rounded-[50%]" />
+  ) : isAssetSymbol(symbol) ? (
     <img
       src={assetIcons[symbol]}
       className={className}
@@ -793,6 +797,7 @@ export const AssetIcon = ({
   ) : (
     <Placeholder className={className} symbol={symbol ?? ''} />
   );
+
 const $Placeholder = styled.div`
   background-color: var(--color-layer-5);
   width: 1em;

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -786,7 +786,12 @@ export const AssetIcon = ({
   className?: string;
 }) =>
   logoUrl ? (
-    <img src={logoUrl} className={className} alt="" tw="h-[1em] w-auto rounded-[50%]" />
+    <img
+      src={logoUrl}
+      className={className}
+      alt={symbol ?? 'logo'}
+      tw="h-[1em] w-auto rounded-[50%]"
+    />
   ) : isAssetSymbol(symbol) ? (
     <img
       src={assetIcons[symbol]}

--- a/src/constants/assetMetadata.ts
+++ b/src/constants/assetMetadata.ts
@@ -20,6 +20,7 @@ export type MetadataServicePricesResponse = Record<
     percent_change_24h: number | null;
     volume_24h: number | null;
     market_cap: number | null;
+    self_reported_market_cap: number | null;
   }
 >;
 
@@ -50,7 +51,7 @@ export type MetadataServiceAsset = {
   percentChange24h: number | null;
   volume24h: number | null;
   marketCap: number | null;
-
+  reportedMarketCap: number | null;
   tickSizeDecimals: number;
 };
 

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -61,6 +61,7 @@ export const useMetadataService = () => {
             percentChange24h: prices[key].percent_change_24h,
             marketCap: prices[key].market_cap,
             volume24h: prices[key].volume_24h,
+            reportedMarketCap: prices[key].self_reported_market_cap,
             tickSizeDecimals,
           };
         }

--- a/src/pages/trade/InnerPanel.tsx
+++ b/src/pages/trade/InnerPanel.tsx
@@ -94,7 +94,7 @@ export const InnerPanel = ({ launchableMarketId }: { launchableMarketId?: string
       value={value}
       onValueChange={setValue}
       items={innerPanelItems}
-      slotToolbar={<MarketLinks />}
+      slotToolbar={<MarketLinks launchableMarketId={launchableMarketId} />}
       withTransitions={false}
     />
   );

--- a/src/pages/trade/MobileBottomPanel.tsx
+++ b/src/pages/trade/MobileBottomPanel.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from 'react';
+
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { MobileTabs } from '@/components/Tabs';
-import { MarketDetails } from '@/views/MarketDetails';
+import { CurrentMarketDetails } from '@/views/MarketDetails/CurrentMarketDetails';
+import { LaunchableMarketDetails } from '@/views/MarketDetails/LaunchableMarketDetails';
 import { MarketStatsDetails } from '@/views/MarketStatsDetails';
 import { UnlaunchedMarketStatsDetails } from '@/views/UnlaunchedMarketStatsDetails';
 
@@ -16,29 +19,40 @@ enum InfoSection {
 export const MobileBottomPanel = ({ launchableMarketId }: { launchableMarketId?: string }) => {
   const stringGetter = useStringGetter();
 
-  return (
-    <MobileTabs
-      defaultValue={InfoSection.Statistics}
-      items={[
+  const items = useMemo(() => {
+    if (launchableMarketId) {
+      return [
         {
           value: InfoSection.Statistics,
           label: stringGetter({ key: STRING_KEYS.STATISTICS }),
-          content: launchableMarketId ? (
+          content: (
             <UnlaunchedMarketStatsDetails
               launchableMarketId={launchableMarketId}
               showMidMarketPrice={false}
             />
-          ) : (
-            <MarketStatsDetails showMidMarketPrice={false} />
           ),
         },
         {
           value: InfoSection.About,
           label: stringGetter({ key: STRING_KEYS.ABOUT }),
-          content: <MarketDetails />,
+          content: <LaunchableMarketDetails launchableMarketId={launchableMarketId} />,
         },
-      ]}
-      withBorders={false}
-    />
-  );
+      ];
+    }
+
+    return [
+      {
+        value: InfoSection.Statistics,
+        label: stringGetter({ key: STRING_KEYS.STATISTICS }),
+        content: <MarketStatsDetails showMidMarketPrice={false} />,
+      },
+      {
+        value: InfoSection.About,
+        label: stringGetter({ key: STRING_KEYS.ABOUT }),
+        content: <CurrentMarketDetails />,
+      },
+    ];
+  }, [launchableMarketId]);
+
+  return <MobileTabs defaultValue={InfoSection.Statistics} items={items} withBorders={false} />;
 };

--- a/src/views/MarketDetails/CurrentMarketDetails.tsx
+++ b/src/views/MarketDetails/CurrentMarketDetails.tsx
@@ -1,22 +1,13 @@
 import BigNumber from 'bignumber.js';
 import { shallowEqual } from 'react-redux';
-import styled from 'styled-components';
 
 import { PerpetualMarketType } from '@/constants/abacus';
-import { ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 
-import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
-import breakpoints from '@/styles/breakpoints';
-import { layoutMixins } from '@/styles/layoutMixins';
-
-import { AssetIcon } from '@/components/AssetIcon';
-import { Button } from '@/components/Button';
-import { Details, DetailsItem } from '@/components/Details';
+import { DetailsItem } from '@/components/Details';
 import { DiffOutput } from '@/components/DiffOutput';
-import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 
 import { useAppSelector } from '@/state/appTypes';
@@ -25,11 +16,10 @@ import { getCurrentMarketData } from '@/state/perpetualsSelectors';
 
 import { BIG_NUMBERS } from '@/lib/numbers';
 
-import { MarketLinks } from './MarketLinks';
+import { MarketDetails } from './MarketDetails';
 
-export const MarketDetails: React.FC = () => {
+export const CurrentMarketDetails = () => {
   const stringGetter = useStringGetter();
-  const { isTablet } = useBreakpoints();
   const { configs, displayId, market } = useAppSelector(getCurrentMarketData, shallowEqual) ?? {};
   const { id, name, resources } = useAppSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
 
@@ -161,106 +151,13 @@ export const MarketDetails: React.FC = () => {
   ] satisfies DetailsItem[];
 
   return (
-    <$MarketDetails>
-      <header tw="column gap-1.25">
-        <div tw="row flex-wrap gap-0.5">
-          <$MarketTitle>
-            <AssetIcon symbol={id} />
-            {name}
-          </$MarketTitle>
-          {isTablet && <MarketLinks tw="[place-self:start_end]" />}
-        </div>
-
-        <$MarketDescription>
-          {primaryDescriptionKey && <p>{stringGetter({ key: `APP.${primaryDescriptionKey}` })}</p>}
-          {secondaryDescriptionKey && (
-            <p>{stringGetter({ key: `APP.${secondaryDescriptionKey}` })}</p>
-          )}
-        </$MarketDescription>
-
-        {!isTablet && (
-          <div tw="row flex-wrap gap-0.5 overflow-x-auto">
-            {whitepaperLink && (
-              <Button
-                type={ButtonType.Link}
-                shape={ButtonShape.Pill}
-                size={ButtonSize.Small}
-                href={whitepaperLink}
-                slotRight={<Icon iconName={IconName.LinkOut} />}
-              >
-                {stringGetter({ key: STRING_KEYS.WHITEPAPER })}
-              </Button>
-            )}
-            {websiteLink && (
-              <Button
-                type={ButtonType.Link}
-                shape={ButtonShape.Pill}
-                size={ButtonSize.Small}
-                href={websiteLink}
-                slotRight={<Icon iconName={IconName.LinkOut} />}
-              >
-                {stringGetter({ key: STRING_KEYS.WEBSITE })}
-              </Button>
-            )}
-            {coinMarketCapsLink && (
-              <Button
-                type={ButtonType.Link}
-                shape={ButtonShape.Pill}
-                size={ButtonSize.Small}
-                href={coinMarketCapsLink}
-                slotRight={<Icon iconName={IconName.LinkOut} />}
-              >
-                CoinmarketCap
-              </Button>
-            )}
-          </div>
-        )}
-      </header>
-
-      <Details items={items} withSeparators tw="font-mini-book" />
-    </$MarketDetails>
+    <MarketDetails
+      assetName={name}
+      assetIcon={{ symbol: id }}
+      marketDetailItems={items}
+      primaryDescription={stringGetter({ key: `APP.${primaryDescriptionKey}` })}
+      secondaryDescription={stringGetter({ key: `APP.${secondaryDescriptionKey}` })}
+      urls={{ technicalDoc: whitepaperLink, website: websiteLink, cmc: coinMarketCapsLink }}
+    />
   );
 };
-
-const $MarketDetails = styled.div`
-  margin: auto;
-  width: 100%;
-
-  ${layoutMixins.gridConstrainedColumns}
-  --grid-max-columns: 2;
-  --column-gap: 2.25em;
-  --column-min-width: 18rem;
-  --column-max-width: 22rem;
-  --single-column-max-width: 25rem;
-
-  justify-content: center;
-  align-items: center;
-  padding: clamp(0.5rem, 7.5%, 2.5rem);
-  row-gap: 1rem;
-
-  @media ${breakpoints.tablet} {
-    padding: 0 clamp(0.5rem, 7.5%, 2.5rem);
-  }
-`;
-const $MarketTitle = styled.h3`
-  ${layoutMixins.row}
-  font: var(--font-large-medium);
-  gap: 0.5rem;
-
-  img {
-    width: 2.25rem;
-    height: 2.25rem;
-  }
-`;
-const $MarketDescription = styled.div`
-  ${layoutMixins.column}
-  gap: 0.5em;
-
-  p {
-    font: var(--font-small-book);
-
-    &:last-of-type {
-      color: var(--color-text-0);
-    }
-  }
-`;

--- a/src/views/MarketDetails/LaunchableMarketDetails.tsx
+++ b/src/views/MarketDetails/LaunchableMarketDetails.tsx
@@ -1,0 +1,105 @@
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { DetailsItem } from '@/components/Details';
+import { Output, OutputType } from '@/components/Output';
+
+import { getDisplayableTickerFromMarket } from '@/lib/assetUtils';
+import { BIG_NUMBERS } from '@/lib/numbers';
+
+import { MarketDetails } from './MarketDetails';
+
+const ISOLATED_LIQUIDITY_TIER_INFO = {
+  initialMarginFraction: 0.05,
+  maintenanceMarginFraction: 0.03,
+  impactNotional: 2_500,
+};
+
+export const LaunchableMarketDetails = ({ launchableMarketId }: { launchableMarketId: string }) => {
+  const stringGetter = useStringGetter();
+  const launchableAsset = useMetadataServiceAssetFromId(launchableMarketId);
+
+  if (!launchableAsset) return null;
+
+  const { name, id, logo, urls, marketCap, volume24h } = launchableAsset;
+  const { website, technicalDoc, cmc } = urls;
+
+  const items = [
+    {
+      key: 'market-name',
+      label: stringGetter({ key: STRING_KEYS.MARKET_NAME }),
+      value: name,
+    },
+    {
+      key: 'market-cap',
+      label: stringGetter({ key: STRING_KEYS.MARKET_CAP }),
+      value: <Output useGrouping value={marketCap} type={OutputType.Fiat} />,
+    },
+    {
+      key: 'volume-24h',
+      label: stringGetter({ key: STRING_KEYS.SPOT_VOLUME_24H }),
+      value: <Output useGrouping value={volume24h} type={OutputType.Fiat} />,
+    },
+    {
+      key: 'ticker',
+      label: stringGetter({ key: STRING_KEYS.TICKER }),
+      value: getDisplayableTickerFromMarket(`${id}-USD`),
+    },
+    {
+      key: 'market-type',
+      label: stringGetter({ key: STRING_KEYS.TYPE }),
+      value: stringGetter({ key: STRING_KEYS.ISOLATED }),
+    },
+    {
+      key: 'max-leverage',
+      label: stringGetter({ key: STRING_KEYS.MAXIMUM_LEVERAGE }),
+      tooltip: 'maximum-leverage',
+      value: (
+        <Output
+          useGrouping
+          value={
+            ISOLATED_LIQUIDITY_TIER_INFO.initialMarginFraction
+              ? BIG_NUMBERS.ONE.div(ISOLATED_LIQUIDITY_TIER_INFO.initialMarginFraction)
+              : null
+          }
+          type={OutputType.Multiple}
+        />
+      ),
+    },
+    {
+      key: 'maintenance-margin-fraction',
+      label: stringGetter({ key: STRING_KEYS.MAINTENANCE_MARGIN_FRACTION }),
+      tooltip: 'maintenance-margin-fraction',
+      value: (
+        <Output
+          useGrouping
+          value={ISOLATED_LIQUIDITY_TIER_INFO.maintenanceMarginFraction}
+          type={OutputType.SmallPercent}
+        />
+      ),
+    },
+    {
+      key: 'initial-margin-fraction',
+      label: stringGetter({ key: STRING_KEYS.INITIAL_MARGIN_FRACTION }),
+      tooltip: 'initial-margin-fraction',
+      value: (
+        <Output
+          useGrouping
+          value={ISOLATED_LIQUIDITY_TIER_INFO.initialMarginFraction}
+          type={OutputType.SmallPercent}
+        />
+      ),
+    },
+  ] satisfies DetailsItem[];
+
+  return (
+    <MarketDetails
+      assetName={name}
+      assetIcon={{ logoUrl: logo }}
+      marketDetailItems={items}
+      urls={{ technicalDoc, website, cmc }}
+    />
+  );
+};

--- a/src/views/MarketDetails/MarketDetails.tsx
+++ b/src/views/MarketDetails/MarketDetails.tsx
@@ -1,0 +1,149 @@
+import styled from 'styled-components';
+
+import type { Nullable } from '@/constants/abacus';
+import { ButtonShape, ButtonSize, ButtonType } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useBreakpoints } from '@/hooks/useBreakpoints';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import breakpoints from '@/styles/breakpoints';
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { AssetIcon } from '@/components/AssetIcon';
+import { Button } from '@/components/Button';
+import { Details, DetailsItem } from '@/components/Details';
+import { Icon, IconName } from '@/components/Icon';
+
+import { MarketLinks } from '../MarketLinks';
+
+type MarketDetailsProps = {
+  assetName: Nullable<string>;
+  assetIcon: {
+    symbol?: Nullable<string>;
+    logoUrl?: string;
+  };
+  marketDetailItems: DetailsItem[];
+  primaryDescription?: string;
+  secondaryDescription?: string;
+  urls?: {
+    technicalDoc?: Nullable<string>;
+    website?: Nullable<string>;
+    cmc?: Nullable<string>;
+  };
+};
+
+export const MarketDetails = ({
+  assetName,
+  assetIcon,
+  marketDetailItems,
+  primaryDescription,
+  secondaryDescription,
+  urls,
+}: MarketDetailsProps) => {
+  const stringGetter = useStringGetter();
+  const { isTablet } = useBreakpoints();
+  const { technicalDoc, website, cmc } = urls ?? {};
+
+  return (
+    <$MarketDetails>
+      <header tw="column gap-1.25">
+        <div tw="row flex-wrap gap-0.5">
+          <$MarketTitle>
+            <AssetIcon symbol={assetIcon.symbol} logoUrl={assetIcon.logoUrl} />
+            {assetName}
+          </$MarketTitle>
+          {isTablet && <MarketLinks tw="[place-self:start_end]" />}
+        </div>
+
+        <$MarketDescription>
+          {primaryDescription && <p>{primaryDescription}</p>}
+          {secondaryDescription && <p>{secondaryDescription}</p>}
+        </$MarketDescription>
+
+        {!isTablet && (
+          <div tw="row flex-wrap gap-0.5 overflow-x-auto">
+            {technicalDoc && (
+              <Button
+                type={ButtonType.Link}
+                shape={ButtonShape.Pill}
+                size={ButtonSize.Small}
+                href={technicalDoc}
+                slotRight={<Icon iconName={IconName.LinkOut} />}
+              >
+                {stringGetter({ key: STRING_KEYS.WHITEPAPER })}
+              </Button>
+            )}
+            {website && (
+              <Button
+                type={ButtonType.Link}
+                shape={ButtonShape.Pill}
+                size={ButtonSize.Small}
+                href={website}
+                slotRight={<Icon iconName={IconName.LinkOut} />}
+              >
+                {stringGetter({ key: STRING_KEYS.WEBSITE })}
+              </Button>
+            )}
+            {cmc && (
+              <Button
+                type={ButtonType.Link}
+                shape={ButtonShape.Pill}
+                size={ButtonSize.Small}
+                href={cmc}
+                slotRight={<Icon iconName={IconName.LinkOut} />}
+              >
+                CoinmarketCap
+              </Button>
+            )}
+          </div>
+        )}
+      </header>
+
+      <Details items={marketDetailItems} withSeparators tw="font-mini-book" />
+    </$MarketDetails>
+  );
+};
+
+const $MarketDetails = styled.div`
+  margin: auto;
+  width: 100%;
+
+  ${layoutMixins.gridConstrainedColumns}
+  --grid-max-columns: 2;
+  --column-gap: 2.25em;
+  --column-min-width: 18rem;
+  --column-max-width: 22rem;
+  --single-column-max-width: 25rem;
+
+  justify-content: center;
+  align-items: center;
+  padding: clamp(0.5rem, 7.5%, 2.5rem);
+  row-gap: 1rem;
+
+  @media ${breakpoints.tablet} {
+    padding: 0 clamp(0.5rem, 7.5%, 2.5rem);
+  }
+`;
+const $MarketTitle = styled.h3`
+  ${layoutMixins.row}
+  font: var(--font-large-medium);
+  gap: 0.5rem;
+
+  img {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+`;
+const $MarketDescription = styled.div`
+  ${layoutMixins.column}
+  gap: 0.5em;
+
+  p {
+    font: var(--font-small-book);
+
+    &:last-of-type {
+      color: var(--color-text-0);
+    }
+  }
+`;

--- a/src/views/MarketLinks.tsx
+++ b/src/views/MarketLinks.tsx
@@ -2,30 +2,36 @@ import { shallowEqual } from 'react-redux';
 
 import { ButtonType } from '@/constants/buttons';
 
+import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 
-export const MarketLinks = () => {
+import { orEmptyObj } from '@/lib/typeUtils';
+
+export const MarketLinks = ({ launchableMarketId }: { launchableMarketId?: string }) => {
   const { resources } = useAppSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
-  const { coinMarketCapsLink, websiteLink, whitepaperLink } = resources ?? {};
+  const { coinMarketCapsLink, websiteLink, whitepaperLink } = orEmptyObj(resources);
+  const launchableAsset = useMetadataServiceAssetFromId(launchableMarketId);
+  const { urls } = orEmptyObj(launchableAsset);
 
   const linkItems = [
     {
       key: 'coinmarketcap',
-      href: coinMarketCapsLink,
+      href: urls?.cmc ?? coinMarketCapsLink,
       icon: IconName.CoinMarketCap,
     },
     {
       key: 'whitepaper',
-      href: whitepaperLink,
+      href: urls?.technicalDoc ?? whitepaperLink,
       icon: IconName.Whitepaper,
     },
     {
       key: 'project-website',
-      href: websiteLink,
+      href: urls?.website ?? websiteLink,
       icon: IconName.Website,
     },
   ].filter(({ href }) => href);


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1681" alt="Screen Shot 2024-10-01 at 4 34 42 PM" src="https://github.com/user-attachments/assets/540d3c93-9086-4d2d-8dc1-c3ab0399b312">

<!-- Overall purpose of the PR -->
Add `details` pane, on Trade page when viewing a Launchable Market.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<InnerPanel>`
  - Update `InnerPanel` to have a memoized list of items to pass to `<Tabs>`

- `<MarketDetails>`
  - create basic market details that will be used in `<CurrentMarketDetails>` and `<LaunchableMarketDetails>` 

- New `<CurrentMarketDetails>` and `<LaunchableMarketDetails>`
  - Different data sources that end up being passed to `<MarketDetails>` 

## Components

- `<AssetIcon>`
  - Add `logoUrl` as a possible prop to accept `s3` link for icon

## Constants/Types

- `constants/assetMetadata`
  - handle API update that returns `self_reported_market_cap`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
