### PR TITLE
feat: market dropdown shortcut '/' key

### DIFF
--- a/src/lib/domUtils.ts
+++ b/src/lib/domUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Copied from https://github.com/palantir/blueprint/blob/develop/packages/core/src/common/utils/domUtils.ts#L33
+ * Checks whether the given element is inside something that looks like a text input.
+ * This is particularly useful to determine if a keyboard event inside this element should take priority over hotkey
+ * bindings / keyboard shortcut handlers.
+ *
+ * @returns true if the element is inside a text input
+ */
+export function elementIsTextInput(elem: HTMLElement) {
+  // we check these cases for unit testing, but this should not happen
+  // during normal operation
+  if (elem == null || elem.closest == null) {
+    return false;
+  }
+
+  const editable = elem.closest<HTMLInputElement>('input, textarea, [contenteditable=true]');
+
+  if (editable == null) {
+    return false;
+  }
+
+  // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
+  if (editable.tagName.toLowerCase() === 'input') {
+    const inputType = editable.type;
+    if (inputType === 'checkbox' || inputType === 'radio') {
+      return false;
+    }
+  }
+
+  // don't let read-only fields prevent hotkey behavior
+  if (editable.readOnly) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -290,7 +290,14 @@ export const MarketsDropdown = memo(
     useEffect(() => {
       // listen for '/' key to open the dropdown
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === '/') {
+        if (event.key !== '/' || !event.target) return;
+
+        const target = event.target as HTMLElement;
+        const targetTagName = target.tagName?.toLowerCase();
+        const isTypingInInput =
+          targetTagName === 'input' || targetTagName === 'textarea' || target.isContentEditable;
+
+        if (!isTypingInInput) {
           event.preventDefault();
           setIsOpen(true);
         }
@@ -301,7 +308,7 @@ export const MarketsDropdown = memo(
       return () => {
         window.removeEventListener('keydown', handleKeyDown);
       };
-    }, []);
+    }, [isOpen]);
 
     return (
       <$Popover

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -34,6 +34,7 @@ import { Toolbar } from '@/components/Toolbar';
 
 import { getMarketMaxLeverage } from '@/state/perpetualsSelectors';
 
+import { elementIsTextInput } from '@/lib/domUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { calculateMarketMaxLeverage } from '@/lib/marketsHelpers';
 import { MustBigNumber } from '@/lib/numbers';
@@ -292,12 +293,9 @@ export const MarketsDropdown = memo(
       const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key !== '/' || !event.target) return;
 
-        const target = event.target as HTMLElement;
-        const targetTagName = target.tagName?.toLowerCase();
-        const isTypingInInput =
-          targetTagName === 'input' || targetTagName === 'textarea' || target.isContentEditable;
+        const isTextInput = elementIsTextInput(event.target as HTMLElement);
 
-        if (!isTypingInInput) {
+        if (!isTextInput) {
           event.preventDefault();
           setIsOpen(true);
         }

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -1,4 +1,4 @@
-import { Key, memo, useMemo, useState } from 'react';
+import { Key, memo, useEffect, useMemo, useState } from 'react';
 
 import { Link, useNavigate } from 'react-router-dom';
 import styled, { css, keyframes } from 'styled-components';
@@ -286,6 +286,22 @@ export const MarketsDropdown = memo(
       ) : undefined;
 
     const triggerBackground = currentMarketId === PREDICTION_MARKET.TRUMPWIN && <$TriggerFlag />;
+
+    useEffect(() => {
+      // listen for '/' key to open the dropdown
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === '/') {
+          event.preventDefault();
+          setIsOpen(true);
+        }
+      };
+
+      window.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        window.removeEventListener('keydown', handleKeyDown);
+      };
+    }, []);
 
     return (
       <$Popover


### PR DESCRIPTION
was gonna do a cool kbd element but it doesn't make sense to exist anywhere so this is a hidden power feature :3

testing:
- go to trade page
- enter '/'
- observe market dropdown open
- notice if you '/' again nothing happens (it is not a toggle!). 'esc' to leave