### PR TITLE
fix: smol trade polishes

### DIFF
--- a/src/views/forms/TradeForm.tsx
+++ b/src/views/forms/TradeForm.tsx
@@ -459,7 +459,7 @@ const $ToggleGroup = styled(ToggleGroup)`
     gap: 0;
 
     img {
-      height: 0;
+      display: none;
     }
   }
 ` as typeof ToggleGroup;

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -112,7 +112,7 @@ export const MarketLeverageInput = ({
       <$WithLabel
         key="leverage"
         label={
-          <div tw="flex gap-0.5">
+          <div tw="flex gap-[0.5ch]">
             <WithTooltip tooltip="leverage" side="right">
               {stringGetter({ key: STRING_KEYS.LEVERAGE })}
             </WithTooltip>

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -219,9 +219,7 @@ export const TradeSizeInputs = () => {
           >
             {stringGetter({ key: STRING_KEYS.AMOUNT })}
           </WithTooltip>
-          {id && (
-            <DisplayUnitTag tw="ml-[0.5ch]" assetId={id} entryPoint="tradeAmountInputAssetTag" />
-          )}
+          {id && <DisplayUnitTag assetId={id} entryPoint="tradeAmountInputAssetTag" />}
         </>
       }
       slotRight={inputToggleButton()}

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -472,10 +472,6 @@ export const PositionsTable = ({
     <$Table
       key={currentMarket ?? 'positions'}
       label={stringGetter({ key: STRING_KEYS.POSITIONS })}
-      defaultSortDescriptor={{
-        column: 'market',
-        direction: 'ascending',
-      }}
       data={positionsData}
       columns={columnKeys.map((key: PositionsTableColumnKey) =>
         getPositionsTableColumnDef({


### PR DESCRIPTION
positions don't need to be default sorted by market; others fills/orders table don't have to default arrow on
<img width="379" alt="image" src="https://github.com/user-attachments/assets/d5cc2b67-8604-4faa-913b-9663e4936b3b">
<img width="320" alt="image" src="https://github.com/user-attachments/assets/f0d541b6-6abb-4121-b7e8-3eb6c946ad5d">

i fucked up label / tag spacing
<img width="156" alt="image" src="https://github.com/user-attachments/assets/bbc6e4ac-e81e-463b-9767-c042e88d0d66">
<img width="219" alt="image" src="https://github.com/user-attachments/assets/fb54e08e-9e03-42d1-ab9b-591642da8973">

mobile size trade type orders toggle should only show icon when selected
<img width="593" alt="image" src="https://github.com/user-attachments/assets/032a456f-7874-4fcf-b65d-4c5f577a7633">
<img width="611" alt="image" src="https://github.com/user-attachments/assets/cf2e4dc0-d626-4360-81b3-4ca37f36cfee">
