### PR TITLE
fix: safari compatibility

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -774,7 +774,7 @@ const Placeholder = ({ className, symbol }: { className?: string; symbol: string
 );
 
 const isAssetSymbol = (symbol: Nullable<string>): symbol is AssetSymbol =>
-  symbol != null && Object.hasOwn(assetIcons, symbol);
+  symbol != null && assetIcons[symbol as AssetSymbol] != null;
 
 export const AssetIcon = ({
   symbol,

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -74,7 +74,9 @@ export const useAnalytics = () => {
   // AnalyticsUserProperty.Version
   useEffect(() => {
     if (latestTag !== undefined) {
-      identify(AnalyticsUserProperties.Version(latestTag.split(`release/v`).at(-1)));
+      const latestVersionArr = latestTag?.split('release/v');
+      const latestVersion = latestVersionArr[latestVersionArr.length - 1];
+      identify(AnalyticsUserProperties.Version(latestVersion));
     }
   }, [latestTag]);
 

--- a/src/lib/skip.ts
+++ b/src/lib/skip.ts
@@ -182,8 +182,8 @@ const getTxDataFromTransferSequence = (
   transferSequence: TransferEventJSON[],
   direction: 'from' | 'to'
 ) => {
-  const transferSequenceIdx = direction === 'to' ? -1 : 0;
-  const transferSequenceObj = transferSequence.at(transferSequenceIdx);
+  const transferSequenceObj =
+    direction === 'to' ? transferSequence.reverse()[0] : transferSequence[0];
   if (!transferSequenceObj) return undefined;
   if ('ibc_transfer' in transferSequenceObj) {
     return getTxDataFromIbcTransfer(transferSequenceObj.ibc_transfer, direction);

--- a/src/views/dialogs/HelpDialog.tsx
+++ b/src/views/dialogs/HelpDialog.tsx
@@ -114,9 +114,12 @@ export const HelpDialog = ({ setIsOpen }: DialogProps<HelpDialogProps>) => {
     </span>
   );
 
-  const maybeLatestVersion = latestVersion && (
+  const latestVersionArr = latestVersion?.split(`release/v`);
+  const version = latestVersionArr?.[latestVersionArr.length - 1];
+
+  const maybeLatestVersion = version && (
     <span>
-      Version - <span title={latestVersion}>{`${latestVersion.split(`release/v`).at(-1)}`}</span>
+      Version - <span title={latestVersion}>{version}</span>
     </span>
   );
 


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Fix browser compatibility with Safari

---
Replace usage of `Object.hasOwn` and `.at()`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
