### PR TITLE
feat(create-market): Add create market client call

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.12.23",
-    "@dydxprotocol/v4-client-js": "1.10.0",
+    "@dydxprotocol/v4-client-js": "1.11.0",
     "@dydxprotocol/v4-localization": "^1.1.216",
     "@dydxprotocol/v4-proto": "^7.0.0-dev.0",
     "@emotion/is-prop-valid": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 1.12.23
     version: 1.12.23
   '@dydxprotocol/v4-client-js':
-    specifier: 1.10.0
-    version: 1.10.0
+    specifier: 1.11.0
+    version: 1.11.0
   '@dydxprotocol/v4-localization':
     specifier: ^1.1.216
     version: 1.1.216
@@ -3032,8 +3032,8 @@ packages:
       format-util: 1.0.5
     dev: false
 
-  /@dydxprotocol/v4-client-js@1.10.0:
-    resolution: {integrity: sha512-qvZqj8htZOg+pTPA3ixTIa9ChdhALHU5K1VXRU5/d5fziFrt5iDsieSsVmPj9PE8I9VpWFBG7e/HXybtFM2usw==}
+  /@dydxprotocol/v4-client-js@1.11.0:
+    resolution: {integrity: sha512-P8lvkLh3umx+URuPyEAxDS1JuHBS7ABocJQi9XkJR24vrjvDd3iYUZoUQMslyCDiiJZ9/cgvnu9rle5wp+Q0Ng==}
     dependencies:
       '@cosmjs/amino': 0.32.3
       '@cosmjs/encoding': 0.32.3

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -735,6 +735,22 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
     [compositeClient, localDydxWallet, newMarketProposal]
   );
 
+  // ------ Listing Method ------ //
+  const createPermissionlessMarket = useCallback(
+    async (ticker: string) => {
+      if (!compositeClient) {
+        throw new Error('client not initialized');
+      } else if (!subaccountClient?.address) {
+        throw new Error('wallet not initialized');
+      }
+
+      const response = await compositeClient.createMarketPermissionless(subaccountClient, ticker);
+
+      return response;
+    },
+    [compositeClient, subaccountClient]
+  );
+
   // ------ Staking Methods ------ //
   const delegate = useCallback(
     async (validator: string, amount: number) => {
@@ -1050,6 +1066,9 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
 
     // Governance Methods
     submitNewMarketProposal,
+
+    // Listing Methods
+    createPermissionlessMarket,
 
     // Staking methods
     delegate,

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -8,6 +8,7 @@ import { STRING_KEYS } from '@/constants/localization';
 
 import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
 import { useStringGetter } from '@/hooks/useStringGetter';
+import { useSubaccount } from '@/hooks/useSubaccount';
 
 import { formMixins } from '@/styles/formMixins';
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -46,6 +47,7 @@ export const NewMarketPreviewStep = ({
   const [showAgreement, setShowAgreement] = useState(false);
   const baseAsset = getDisplayableAssetFromTicker(ticker);
   const launchableAsset = useMetadataServiceAssetFromId(ticker);
+  const { createPermissionlessMarket } = useSubaccount();
 
   const alertMessage = useMemo(() => {
     let alert;
@@ -161,9 +163,12 @@ export const NewMarketPreviewStep = ({
           setErrorMessage(undefined);
 
           try {
+            const response = await createPermissionlessMarket(ticker);
+            // eslint-disable-next-line no-console
+            console.log('debug:createPermissionlessMarket', response);
             onSuccess(ticker);
           } catch (error) {
-            log('NewMarketPreviewForm/submitNewMarketProposal', error);
+            log('NewMarketPreviewForm/createPermissionlessMarket', error);
             setErrorMessage(error.message);
           } finally {
             setIsLoading(false);


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Update frontend to use new `createPermissionlessMarket` client functions.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `v7.0 <NewMarketPreviewForm>`
  - use `createPermissionlessMarket` method

## Hooks

- `hooks/useSubaccount`
  - add `createPermissionlessMarket` method

## Packages

- `@dydxprotocol/v4-client-js`
  - Bump version to one that includes client call 
  - updated: v1.10.0 -> v1.11.0

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
