### PR TITLE
fix: fix stacking of characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.12.21",
     "@dydxprotocol/v4-client-js": "1.10.0",
-    "@dydxprotocol/v4-localization": "^1.1.216",
+    "@dydxprotocol/v4-localization": "^1.1.217",
     "@dydxprotocol/v4-proto": "^7.0.0-dev.0",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: 1.10.0
     version: 1.10.0
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.216
-    version: 1.1.216
+    specifier: ^1.1.217
+    version: 1.1.217
   '@dydxprotocol/v4-proto':
     specifier: ^7.0.0-dev.0
     version: 7.0.0-dev.0
@@ -3061,8 +3061,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.216:
-    resolution: {integrity: sha512-Fy9GCfQwffwl9xaGTFM8+gzQln1Ye95amkRgS/0/Kjjd4ciyaS2+lgSiO2Tb0MTHAF3fxm/Z9Hmi3TS4rlf36g==}
+  /@dydxprotocol/v4-localization@1.1.217:
+    resolution: {integrity: sha512-nD3fDRqqRzM44QHhyGg0MeeTIy8n2K7/V8fWaY6VXTrNP/KEE3zkXozXvL0ZXeOulA7+Kf+otwCh2aM5apYkLA==}
     dev: false
 
   /@dydxprotocol/v4-proto@7.0.0-dev.0:

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -84,7 +84,7 @@ export const Tabs = <TabItemsValue extends string>({
                 $withUnderline={withUnderline}
                 disabled={disabled}
               >
-                {item.label}
+                <$Label>{item.label}</$Label>
                 {item.tag && <Tag>{item.tag}</Tag>}
                 {item.slotRight}
               </$Trigger>
@@ -103,7 +103,7 @@ export const Tabs = <TabItemsValue extends string>({
               }
               disabled={disabled}
             >
-              {item.label}
+              <$Label>{item.label}</$Label>
             </$DropdownSelectMenu>
           )
         )}
@@ -269,6 +269,11 @@ const $Trigger = styled(Trigger)<{
       ${tabMixins.tabTriggerUnderlineStyle}
     `}
 `;
+
+const $Label = styled.div`
+  ${layoutMixins.textTruncate}
+`;
+
 const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>`
   ${layoutMixins.flexColumn}
   outline: none;

--- a/src/views/CanvasOrderbook/OrderbookRow.tsx
+++ b/src/views/CanvasOrderbook/OrderbookRow.tsx
@@ -77,6 +77,7 @@ const $OrderbookMiddleRow = styled(OrderbookRow)<{ side?: 'top' | 'bottom' }>`
   height: 1.75rem;
   border-top: var(--border);
   border-bottom: var(--border);
+  white-space: nowrap;
 
   ${({ side }) =>
     side &&


### PR DESCRIPTION
- pull in new translations
- fix stacking of characters in tabs
- note, I verified that "Depth" is a translation key (DEPTH_CHART_SHORT) it's just that japanese happened to translate it as "Depth" :( (will find channel to circuit feedback into)

| before | after | 
| ---- | ---- | 
| <img width="330" alt="Screenshot 2024-10-14 at 5 25 15 PM" src="https://github.com/user-attachments/assets/e1187e73-3bc1-49b7-902d-4408ccd20e2c"> |  <img width="318" alt="Screenshot 2024-10-14 at 5 28 13 PM" src="https://github.com/user-attachments/assets/b9e2b897-e15c-49af-9221-59f74cea1ff6"> | 
| <img width="753" alt="Screenshot 2024-10-14 at 5 40 30 PM" src="https://github.com/user-attachments/assets/a91292b9-62d8-49df-8262-5be3437f0915"> | <img width="738" alt="Screenshot 2024-10-14 at 5 40 21 PM" src="https://github.com/user-attachments/assets/369d4a1c-5823-4c04-bfbb-55e3aa37f5da"> |
| <img width="735" alt="Screenshot 2024-10-14 at 5 43 56 PM" src="https://github.com/user-attachments/assets/cc33f221-7e6a-40dc-a70a-93510d2fe27f"> | <img width="735" alt="Screenshot 2024-10-14 at 5 44 07 PM" src="https://github.com/user-attachments/assets/7ff0cf7b-8b66-4fcd-ad23-993ee9148715"> |


