### PR TITLE
fix(polymarket): add dismissable reducer and fix ticker

### DIFF
--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -36,9 +36,6 @@ export enum LocalStorageKey {
   HasSeenTradeFormMessageTRUMPWIN = 'dydx.HasSeenTradeFormMessageTRUMPWIN',
 }
 
-// TODO: Remove or migrate
-// HasSeenPredictionMarketsIntro = 'dydx.HasSeenPredictionMarketsIntro',
-
 export const LOCAL_STORAGE_VERSIONS = {
   [LocalStorageKey.EvmDerivedAddresses]: 'v2',
   [LocalStorageKey.SolDerivedAddresses]: 'v1',

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -36,6 +36,9 @@ export enum LocalStorageKey {
   HasSeenTradeFormMessageTRUMPWIN = 'dydx.HasSeenTradeFormMessageTRUMPWIN',
 }
 
+// TODO: Remove or migrate
+// HasSeenPredictionMarketsIntro = 'dydx.HasSeenPredictionMarketsIntro',
+
 export const LOCAL_STORAGE_VERSIONS = {
   [LocalStorageKey.EvmDerivedAddresses]: 'v2',
   [LocalStorageKey.SolDerivedAddresses]: 'v1',

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -34,9 +34,6 @@ export enum LocalStorageKey {
   // Discoverability
   HasSeenElectionBannerTRUMPWIN = 'dydx.HasSeenElectionBannerTRUMPWIN',
   HasSeenTradeFormMessageTRUMPWIN = 'dydx.HasSeenTradeFormMessageTRUMPWIN',
-
-  // Informational
-  HasSeenPredictionMarketsIntro = 'dydx.HasSeenPredictionMarketsIntro',
 }
 
 export const LOCAL_STORAGE_VERSIONS = {

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -17,7 +17,7 @@ import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { closeDialogInTradeBox, openDialog } from '@/state/dialogs';
 import { getActiveTradeBoxDialog } from '@/state/dialogsSelectors';
-import { getHasSeenPolymarketDialog } from '@/state/dismissableSelectors';
+import { gethasSeenPredictionMarketIntoDialog } from '@/state/dismissableSelectors';
 import { setCurrentMarketId } from '@/state/perpetuals';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
@@ -36,7 +36,7 @@ export const useCurrentMarketId = () => {
   const launchableMarkets = useLaunchableMarkets();
   const activeTradeBoxDialog = useAppSelector(getActiveTradeBoxDialog);
   const hasLoadedLaunchableMarkets = launchableMarkets.data.length > 0;
-  const hasSeenPolymarketDialog = useAppSelector(getHasSeenPolymarketDialog);
+  const hasSeenPredictionMarketIntoDialog = useAppSelector(gethasSeenPredictionMarketIntoDialog);
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,
@@ -44,7 +44,7 @@ export const useCurrentMarketId = () => {
   });
 
   const onNavigateToPredictionMarket = () => {
-    if (!hasSeenPolymarketDialog) {
+    if (!hasSeenPredictionMarketIntoDialog) {
       dispatch(openDialog(DialogTypes.PredictionMarketIntro()));
     }
   };

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -17,7 +17,7 @@ import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { closeDialogInTradeBox, openDialog } from '@/state/dialogs';
 import { getActiveTradeBoxDialog } from '@/state/dialogsSelectors';
-import { gethasSeenPredictionMarketIntoDialog } from '@/state/dismissableSelectors';
+import { getHasSeenPredictionMarketIntoDialog } from '@/state/dismissableSelectors';
 import { setCurrentMarketId } from '@/state/perpetuals';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
@@ -36,7 +36,7 @@ export const useCurrentMarketId = () => {
   const launchableMarkets = useLaunchableMarkets();
   const activeTradeBoxDialog = useAppSelector(getActiveTradeBoxDialog);
   const hasLoadedLaunchableMarkets = launchableMarkets.data.length > 0;
-  const hasSeenPredictionMarketIntoDialog = useAppSelector(gethasSeenPredictionMarketIntoDialog);
+  const hasSeenPredictionMarketIntoDialog = useAppSelector(getHasSeenPredictionMarketIntoDialog);
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -17,6 +17,7 @@ import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { closeDialogInTradeBox, openDialog } from '@/state/dialogs';
 import { getActiveTradeBoxDialog } from '@/state/dialogsSelectors';
+import { getHasSeenPolymarketDialog } from '@/state/dismissableSelectors';
 import { setCurrentMarketId } from '@/state/perpetuals';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
@@ -35,19 +36,15 @@ export const useCurrentMarketId = () => {
   const launchableMarkets = useLaunchableMarkets();
   const activeTradeBoxDialog = useAppSelector(getActiveTradeBoxDialog);
   const hasLoadedLaunchableMarkets = launchableMarkets.data.length > 0;
+  const hasSeenPolymarketDialog = useAppSelector(getHasSeenPolymarketDialog);
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,
     defaultValue: DEFAULT_MARKETID,
   });
 
-  const [hasSeenPredictionMarketsIntro] = useLocalStorage({
-    key: LocalStorageKey.HasSeenPredictionMarketsIntro,
-    defaultValue: false,
-  });
-
   const onNavigateToPredictionMarket = () => {
-    if (!hasSeenPredictionMarketsIntro) {
+    if (!hasSeenPolymarketDialog) {
       dispatch(openDialog(DialogTypes.PredictionMarketIntro()));
     }
   };

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -17,7 +17,7 @@ import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { closeDialogInTradeBox, openDialog } from '@/state/dialogs';
 import { getActiveTradeBoxDialog } from '@/state/dialogsSelectors';
-import { getHasSeenPredictionMarketIntoDialog } from '@/state/dismissableSelectors';
+import { getHasSeenPredictionMarketIntroDialog } from '@/state/dismissableSelectors';
 import { setCurrentMarketId } from '@/state/perpetuals';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
@@ -36,7 +36,7 @@ export const useCurrentMarketId = () => {
   const launchableMarkets = useLaunchableMarkets();
   const activeTradeBoxDialog = useAppSelector(getActiveTradeBoxDialog);
   const hasLoadedLaunchableMarkets = launchableMarkets.data.length > 0;
-  const hasSeenPredictionMarketIntoDialog = useAppSelector(getHasSeenPredictionMarketIntoDialog);
+  const hasSeenPredictionMarketIntroDialog = useAppSelector(getHasSeenPredictionMarketIntroDialog);
 
   const [lastViewedMarket, setLastViewedMarket] = useLocalStorage({
     key: LocalStorageKey.LastViewedMarket,
@@ -44,7 +44,7 @@ export const useCurrentMarketId = () => {
   });
 
   const onNavigateToPredictionMarket = () => {
-    if (!hasSeenPredictionMarketIntoDialog) {
+    if (!hasSeenPredictionMarketIntroDialog) {
       dispatch(openDialog(DialogTypes.PredictionMarketIntro()));
     }
   };

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -47,7 +47,7 @@ const rootReducer = combineReducers(reducers);
 
 const persistConfig = {
   key: 'root',
-  version: 1,
+  version: 2,
   storage,
   whitelist: ['affiliates', 'dismissable', 'tradingView', 'wallet'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -11,6 +11,7 @@ import appMiddleware from './appMiddleware';
 import { assetsSlice } from './assets';
 import { configsSlice } from './configs';
 import { dialogsSlice } from './dialogs';
+import { dismissableSlice } from './dismissable';
 import { inputsSlice } from './inputs';
 import { layoutSlice } from './layout';
 import { localOrdersSlice } from './localOrders';
@@ -30,6 +31,7 @@ const reducers = {
   assets: assetsSlice.reducer,
   configs: configsSlice.reducer,
   dialogs: dialogsSlice.reducer,
+  dismissable: dismissableSlice.reducer,
   inputs: inputsSlice.reducer,
   layout: layoutSlice.reducer,
   localization: localizationSlice.reducer,
@@ -47,7 +49,7 @@ const persistConfig = {
   key: 'root',
   version: 1,
   storage,
-  whitelist: ['tradingView', 'wallet', 'affiliates'],
+  whitelist: ['affiliates', 'dismissable', 'tradingView', 'wallet'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),
 };
 

--- a/src/state/dismissable.ts
+++ b/src/state/dismissable.ts
@@ -2,21 +2,21 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 export interface DismissableState {
-  hasSeenPolymarketDialog: boolean;
+  hasSeenPredictionMarketIntoDialog: boolean;
 }
 
 const initialState: DismissableState = {
-  hasSeenPolymarketDialog: false,
+  hasSeenPredictionMarketIntoDialog: false,
 };
 
 export const dismissableSlice = createSlice({
   name: 'Dismissable',
   initialState,
   reducers: {
-    setHasSeenPolymarketDialog: (state, action: PayloadAction<boolean>) => {
-      state.hasSeenPolymarketDialog = action.payload;
+    setHasSeenPredictionMarketIntoDialog: (state, action: PayloadAction<boolean>) => {
+      state.hasSeenPredictionMarketIntoDialog = action.payload;
     },
   },
 });
 
-export const { setHasSeenPolymarketDialog } = dismissableSlice.actions;
+export const { setHasSeenPredictionMarketIntoDialog } = dismissableSlice.actions;

--- a/src/state/dismissable.ts
+++ b/src/state/dismissable.ts
@@ -2,21 +2,21 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 export interface DismissableState {
-  hasSeenPredictionMarketIntoDialog: boolean;
+  hasSeenPredictionMarketIntroDialog: boolean;
 }
 
 const initialState: DismissableState = {
-  hasSeenPredictionMarketIntoDialog: false,
+  hasSeenPredictionMarketIntroDialog: false,
 };
 
 export const dismissableSlice = createSlice({
   name: 'Dismissable',
   initialState,
   reducers: {
-    setHasSeenPredictionMarketIntoDialog: (state, action: PayloadAction<boolean>) => {
-      state.hasSeenPredictionMarketIntoDialog = action.payload;
+    setHasSeenPredictionMarketIntroDialog: (state, action: PayloadAction<boolean>) => {
+      state.hasSeenPredictionMarketIntroDialog = action.payload;
     },
   },
 });
 
-export const { setHasSeenPredictionMarketIntoDialog } = dismissableSlice.actions;
+export const { setHasSeenPredictionMarketIntroDialog } = dismissableSlice.actions;

--- a/src/state/dismissable.ts
+++ b/src/state/dismissable.ts
@@ -1,0 +1,22 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface DismissableState {
+  hasSeenPolymarketDialog: boolean;
+}
+
+const initialState: DismissableState = {
+  hasSeenPolymarketDialog: false,
+};
+
+export const dismissableSlice = createSlice({
+  name: 'Dismissable',
+  initialState,
+  reducers: {
+    setHasSeenPolymarketDialog: (state, action: PayloadAction<boolean>) => {
+      state.hasSeenPolymarketDialog = action.payload;
+    },
+  },
+});
+
+export const { setHasSeenPolymarketDialog } = dismissableSlice.actions;

--- a/src/state/dismissableSelectors.ts
+++ b/src/state/dismissableSelectors.ts
@@ -1,4 +1,4 @@
 import { type RootState } from './_store';
 
-export const gethasSeenPredictionMarketIntoDialog = (state: RootState) =>
+export const getHasSeenPredictionMarketIntoDialog = (state: RootState) =>
   state.dismissable.hasSeenPredictionMarketIntoDialog;

--- a/src/state/dismissableSelectors.ts
+++ b/src/state/dismissableSelectors.ts
@@ -1,4 +1,4 @@
 import { type RootState } from './_store';
 
-export const getHasSeenPredictionMarketIntoDialog = (state: RootState) =>
-  state.dismissable.hasSeenPredictionMarketIntoDialog;
+export const getHasSeenPredictionMarketIntroDialog = (state: RootState) =>
+  state.dismissable.hasSeenPredictionMarketIntroDialog;

--- a/src/state/dismissableSelectors.ts
+++ b/src/state/dismissableSelectors.ts
@@ -1,0 +1,4 @@
+import { type RootState } from './_store';
+
+export const getHasSeenPolymarketDialog = (state: RootState) =>
+  state.dismissable.hasSeenPolymarketDialog;

--- a/src/state/dismissableSelectors.ts
+++ b/src/state/dismissableSelectors.ts
@@ -1,4 +1,4 @@
 import { type RootState } from './_store';
 
-export const getHasSeenPolymarketDialog = (state: RootState) =>
-  state.dismissable.hasSeenPolymarketDialog;
+export const gethasSeenPredictionMarketIntoDialog = (state: RootState) =>
+  state.dismissable.hasSeenPredictionMarketIntoDialog;

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -3,10 +3,12 @@ import { MigrationConfig } from 'redux-persist/lib/createMigrate';
 
 import { migration0 } from './migrations/0';
 import { migration1 } from './migrations/1';
+import { migration2 } from './migrations/2';
 
 export const migrations = {
   0: migration0,
   1: migration1,
+  2: migration2,
 } as const;
 
 /*

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -13,7 +13,7 @@ import {
 import { WalletState } from '../wallet';
 import { parseStorageItem } from './utils';
 
-type V1State = PersistedState & { wallet: WalletState };
+export type V1State = PersistedState & { wallet: WalletState };
 /**
  * Move over wallet data from localStorage into redux
  * TODO (in future migration): Remove these localStorage items

--- a/src/state/migrations/2.ts
+++ b/src/state/migrations/2.ts
@@ -1,0 +1,28 @@
+import { PersistedState } from 'redux-persist';
+
+import { DismissableState } from '../dismissable';
+import { parseStorageItem } from './utils';
+
+export type V2State = PersistedState & { dismissable: DismissableState };
+/**
+ * Third migration, moving over the hasSeenPredictionMarketsIntro localStorage item
+ *
+ */
+export function migration2(state: PersistedState | undefined): V2State {
+  if (!state) {
+    throw new Error('state must be defined');
+  }
+
+  const hasSeenPredictionMarketsIntro = parseStorageItem<boolean>(
+    localStorage.getItem('dydx.HasSeenPredictionMarketsIntro')
+  );
+
+  localStorage.removeItem('dydx.HasSeenPredictionMarketsIntro');
+
+  return {
+    ...state,
+    dismissable: {
+      hasSeenPredictionMarketIntroDialog: hasSeenPredictionMarketsIntro ?? false,
+    },
+  };
+}

--- a/src/state/migrations/__test__/2.test.ts
+++ b/src/state/migrations/__test__/2.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { V1State } from '../1';
+import { migration2 } from '../2';
+
+const V1_STATE: V1State = {
+  _persist: { version: 1, rehydrated: true },
+  wallet: {
+    sourceAccount: {
+      address: undefined,
+      chain: undefined,
+      encryptedSignature: undefined,
+      walletInfo: undefined,
+    },
+  },
+};
+
+describe('migration2', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should add hasSeenPredictionMarketIntroDialog property set to false', () => {
+    const result = migration2(V1_STATE);
+    expect(result.dismissable.hasSeenPredictionMarketIntroDialog).toBe(false);
+  });
+
+  it('should overwrite hasSeenPredictionMarketIntroDialog if it already exists', () => {
+    const result = migration2(V1_STATE);
+    expect(result.dismissable.hasSeenPredictionMarketIntroDialog).toBe(false);
+  });
+
+  it('should copy localStorage values to dismissable object', () => {
+    localStorage.setItem('dydx.HasSeenPredictionMarketsIntro', 'true');
+
+    const result = migration2(V1_STATE);
+
+    expect(result.dismissable.hasSeenPredictionMarketIntroDialog).toBe(true);
+    // Check if localStorage items were removed
+    expect(localStorage.getItem('dydx.HasSeenPredictionMarketsIntro')).toBeNull();
+  });
+});

--- a/src/views/MarketDetails/CurrentMarketDetails.tsx
+++ b/src/views/MarketDetails/CurrentMarketDetails.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getCurrentMarketData } from '@/state/perpetualsSelectors';
 
+import { getDisplayableTickerFromMarket } from '@/lib/assetUtils';
 import { BIG_NUMBERS } from '@/lib/numbers';
 
 import { MarketDetails } from './MarketDetails';
@@ -51,14 +52,9 @@ export const CurrentMarketDetails = () => {
 
   const items = [
     {
-      key: 'market-name',
-      label: stringGetter({ key: STRING_KEYS.MARKET_NAME }),
-      value: displayId,
-    },
-    {
       key: 'ticker',
       label: stringGetter({ key: STRING_KEYS.TICKER }),
-      value: market,
+      value: getDisplayableTickerFromMarket(market ?? ''),
     },
     {
       key: 'market-type',

--- a/src/views/MarketDetails/CurrentMarketDetails.tsx
+++ b/src/views/MarketDetails/CurrentMarketDetails.tsx
@@ -14,14 +14,13 @@ import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { getCurrentMarketData } from '@/state/perpetualsSelectors';
 
-import { getDisplayableTickerFromMarket } from '@/lib/assetUtils';
 import { BIG_NUMBERS } from '@/lib/numbers';
 
 import { MarketDetails } from './MarketDetails';
 
 export const CurrentMarketDetails = () => {
   const stringGetter = useStringGetter();
-  const { configs, displayId, market } = useAppSelector(getCurrentMarketData, shallowEqual) ?? {};
+  const { configs, displayId } = useAppSelector(getCurrentMarketData, shallowEqual) ?? {};
   const { id, name, resources } = useAppSelector(getCurrentMarketAssetData, shallowEqual) ?? {};
 
   if (!configs) return null;
@@ -54,7 +53,7 @@ export const CurrentMarketDetails = () => {
     {
       key: 'ticker',
       label: stringGetter({ key: STRING_KEYS.TICKER }),
-      value: getDisplayableTickerFromMarket(market ?? ''),
+      value: displayId,
     },
     {
       key: 'market-type',

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -15,7 +15,7 @@ import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
 import { NewTag } from '@/components/Tag';
 
-import { setHasSeenPredictionMarketIntoDialog } from '@/state/dismissable';
+import { setHasSeenPredictionMarketIntroDialog } from '@/state/dismissable';
 
 export const PredictionMarketIntroDialog = ({
   setIsOpen,
@@ -25,7 +25,7 @@ export const PredictionMarketIntroDialog = ({
   const dispatch = useDispatch();
 
   const onDismissPredictionMarketsIntro = useCallback(() => {
-    dispatch(setHasSeenPredictionMarketIntoDialog(true));
+    dispatch(setHasSeenPredictionMarketIntroDialog(true));
   }, [dispatch]);
 
   const onContinue = useCallback(() => {

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -15,7 +15,7 @@ import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
 import { NewTag } from '@/components/Tag';
 
-import { sethasSeenPredictionMarketIntoDialog } from '@/state/dismissable';
+import { setHasSeenPredictionMarketIntoDialog } from '@/state/dismissable';
 
 export const PredictionMarketIntroDialog = ({
   setIsOpen,
@@ -25,7 +25,7 @@ export const PredictionMarketIntroDialog = ({
   const dispatch = useDispatch();
 
   const onDismissPredictionMarketsIntro = useCallback(() => {
-    dispatch(sethasSeenPredictionMarketIntoDialog(true));
+    dispatch(setHasSeenPredictionMarketIntoDialog(true));
   }, [dispatch]);
 
   const onContinue = useCallback(() => {

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useState } from 'react';
 
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
 import type { DialogProps, PredictionMarketIntroDialogProps } from '@/constants/dialogs';
-import { LocalStorageKey } from '@/constants/localStorage';
 import { STRING_KEYS } from '@/constants/localization';
 
-import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { Button } from '@/components/Button';
@@ -16,20 +15,26 @@ import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
 import { NewTag } from '@/components/Tag';
 
+import { setHasSeenPolymarketDialog } from '@/state/dismissable';
+
 export const PredictionMarketIntroDialog = ({
   setIsOpen,
 }: DialogProps<PredictionMarketIntroDialogProps>) => {
   const stringGetter = useStringGetter();
   const [doNotShowAgain, setDoNotShowAgain] = useState(false);
-  const [, setHasSeenPredictionMarketsIntro] = useLocalStorage({
-    key: LocalStorageKey.HasSeenPredictionMarketsIntro,
-    defaultValue: false,
-  });
+  const dispatch = useDispatch();
+
+  const onDismissPredictionMarketsIntro = useCallback(() => {
+    dispatch(setHasSeenPolymarketDialog(true));
+  }, [dispatch]);
 
   const onContinue = useCallback(() => {
-    setHasSeenPredictionMarketsIntro(doNotShowAgain);
+    if (doNotShowAgain) {
+      onDismissPredictionMarketsIntro();
+    }
+
     setIsOpen(false);
-  }, [doNotShowAgain, setIsOpen, setHasSeenPredictionMarketsIntro]);
+  }, [doNotShowAgain, setIsOpen, onDismissPredictionMarketsIntro]);
 
   const renderPoint = ({
     icon,

--- a/src/views/dialogs/PredictionMarketIntroDialog.tsx
+++ b/src/views/dialogs/PredictionMarketIntroDialog.tsx
@@ -15,7 +15,7 @@ import { Dialog } from '@/components/Dialog';
 import { Icon, IconName } from '@/components/Icon';
 import { NewTag } from '@/components/Tag';
 
-import { setHasSeenPolymarketDialog } from '@/state/dismissable';
+import { sethasSeenPredictionMarketIntoDialog } from '@/state/dismissable';
 
 export const PredictionMarketIntroDialog = ({
   setIsOpen,
@@ -25,7 +25,7 @@ export const PredictionMarketIntroDialog = ({
   const dispatch = useDispatch();
 
   const onDismissPredictionMarketsIntro = useCallback(() => {
-    dispatch(setHasSeenPolymarketDialog(true));
+    dispatch(sethasSeenPredictionMarketIntoDialog(true));
   }, [dispatch]);
 
   const onContinue = useCallback(() => {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->

Miscellaneous fixes for Polymarket feature and long form tickers.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<PredictionMarketIntroDialog>`
  - Use `dismissable` slice to set `hasSeenPredictionMarketIntroDialog`

- `<CurrentMarketDetail>`
  - Remove long form ticker

## Hooks

- `hooks/useCurrentMarketId`
  - use `hasSeenPredictionMarketIntroDialog` via `useAppSelector`

## State

- new `state/dismissable`, `state/_store`
  - Add `dismissable` reducer/slice and add to redux-persist
  - Add `dismissableSelectors`
  - Use for `hasSeenPredictionMarketIntroDialog` to replace `useLocalStorage`

- new `state/migration2`
  - migrate localStorage to redux persist 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
