### PR TITLE
style: re-order launch incentives

### DIFF
--- a/src/pages/token/RewardsPage.tsx
+++ b/src/pages/token/RewardsPage.tsx
@@ -112,8 +112,8 @@ const RewardsPage = () => {
             {showStakingRewardPanel && stakingRewardPanel}
             <StakingPanel />
             <UnbondingPanels />
-            <TradingRewardsChartPanel />
             <LaunchIncentivesPanel />
+            <TradingRewardsChartPanel />
             <NewMarketsPanel />
             <GovernancePanel />
             <RewardHistoryPanel />
@@ -126,8 +126,8 @@ const RewardsPage = () => {
           {showMigratePanel && <MigratePanel />}
           <div tw="flex gap-1.5">
             <div tw="flexColumn flex-[2] gap-1.5">
-              <TradingRewardsChartPanel />
               <LaunchIncentivesPanel />
+              <TradingRewardsChartPanel />
               <RewardHistoryPanel />
             </div>
             <div tw="flexColumn flex-1 gap-1.5">


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1568" alt="Screen Shot 2024-10-04 at 10 49 04 AM" src="https://github.com/user-attachments/assets/6b404129-2979-4b3b-ab83-a271b9035071">


<!-- Overall purpose of the PR -->
Move launch incentives above Trading Rewards graph

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<RewardsPage>`
  - Update tile order

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
