### PR TITLE
fix: dydx address tooltip text should match the chain name OTE-845

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.12.12",
     "@dydxprotocol/v4-client-js": "1.6.1",
-    "@dydxprotocol/v4-localization": "^1.1.209",
+    "@dydxprotocol/v4-localization": "^1.1.210",
     "@dydxprotocol/v4-proto": "^6.0.1",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: 1.6.1
     version: 1.6.1
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.209
-    version: 1.1.209
+    specifier: ^1.1.210
+    version: 1.1.210
   '@dydxprotocol/v4-proto':
     specifier: ^6.0.1
     version: 6.0.1
@@ -3061,8 +3061,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.209:
-    resolution: {integrity: sha512-H0UxaQFd4SaYyywoeQRD/WE6uVCtRY/GwMoQZnhHA3qCpanXI+tlDDLai18chLTMGtnIO/Ss7GMBrcJS20tf1A==}
+  /@dydxprotocol/v4-localization@1.1.210:
+    resolution: {integrity: sha512-+dkvwrdM3e3o80ltEqLPjL98Y4nIXbEqV0ZvXPtrNX/Tj6KGrtOU94nlVybjd+jYbttGVGNaNHWhVIbeUog9Rw==}
     dev: false
 
   /@dydxprotocol/v4-proto@6.0.1:

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -131,23 +131,11 @@ export const AccountMenu = () => {
               <AssetIcon symbol="DYDX" tw="z-[2] text-[1.75rem]" />
               <$Column>
                 {connectedWallet && connectedWallet?.name !== WalletType.Keplr ? (
-                  <WithTooltip
-                    slotTooltip={
-                      <dl>
-                        <dt>
-                          {stringGetter({
-                            key: TOOLTIP_STRING_KEYS.DYDX_ADDRESS_BODY,
-                            params: {
-                              DYDX_ADDRESS: <strong>{truncateAddress(dydxAddress)}</strong>,
-                              EVM_ADDRESS: truncateAddress(evmAddress, '0x'),
-                            },
-                          })}
-                        </dt>
-                      </dl>
-                    }
-                  >
-                    <$label>{stringGetter({ key: STRING_KEYS.DYDX_CHAIN_ADDRESS })}</$label>
-                  </WithTooltip>
+                  <DydxDerivedAddress
+                    evmAddress={evmAddress}
+                    solAddress={solAddress}
+                    dydxAddress={dydxAddress}
+                  />
                 ) : (
                   <$label>{stringGetter({ key: STRING_KEYS.DYDX_CHAIN_ADDRESS })}</$label>
                 )}
@@ -383,6 +371,46 @@ export const AccountMenu = () => {
       {walletIcon}
       {!isTablet && <$Address>{truncateAddress(dydxAddress)}</$Address>}
     </$DropdownMenu>
+  );
+};
+
+const DydxDerivedAddress = ({
+  evmAddress,
+  solAddress,
+  dydxAddress,
+}: {
+  evmAddress?: string;
+  solAddress?: string;
+  dydxAddress?: string;
+}) => {
+  const stringGetter = useStringGetter();
+
+  const tooltipText = solAddress
+    ? stringGetter({
+        key: TOOLTIP_STRING_KEYS.DYDX_ADDRESS_FROM_SOLANA_BODY,
+        params: {
+          DYDX_ADDRESS: <strong>{truncateAddress(dydxAddress)}</strong>,
+          SOLANA_ADDRESS: truncateAddress(solAddress, ''),
+        },
+      })
+    : stringGetter({
+        key: TOOLTIP_STRING_KEYS.DYDX_ADDRESS_FROM_ETHEREUM_BODY,
+        params: {
+          DYDX_ADDRESS: <strong>{truncateAddress(dydxAddress)}</strong>,
+          EVM_ADDRESS: truncateAddress(evmAddress, '0x'),
+        },
+      });
+
+  return (
+    <WithTooltip
+      slotTooltip={
+        <dl>
+          <dt>{tooltipText}</dt>
+        </dl>
+      }
+    >
+      <$label>{stringGetter({ key: STRING_KEYS.DYDX_CHAIN_ADDRESS })}</$label>
+    </WithTooltip>
   );
 };
 


### PR DESCRIPTION
| Ethereum | Solana |
|-----------|-------|
|<img width="361" alt="Screenshot 2024-10-01 at 11 58 46 PM" src="https://github.com/user-attachments/assets/702fc7d5-f137-4b91-8634-14bbcfd38224">|<img width="376" alt="Screenshot 2024-10-01 at 11 59 08 PM" src="https://github.com/user-attachments/assets/09d5a259-ec06-4237-903a-a1aca84397cf">|

