### PR TITLE
fix: fix icon sizing

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,9 +1,10 @@
 import { Content, Header, Item, Root, Trigger } from '@radix-ui/react-accordion';
 import styled, { keyframes } from 'styled-components';
 
-import { PlusIcon } from '@/icons';
 import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
+
+import { Icon, IconName } from './Icon';
 
 export type AccordionItem = {
   header: React.ReactNode;
@@ -24,7 +25,7 @@ export const Accordion = ({ items, className }: AccordionProps) => (
           <$Trigger>
             {header}
             <$Icon>
-              <PlusIcon />
+              <Icon iconName={IconName.Plus} size="1.125em" />
             </$Icon>
           </$Trigger>
         </Header>
@@ -60,11 +61,6 @@ const $Icon = styled.div`
   border: solid var(--border-width) var(--color-border);
   border-radius: 50%;
   font: var(--font-small-book);
-
-  svg {
-    height: 1.125em;
-    width: 1.125em;
-  }
 `;
 
 const $Trigger = styled(Trigger)`

--- a/src/components/DiffArrow.tsx
+++ b/src/components/DiffArrow.tsx
@@ -17,7 +17,7 @@ export type DiffArrowProps = ElementProps & StyleProps;
 
 export const DiffArrow = ({ className, direction = 'right', sign }: DiffArrowProps) => (
   <$DiffArrowContainer className={className} direction={direction} sign={sign}>
-    <Icon iconName={IconName.Arrow} />
+    <Icon iconName={IconName.Arrow} size="0.75em" />
   </$DiffArrowContainer>
 );
 const $DiffArrowContainer = styled.span<DiffArrowProps>`
@@ -28,11 +28,6 @@ const $DiffArrowContainer = styled.span<DiffArrowProps>`
   display: inline-flex;
   position: relative;
   color: var(--diffArrow-color);
-
-  svg {
-    width: 0.75em;
-    height: 0.75em;
-  }
 
   ${({ sign }) =>
     sign &&

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -11,6 +11,7 @@ import { ToggleButton, type ToggleButtonProps } from '@/components/ToggleButton'
 type ElementProps = {
   isToggle?: boolean;
   iconName?: IconName;
+  iconSize?: string;
   iconComponent?: ElementType;
   action?: ButtonAction;
   state?: ButtonState | ButtonStateConfig;
@@ -27,6 +28,7 @@ export const IconButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Icon
       href,
       isToggle,
       iconName,
+      iconSize,
       iconComponent,
 
       onClick,
@@ -59,7 +61,7 @@ export const IconButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Icon
         onClick={onClick}
         {...otherProps}
       >
-        <Icon iconName={iconName} iconComponent={iconComponent} />
+        <Icon iconName={iconName} iconComponent={iconComponent} size={iconSize} />
       </$IconButton>
     );
   }

--- a/src/components/TriangleIndicator.tsx
+++ b/src/components/TriangleIndicator.tsx
@@ -21,7 +21,7 @@ const getSign = (num: BigNumber) =>
 export const TriangleIndicator = ({ className, value }: TriangleIndicatorProps) => {
   return (
     <$TriangleIndicator className={className} sign={getSign(value)}>
-      <Icon iconName={IconName.Triangle} />
+      <Icon iconName={IconName.Triangle} size="0.375em" />
     </$TriangleIndicator>
   );
 };
@@ -30,11 +30,6 @@ const $TriangleIndicator = styled.div<{ sign: NumberSign }>`
   align-items: center;
   height: 100%;
   margin-top: 0.0625rem;
-
-  svg {
-    width: 0.375em;
-    height: 0.375em;
-  }
 
   ${({ sign }) =>
     ({

--- a/src/components/WithConfirmationPopover.tsx
+++ b/src/components/WithConfirmationPopover.tsx
@@ -73,7 +73,9 @@ export const WithConfirmationPopover = forwardRef(
           >
             {children}
             <div tw="row justify-end gap-0.25">
-              {onCancel && <$CancelButton iconName={IconName.Close} onClick={onCancel} />}
+              {onCancel && (
+                <$CancelButton iconName={IconName.Close} onClick={onCancel} iconSize="0.8em" />
+              )}
               {onConfirm && <$ConfirmButton iconName={IconName.Check} type={ButtonType.Submit} />}
             </div>
           </form>
@@ -107,8 +109,6 @@ const $CancelButton = styled($IconButton)`
 
   svg {
     color: var(--color-red);
-    width: 0.8em;
-    height: 0.8em;
 
     path {
       stroke-width: 3;

--- a/src/layout/Footer/FooterMobile.tsx
+++ b/src/layout/Footer/FooterMobile.tsx
@@ -49,7 +49,7 @@ export const FooterMobile = () => {
                     label: stringGetter({ key: STRING_KEYS.TRADE }),
                     slotBefore: (
                       <$StartIcon>
-                        <Icon iconName={IconName.Trade} />
+                        <Icon iconName={IconName.Trade} size="1.5rem" />
                       </$StartIcon>
                     ),
                     href: `${AppRoute.Trade}/${marketId ?? DEFAULT_MARKETID}`,
@@ -184,11 +184,6 @@ const $StartIcon = styled.div<{ disabled?: boolean }>`
   background-color: var(--color-accent);
   border: solid var(--border-width) var(--color-border-white);
   border-radius: 50%;
-
-  svg {
-    width: 1.5rem;
-    height: 1.5rem;
-  }
 
   ${({ disabled }) =>
     disabled &&

--- a/src/pages/trade/MobileTopPanel.tsx
+++ b/src/pages/trade/MobileTopPanel.tsx
@@ -37,7 +37,7 @@ enum Tab {
 const TabButton = ({ value, label, icon }: { value: Tab; label: string; icon: IconName }) => (
   <Trigger asChild value={value}>
     <$TabButton>
-      <Icon iconName={icon} />
+      <Icon iconName={icon} size="1.375rem" />
       <span>{label}</span>
     </$TabButton>
   </Trigger>
@@ -152,11 +152,6 @@ const $TabButton = styled(ToggleButton)`
       font-size: 0;
       opacity: 0;
     }
-  }
-
-  svg {
-    width: 1.375rem;
-    height: 1.375rem;
   }
 `;
 const $ScrollableTableContainer = styled.div`

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -269,11 +269,6 @@ const $ConnectedAccountInfoContainer = styled.div<{ $showHeader?: boolean }>`
 
 const $Button = styled(Button)`
   margin-right: -0.3rem;
-
-  svg {
-    width: 1.25em;
-    height: 1.25em;
-  }
 `;
 
 const $IconButton = styled(IconButton)`

--- a/src/views/dialogs/DisplaySettingsDialog.tsx
+++ b/src/views/dialogs/DisplaySettingsDialog.tsx
@@ -145,11 +145,13 @@ export const DisplaySettingsDialog = ({ setIsOpen }: DialogProps<DisplaySettings
                   iconName={IconName.Arrow}
                   direction="up"
                   color={colorMode === AppColorMode.GreenUp ? 'green' : 'red'}
+                  size="0.875em"
                 />
                 <$ArrowIcon
                   iconName={IconName.Arrow}
                   direction="down"
                   color={colorMode === AppColorMode.GreenUp ? 'red' : 'green'}
+                  size="0.875em"
                 />
               </$ArrowIconContainer>
               {stringGetter({ key: label })}
@@ -263,11 +265,6 @@ const $AppThemeHeader = styled.h3<{ textcolor: string }>`
 const $ArrowIconContainer = styled.div`
   ${layoutMixins.column}
   gap: 0.25rem;
-
-  svg {
-    height: 0.875em;
-    width: 0.875em;
-  }
 `;
 
 const $ArrowIcon = styled(Icon)<{ direction: 'up' | 'down'; color: 'green' | 'red' }>`

--- a/src/views/dialogs/MnemonicExportDialog.tsx
+++ b/src/views/dialogs/MnemonicExportDialog.tsx
@@ -46,7 +46,7 @@ export const MnemonicExportDialog = ({ setIsOpen }: DialogProps<MnemonicExportDi
       <>
         <span tw="row gap-1 text-color-text-1">
           <$CautionIconContainer>
-            <Icon iconName={IconName.CautionCircleStroked} />
+            <Icon iconName={IconName.CautionCircleStroked} size="1.125em" />
           </$CautionIconContainer>
 
           <p>{stringGetter({ key: STRING_KEYS.SECRET_PHRASE_RISK })}</p>
@@ -144,8 +144,6 @@ const $CautionIconContainer = styled.div`
   color: var(--color-error);
 
   svg {
-    width: 1.125em;
-    height: 1.125em;
     justify-self: center;
   }
 

--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -281,6 +281,7 @@ export const TradeForm = ({
                 shape={ButtonShape.Circle}
                 action={ButtonAction.Navigation}
                 size={ButtonSize.XSmall}
+                iconSize="1.25em"
                 onClick={() => onTradeTypeChange(TradeTypes.LIMIT)}
               />
             )}
@@ -466,11 +467,6 @@ const $ToggleGroup = styled(ToggleGroup)`
 const $IconButton = styled(IconButton)`
   --button-backgroundColor: var(--color-white-faded);
   flex-shrink: 0;
-
-  svg {
-    width: 1.25em;
-    height: 1.25em;
-  }
 `;
 
 const $InputsColumn = styled.div`

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -49,6 +49,7 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
       <$CancelButton
         key="cancelorder"
         iconName={IconName.Close}
+        iconSize="0.875em"
         shape={ButtonShape.Square}
         {...(isOrderStatusClearable(status)
           ? { onClick: () => dispatch(clearOrder(orderId)) }
@@ -65,9 +66,4 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
 };
 const $CancelButton = styled(IconButton)`
   --button-hover-textColor: var(--color-red);
-
-  svg {
-    width: 0.875em;
-    height: 0.875em;
-  }
 `;

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -212,7 +212,7 @@ export const PositionsTriggersCell = ({
               }
               slotTrigger={
                 <$PartialFillIcon>
-                  <Icon iconName={IconName.PositionPartial} />
+                  <Icon iconName={IconName.PositionPartial} size="0.875em" />
                 </$PartialFillIcon>
               }
             />
@@ -291,8 +291,5 @@ const $ActionButton = styled(Button)`
 const $PartialFillIcon = styled.span`
   svg {
     display: block;
-
-    width: 0.875em;
-    height: 0.875em;
   }
 `;


### PR DESCRIPTION
man I added min-height and min-size as part of my truncation PR to prevent icons from shrinking. Thought I caught all the cases of icon sizing, but realized I missed when we were applying custom icon sizing via `svg {}` in css so some of our small icons were being rendered too large due to `min-height: 1em;`. Updated with a quick search of `svg {}`