### PR TITLE
fix: use imf for positions margin calculation

### DIFF
--- a/src/lib/__test__/tradeData.spec.ts
+++ b/src/lib/__test__/tradeData.spec.ts
@@ -80,29 +80,29 @@ describe('hasPositionSideChanged', () => {
 
 describe('calculateCrossPositionMargin', () => {
   it('should calculate the position margin', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: 100, adjustedMmf: 0.1 })).toEqual('10.00');
+    expect(calculateCrossPositionMargin({ notionalTotal: 100, adjustedImf: 0.1 })).toEqual('10.00');
   });
 
   it('should calculate the position margin with a notionalTotal of 0', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: 0, adjustedMmf: 0.1 })).toEqual('0.00');
+    expect(calculateCrossPositionMargin({ notionalTotal: 0, adjustedImf: 0.1 })).toEqual('0.00');
   });
 
   it('should calculate the position margin with a adjustedMmf of 0', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: 100, adjustedMmf: 0 })).toEqual('0.00');
+    expect(calculateCrossPositionMargin({ notionalTotal: 100, adjustedImf: 0 })).toEqual('0.00');
   });
 
   it('should calculate the position margin with a notionalTotal of 0 and a adjustedMmf of 0', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: 0, adjustedMmf: 0 })).toEqual('0.00');
+    expect(calculateCrossPositionMargin({ notionalTotal: 0, adjustedImf: 0 })).toEqual('0.00');
   });
 
   it('should calculate the position margin with a negative notionalTotal', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: -100, adjustedMmf: 0.1 })).toEqual(
+    expect(calculateCrossPositionMargin({ notionalTotal: -100, adjustedImf: 0.1 })).toEqual(
       '-10.00'
     );
   });
 
   it('should handle undefined notionalTotal', () => {
-    expect(calculateCrossPositionMargin({ notionalTotal: undefined, adjustedMmf: 0.1 })).toEqual(
+    expect(calculateCrossPositionMargin({ notionalTotal: undefined, adjustedImf: 0.1 })).toEqual(
       '0.00'
     );
   });

--- a/src/lib/tradeData.ts
+++ b/src/lib/tradeData.ts
@@ -4,11 +4,11 @@ import {
   AbacusMarginMode,
   AbacusOrderSide,
   AbacusOrderTypes,
-  ErrorType,
   ErrorFormat,
-  type ErrorFormatType,
+  ErrorType,
   ValidationError,
   type AbacusOrderSides,
+  type ErrorFormatType,
   type Nullable,
   type SubaccountPosition,
   type TradeState,
@@ -141,13 +141,13 @@ export const getTradeInputAlert = ({
 
 export const calculateCrossPositionMargin = ({
   notionalTotal,
-  adjustedMmf,
+  adjustedImf,
 }: {
   notionalTotal?: Nullable<number>;
-  adjustedMmf?: Nullable<number>;
+  adjustedImf?: Nullable<number>;
 }) => {
   const notionalTotalBN = MustBigNumber(notionalTotal);
-  const adjustedMmfBN = MustBigNumber(adjustedMmf);
+  const adjustedMmfBN = MustBigNumber(adjustedImf);
   return notionalTotalBN.times(adjustedMmfBN).toFixed(USD_DECIMALS);
 };
 
@@ -165,14 +165,14 @@ export const getMarginModeFromSubaccountNumber = (subaccountNumber: Nullable<num
 };
 
 export const getPositionMargin = ({ position }: { position: SubaccountPosition }) => {
-  const { childSubaccountNumber, equity, notionalTotal, adjustedMmf } = position;
+  const { childSubaccountNumber, equity, notionalTotal, adjustedImf } = position;
   const marginMode = getMarginModeFromSubaccountNumber(childSubaccountNumber);
 
   const margin =
     marginMode === AbacusMarginMode.Cross
       ? calculateCrossPositionMargin({
           notionalTotal: notionalTotal?.current,
-          adjustedMmf: adjustedMmf.current,
+          adjustedImf: adjustedImf.current,
         })
       : equity?.current;
 

--- a/src/lib/tradeData.ts
+++ b/src/lib/tradeData.ts
@@ -147,8 +147,8 @@ export const calculateCrossPositionMargin = ({
   adjustedImf?: Nullable<number>;
 }) => {
   const notionalTotalBN = MustBigNumber(notionalTotal);
-  const adjustedMmfBN = MustBigNumber(adjustedImf);
-  return notionalTotalBN.times(adjustedMmfBN).toFixed(USD_DECIMALS);
+  const adjustedImfBN = MustBigNumber(adjustedImf);
+  return notionalTotalBN.times(adjustedImfBN).toFixed(USD_DECIMALS);
 };
 
 /**

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -75,7 +75,7 @@ export const PlaceOrderButtonAndReceipt = ({
   const subaccountNumber = useAppSelector(getSubaccountId);
   const currentInput = useAppSelector(getCurrentInput);
   const { tickSizeDecimals } = orEmptyObj(useAppSelector(getCurrentMarketConfig, shallowEqual));
-  const { liquidationPrice, equity, leverage, notionalTotal, adjustedMmf } = orEmptyObj(
+  const { liquidationPrice, equity, leverage, notionalTotal, adjustedImf } = orEmptyObj(
     useAppSelector(getCurrentMarketPositionData, shallowEqual)
   );
 
@@ -110,14 +110,14 @@ export const PlaceOrderButtonAndReceipt = ({
       const currentCrossMargin = nullIfZero(
         calculateCrossPositionMargin({
           notionalTotal: notionalTotal?.current,
-          adjustedMmf: adjustedMmf?.current,
+          adjustedImf: adjustedImf?.current,
         })
       );
 
       const postOrderCrossMargin = nullIfZero(
         calculateCrossPositionMargin({
           notionalTotal: notionalTotal?.postOrder,
-          adjustedMmf: adjustedMmf?.postOrder,
+          adjustedImf: adjustedImf?.postOrder,
         })
       );
 


### PR DESCRIPTION
Hyperliquid does this, and it seems to make more sense to keep the idea of MMF hidden from users most of the time. 