### PR TITLE
fix: external nav dialog on api documentation

### DIFF
--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -123,7 +123,6 @@ export const HeaderDesktop = () => {
               value: 'DOCUMENTATION',
               slotBefore: <Icon iconName={IconName.Terminal} />,
               label: stringGetter({ key: STRING_KEYS.API_DOCUMENTATION }),
-              // href: documentation,
               onClick: () => {
                 dispatch(
                   openDialog(

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -123,7 +123,16 @@ export const HeaderDesktop = () => {
               value: 'DOCUMENTATION',
               slotBefore: <Icon iconName={IconName.Terminal} />,
               label: stringGetter({ key: STRING_KEYS.API_DOCUMENTATION }),
-              href: documentation,
+              // href: documentation,
+              onClick: () => {
+                dispatch(
+                  openDialog(
+                    DialogTypes.ExternalLink({
+                      link: documentation,
+                    })
+                  )
+                );
+              },
             },
             {
               value: 'MINTSCAN',


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/user-attachments/assets/838dd724-b7f9-4fca-b1fe-118174f33e93


<!-- Overall purpose of the PR -->

Add External Navigation dialog.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<HeaderDesktop>`
  - Add ExternalLink Dialog when users try to navigate to API Documentation

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
