### PR TITLE
feat: cctp withdrawals: network select dropdown [3/n]

### DIFF
--- a/src/components/ComboboxMenu.tsx
+++ b/src/components/ComboboxMenu.tsx
@@ -76,7 +76,6 @@ export const ComboboxMenu = <
         <$Header $withStickyLayout={withStickyLayout}>
           {alternateSearchInputComponent ? (
             <$SearchInput
-              autoFocus
               value={searchValue}
               onChange={setSearchValue}
               placeholder={placeholderWithDefault}

--- a/src/components/ComboboxMenu.tsx
+++ b/src/components/ComboboxMenu.tsx
@@ -13,6 +13,8 @@ import { popoverMixins } from '@/styles/popoverMixins';
 
 import { Tag } from '@/components/Tag';
 
+import { SearchInput } from './SearchInput';
+
 type ElementProps<MenuItemValue extends string | number, MenuGroupValue extends string | number> = {
   items: MenuConfig<MenuItemValue, MenuGroupValue>;
   onItemSelected?: () => void;
@@ -21,6 +23,7 @@ type ElementProps<MenuItemValue extends string | number, MenuGroupValue extends 
   inputPlaceholder?: string;
   slotEmpty?: ReactNode;
   withSearch?: boolean;
+  useSearchInputComponent?: boolean;
 };
 
 type StyleProps = {
@@ -45,6 +48,7 @@ export const ComboboxMenu = <
   inputPlaceholder,
   slotEmpty,
   withSearch = true,
+  useSearchInputComponent,
 
   className,
   withItemBorders,
@@ -52,6 +56,8 @@ export const ComboboxMenu = <
 }: ComboboxMenuProps<MenuItemValue, MenuGroupValue>) => {
   const stringGetter = useStringGetter();
   const [searchValue, setSearchValue] = useState('');
+
+  const placeholderWithDefault = inputPlaceholder ?? stringGetter({ key: STRING_KEYS.SEARCH });
 
   return (
     <$Command
@@ -68,17 +74,26 @@ export const ComboboxMenu = <
     >
       {withSearch && (
         <$Header $withStickyLayout={withStickyLayout}>
-          <$Input
-            /**
-             * Mobile Issue: Search Input will always trigger mobile keyboard drawer. There is no fix.
-             * https://github.com/pacocoursey/cmdk/issues/127
-             */
-            autoFocus
-            value={searchValue}
-            onValueChange={setSearchValue}
-            placeholder={inputPlaceholder ?? stringGetter({ key: STRING_KEYS.SEARCH })}
-            data-hj-allow
-          />
+          {useSearchInputComponent ? (
+            <$SearchInput
+              autoFocus
+              value={searchValue}
+              onChange={setSearchValue}
+              placeholder={placeholderWithDefault}
+            />
+          ) : (
+            <$Input
+              /**
+               * Mobile Issue: Search Input will always trigger mobile keyboard drawer. There is no fix.
+               * https://github.com/pacocoursey/cmdk/issues/127
+               */
+              autoFocus
+              value={searchValue}
+              onValueChange={setSearchValue}
+              placeholder={placeholderWithDefault}
+              data-hj-allow
+            />
+          )}
         </$Header>
       )}
 
@@ -223,6 +238,14 @@ const $Command = styled(Command)<{ $withStickyLayout?: boolean }>`
             overflow-y: auto;
           }
         `}
+
+  /*
+  Layout mixins withInnerHorizontalBorders forces all children components to have box shadow
+  This creates a border-like effect that we don't want for this dropdown component
+  */
+  && > * {
+    box-shadow: none;
+  }
 `;
 
 const $Header = styled.header<{ $withStickyLayout?: boolean }>`
@@ -350,4 +373,9 @@ const $ItemLabel = styled.div`
   }
 
   min-width: 0;
+`;
+
+const $SearchInput = styled(SearchInput)`
+  margin-top: 0.75em;
+  margin-bottom: 0.5em;
 `;

--- a/src/components/ComboboxMenu.tsx
+++ b/src/components/ComboboxMenu.tsx
@@ -23,7 +23,7 @@ type ElementProps<MenuItemValue extends string | number, MenuGroupValue extends 
   inputPlaceholder?: string;
   slotEmpty?: ReactNode;
   withSearch?: boolean;
-  useSearchInputComponent?: boolean;
+  alternateSearchInputComponent?: boolean;
 };
 
 type StyleProps = {
@@ -48,7 +48,7 @@ export const ComboboxMenu = <
   inputPlaceholder,
   slotEmpty,
   withSearch = true,
-  useSearchInputComponent,
+  alternateSearchInputComponent,
 
   className,
   withItemBorders,
@@ -74,7 +74,7 @@ export const ComboboxMenu = <
     >
       {withSearch && (
         <$Header $withStickyLayout={withStickyLayout}>
-          {useSearchInputComponent ? (
+          {alternateSearchInputComponent ? (
             <$SearchInput
               autoFocus
               value={searchValue}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -50,8 +50,8 @@ export const SearchInput = ({ placeholder, onTextChange, className }: SearchInpu
 const $Search = styled.div`
   ${layoutMixins.row}
   width: auto;
-  height: 2rem;
-  background-color: var(--color-layer-3);
+  height: 2.5rem;
+  background-color: var(--color-layer-5);
   color: ${({ theme }) => theme.textTertiary};
   border-radius: 2.5rem;
   border: solid var(--border-width) var(--color-layer-6);

--- a/src/components/SearchSelectMenu.tsx
+++ b/src/components/SearchSelectMenu.tsx
@@ -28,6 +28,8 @@ type ElementProps = {
   items: MenuConfig<string, string>;
   withSearch?: boolean;
   withReceiptItems?: DetailsItem[];
+  useSearchInputComponent?: boolean;
+  inputPlaceholder?: string;
 };
 
 type StyleProps = {
@@ -45,6 +47,8 @@ export const SearchSelectMenu = ({
   items,
   withSearch = true,
   withReceiptItems,
+  useSearchInputComponent,
+  inputPlaceholder,
 }: SearchSelectMenuProps) => {
   const [open, setOpen] = useState(false);
   const searchSelectMenuRef = useRef<HTMLDivElement & HTMLButtonElement>(null);
@@ -83,6 +87,8 @@ export const SearchSelectMenu = ({
             onItemSelected={() => setOpen(false)}
             withStickyLayout
             $withSearch={withSearch}
+            inputPlaceholder={inputPlaceholder}
+            useSearchInputComponent={useSearchInputComponent}
           />
         </$Popover>
       </$WithDetailsReceipt>
@@ -123,7 +129,6 @@ const $Popover = styled(Popover)`
   border: var(--border-width) solid var(--color-layer-6);
   border-radius: 0.5rem;
   z-index: 2;
-  box-shadow: none;
 `;
 
 type ComboboxMenuStyleProps = { $withSearch?: boolean };

--- a/src/components/SearchSelectMenu.tsx
+++ b/src/components/SearchSelectMenu.tsx
@@ -28,7 +28,7 @@ type ElementProps = {
   items: MenuConfig<string, string>;
   withSearch?: boolean;
   withReceiptItems?: DetailsItem[];
-  useSearchInputComponent?: boolean;
+  alternateSearchInputComponent?: boolean;
   inputPlaceholder?: string;
 };
 
@@ -47,7 +47,7 @@ export const SearchSelectMenu = ({
   items,
   withSearch = true,
   withReceiptItems,
-  useSearchInputComponent,
+  alternateSearchInputComponent,
   inputPlaceholder,
 }: SearchSelectMenuProps) => {
   const [open, setOpen] = useState(false);
@@ -88,7 +88,7 @@ export const SearchSelectMenu = ({
             withStickyLayout
             $withSearch={withSearch}
             inputPlaceholder={inputPlaceholder}
-            useSearchInputComponent={useSearchInputComponent}
+            alternateSearchInputComponent={alternateSearchInputComponent}
           />
         </$Popover>
       </$WithDetailsReceipt>

--- a/src/constants/__test__/cctp.spec.ts
+++ b/src/constants/__test__/cctp.spec.ts
@@ -45,7 +45,21 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           name: 'Avalanche',
         },
       ],
+      '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e': [
+        {
+          chainId: '43114',
+          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+          name: 'Avalanche',
+        },
+      ],
       '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85': [
+        {
+          chainId: '10',
+          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+          name: 'optimism',
+        },
+      ],
+      '0x0b2c639c533813f4aa9d7837caf62653d097ff85': [
         {
           chainId: '10',
           tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
@@ -59,7 +73,21 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           name: 'arbitrum',
         },
       ],
+      '0xaf88d065e77c8cc2239327c5edb3a432268e5831': [
+        {
+          chainId: '42161',
+          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+          name: 'arbitrum',
+        },
+      ],
       '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': [
+        {
+          chainId: '8453',
+          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          name: 'Base',
+        },
+      ],
+      '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': [
         {
           chainId: '8453',
           tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -72,8 +100,20 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
           name: 'Polygon',
         },
+        {
+          chainId: '137',
+          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+          name: 'Polygon',
+        },
       ],
       EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: [
+        {
+          chainId: 'solana',
+          name: 'solana',
+          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        },
+      ],
+      epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v: [
         {
           chainId: 'solana',
           name: 'solana',
@@ -91,7 +131,21 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           name: 'Ethereum',
         },
       ],
+      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': [
+        {
+          chainId: '1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          name: 'Ethereum',
+        },
+      ],
       '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': [
+        {
+          chainId: '43114',
+          tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+          name: 'Avalanche',
+        },
+      ],
+      '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e': [
         {
           chainId: '43114',
           tokenAddress: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
@@ -105,7 +159,21 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           name: 'optimism',
         },
       ],
+      '0x0b2c639c533813f4aa9d7837caf62653d097ff85': [
+        {
+          chainId: '10',
+          tokenAddress: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+          name: 'optimism',
+        },
+      ],
       '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': [
+        {
+          chainId: '42161',
+          tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+          name: 'arbitrum',
+        },
+      ],
+      '0xaf88d065e77c8cc2239327c5edb3a432268e5831': [
         {
           chainId: '42161',
           tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
@@ -119,7 +187,20 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
           name: 'Base',
         },
       ],
+      '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': [
+        {
+          chainId: '8453',
+          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          name: 'Base',
+        },
+      ],
+      // This is fine, this denom is already written in lowercase so it just gets duplicated. it doesn't affect anything
       '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359': [
+        {
+          chainId: '137',
+          tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+          name: 'Polygon',
+        },
         {
           chainId: '137',
           tokenAddress: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
@@ -127,6 +208,13 @@ describe('getMapOfLowestFeeTokensByDenom', () => {
         },
       ],
       EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: [
+        {
+          chainId: 'solana',
+          name: 'solana',
+          tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        },
+      ],
+      epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v: [
         {
           chainId: 'solana',
           name: 'solana',

--- a/src/constants/cctp.ts
+++ b/src/constants/cctp.ts
@@ -2,6 +2,7 @@ import { Asset } from '@skip-go/client';
 
 import cctpTokens from '../../public/configs/cctp.json';
 import { TransferType, TransferTypeType } from './abacus';
+import { TransferType as NewTransferType } from './transfers';
 
 export type CctpTokenInfo = {
   chainId: string;
@@ -34,8 +35,10 @@ export const getMapOfLowestFeeTokensByDenom = (type: NullableTransferType) =>
     (acc, token) => {
       if (!acc[token.tokenAddress]) {
         acc[token.tokenAddress] = [];
+        acc[token.tokenAddress.toLowerCase()] = [];
       }
       acc[token.tokenAddress]!.push(token);
+      acc[token.tokenAddress.toLowerCase()]!.push(token);
       return acc;
     },
     {} as Record<string, CctpTokenInfo[]>
@@ -53,11 +56,42 @@ const getMapOfChainsByChainId = (chains: CctpTokenInfo[]) =>
     {} as Record<string, CctpTokenInfo[]>
   );
 
+// TODO: Refactor/remove these once we delete old deposit/withdraw components
 export const getMapOfLowestFeeTokensByChainId = (type: NullableTransferType) =>
   getMapOfChainsByChainId(getLowestFeeChains(type));
 
 export const getMapOfHighestFeeTokensByChainId = (type: NullableTransferType) =>
   getMapOfChainsByChainId(getHighestFeeChains(type));
+
+const lowestFeeTokensByChainIdMapDeposit = getMapOfLowestFeeTokensByChainId(TransferType.deposit);
+const lowestFeeTokensByChainIdMapWithdrawal = getMapOfLowestFeeTokensByChainId(
+  TransferType.withdrawal
+);
+
+const lowestFeeTokensByDenomDeposit = getMapOfLowestFeeTokensByDenom(TransferType.deposit);
+const lowestFeeTokensByDenomWithdrawal = getMapOfLowestFeeTokensByDenom(TransferType.withdrawal);
+
+// TODO: refactor these functions to include cosmos chains and denoms in lowest fees.
+// This will probably involve a non trivial amount of work so do in separate PR.
+export const isLowFeeChainId = (chainId: string, type: NewTransferType) => {
+  const lowFeeChainIdMap =
+    type === NewTransferType.Deposit
+      ? lowestFeeTokensByChainIdMapDeposit
+      : lowestFeeTokensByChainIdMapWithdrawal;
+  return lowFeeChainIdMap[chainId];
+};
+
+export const isHighFeeChainId = (chainId: string, type: NewTransferType) => {
+  return type === NewTransferType.Withdraw && chainId === '1';
+};
+
+export const isLowFeeDenom = (denom: string, type: NewTransferType) => {
+  const lowFeeDenomMap =
+    type === NewTransferType.Deposit
+      ? lowestFeeTokensByDenomDeposit
+      : lowestFeeTokensByDenomWithdrawal;
+  return lowFeeDenomMap[denom.toLowerCase()];
+};
 
 export const cctpTokensByDenomLowerCased = cctpTokens.reduce(
   (acc, token) => {

--- a/src/constants/transfers.ts
+++ b/src/constants/transfers.ts
@@ -1,10 +1,4 @@
-import { Asset } from '@skip-go/client';
-
 import { WalletNetworkType } from '@/constants/wallets';
-
-import { isNativeDenom } from '@/lib/assetUtils';
-
-import { isTokenCctp } from './cctp';
 
 export enum TransferType {
   Deposit = 'DEPOSIT',
@@ -87,27 +81,4 @@ export const getNetworkTypeFromWalletNetworkType = (
     return 'cosmos';
   }
   return 'evm';
-};
-
-export const getDefaultTokenDenomFromAssets = (assets: Asset[]): string | undefined => {
-  const cctpToken = assets.find((asset) => {
-    return isTokenCctp(asset);
-  });
-  const nativeChainToken = assets.find((asset) => {
-    return isNativeDenom(asset.denom);
-  });
-  const uusdcToken = assets.find((asset) => {
-    return asset.denom === 'uusdc' || asset.originDenom === 'uusdc';
-  });
-  // If not cctp, native chain, or usdc token, default to the first item in the list
-  const defaultTokenDenom =
-    cctpToken?.denom ?? nativeChainToken?.denom ?? uusdcToken?.denom ?? assets[0]?.denom;
-  return defaultTokenDenom;
-};
-
-export const getDefaultChainIDFromNetworkType = (networkType: NetworkType): string | undefined => {
-  if (networkType === 'evm') return '1';
-  if (networkType === 'svm') return 'solana';
-  if (networkType === 'cosmos') return 'noble-1';
-  return undefined;
 };

--- a/src/hooks/transfers/useTransfers.tsx
+++ b/src/hooks/transfers/useTransfers.tsx
@@ -14,8 +14,6 @@ import {
   OSMO_BECH32_PREFIX,
 } from '@/constants/graz';
 import {
-  getDefaultChainIDFromNetworkType,
-  getDefaultTokenDenomFromAssets,
   getNetworkTypeFromWalletNetworkType,
   SWAP_VENUES,
   TransferType,
@@ -26,7 +24,11 @@ import { getSelectedDydxChainId } from '@/state/appSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
 import { convertBech32Address } from '@/lib/addressUtils';
-import { isNativeDenom } from '@/lib/assetUtils';
+import {
+  getDefaultChainIDFromNetworkType,
+  getDefaultTokenDenomFromAssets,
+  isNativeDenom,
+} from '@/lib/assetUtils';
 import { MustBigNumber } from '@/lib/numbers';
 
 import { useAccounts } from '../useAccounts';

--- a/src/lib/assetUtils.ts
+++ b/src/lib/assetUtils.ts
@@ -1,4 +1,8 @@
+import { Asset } from '@skip-go/client';
+
 import { Nullable } from '@/constants/abacus';
+import { isTokenCctp } from '@/constants/cctp';
+import { NetworkType } from '@/constants/transfers';
 
 /**
  *
@@ -65,4 +69,27 @@ export const WAGMI_COSMJS_NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeee
 export const isNativeDenom = (denom: string | undefined): boolean => {
   if (!denom) return false;
   return denom === WAGMI_COSMJS_NATIVE_TOKEN_ADDRESS || denom?.endsWith(SKIP_NATIVE_DENOM_SUFFIX);
+};
+
+export const getDefaultTokenDenomFromAssets = (assets: Asset[]): string => {
+  const cctpToken = assets.find((asset) => {
+    return isTokenCctp(asset);
+  });
+  const nativeChainToken = assets.find((asset) => {
+    return isNativeDenom(asset.denom);
+  });
+  const uusdcToken = assets.find((asset) => {
+    return asset.denom === 'uusdc' || asset.originDenom === 'uusdc';
+  });
+  // If not cctp, native chain, or usdc token, default to the first item in the list
+  const defaultTokenDenom =
+    cctpToken?.denom ?? nativeChainToken?.denom ?? uusdcToken?.denom ?? assets[0]?.denom;
+  return defaultTokenDenom;
+};
+
+export const getDefaultChainIDFromNetworkType = (networkType: NetworkType): string | undefined => {
+  if (networkType === 'evm') return '1';
+  if (networkType === 'svm') return 'solana';
+  if (networkType === 'cosmos') return 'noble-1';
+  return undefined;
 };

--- a/src/lib/assetUtils.ts
+++ b/src/lib/assetUtils.ts
@@ -68,10 +68,10 @@ export const WAGMI_COSMJS_NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeee
 
 export const isNativeDenom = (denom: string | undefined): boolean => {
   if (!denom) return false;
-  return denom === WAGMI_COSMJS_NATIVE_TOKEN_ADDRESS || denom?.endsWith(SKIP_NATIVE_DENOM_SUFFIX);
+  return denom === WAGMI_COSMJS_NATIVE_TOKEN_ADDRESS || denom.endsWith(SKIP_NATIVE_DENOM_SUFFIX);
 };
 
-export const getDefaultTokenDenomFromAssets = (assets: Asset[]): string => {
+export const getDefaultTokenDenomFromAssets = (assets: Asset[]): string | undefined => {
   const cctpToken = assets.find((asset) => {
     return isTokenCctp(asset);
   });

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
@@ -1,0 +1,156 @@
+import { Chain } from '@skip-go/client';
+import tw from 'twin.macro';
+
+import { cctpTokensByChainId, isHighFeeChainId, isLowFeeChainId } from '@/constants/cctp';
+import { SUPPORTED_COSMOS_CHAINS } from '@/constants/graz';
+import { STRING_KEYS } from '@/constants/localization';
+import { TransferType } from '@/constants/transfers';
+import { ConnectorType, WalletType } from '@/constants/wallets';
+
+import { useAccounts } from '@/hooks/useAccounts';
+import { useEnvFeatures } from '@/hooks/useEnvFeatures';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { SearchSelectMenu } from '@/components/SearchSelectMenu';
+
+import { getSelectedDydxChainId } from '@/state/appSelectors';
+import { useAppSelector } from '@/state/appTypes';
+
+import { isTruthy } from '@/lib/isTruthy';
+
+import exchanges from '../../../../../public/configs/exchanges.json';
+import { HighestFeesDecoratorText } from '../HighestFeesText';
+import { LowestFeesDecoratorText } from '../LowestFeesText';
+
+type ElementProps = {
+  selectedExchange?: string;
+  selectedChain?: string;
+  onSelect: (name: string, type: 'chain' | 'exchange') => void;
+  chains: Chain[];
+};
+
+// TODO: fix this
+// our menu item types are wrong (has label typed as a react node even though we use string)
+// so we have to make our own type.
+type SelectableItem = {
+  value: string;
+  label: string;
+  onSelect: () => void;
+  slotBefore: JSX.Element;
+  slotAfter?: JSX.Element;
+};
+
+const solanaChainIdPrefix = 'solana';
+const DEFAULT_NETWORKS_LABEL = 'Networks';
+
+export const NetworkSelectMenu = ({
+  selectedExchange,
+  selectedChain,
+  onSelect,
+  chains,
+}: ElementProps) => {
+  const { sourceAccount } = useAccounts();
+  const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
+  const { CCTPWithdrawalOnly } = useEnvFeatures();
+
+  const stringGetter = useStringGetter();
+
+  const isKeplrWallet = sourceAccount.walletInfo?.name === WalletType.Keplr;
+
+  const getFeeDecoratorComponentForChainId = (chainId: string) => {
+    if (isLowFeeChainId(chainId, TransferType.Withdraw)) return <LowestFeesDecoratorText />;
+    if (isHighFeeChainId(chainId, TransferType.Withdraw)) return <HighestFeesDecoratorText />;
+    return undefined;
+  };
+
+  const chainItems = chains
+    .map((chain) => ({
+      value: chain.chainID,
+      label: chain.chainName,
+      onSelect: () => {
+        onSelect(chain.chainID, 'chain');
+      },
+      slotBefore: <$Img src={chain.logoURI ?? undefined} alt="" />,
+      slotAfter: getFeeDecoratorComponentForChainId(chain.chainID),
+    }))
+    .filter((chain) => {
+      // only cosmos chains are supported on kepler
+      if (isKeplrWallet) {
+        return selectedDydxChainId !== chain.value && SUPPORTED_COSMOS_CHAINS.includes(chain.value);
+      }
+      // only solana chains are supported on phantom
+      if (sourceAccount.walletInfo?.connectorType === ConnectorType.PhantomSolana) {
+        return selectedDydxChainId !== chain.value && chain.value.startsWith(solanaChainIdPrefix);
+      }
+      // other wallets do not support solana
+      if (chain.value.startsWith(solanaChainIdPrefix)) return false;
+
+      if (CCTPWithdrawalOnly) {
+        return !!cctpTokensByChainId[chain.value];
+      }
+
+      return true;
+    });
+
+  const { lowFeeChains, nonLowFeeChains } = chainItems.reduce(
+    (allChains, nextChain) => {
+      if (isLowFeeChainId(nextChain.value, TransferType.Withdraw))
+        allChains.lowFeeChains.push(nextChain);
+      else allChains.nonLowFeeChains.push(nextChain);
+      return allChains;
+    },
+    { lowFeeChains: [], nonLowFeeChains: [] } as {
+      lowFeeChains: SelectableItem[];
+      nonLowFeeChains: SelectableItem[];
+    }
+  );
+
+  // TODO: actually configure exchanges
+  const exchangeItems = Object.values(exchanges).map((exchange) => ({
+    value: exchange.name,
+    label: exchange.label,
+    onSelect: () => {
+      onSelect(exchange.name, 'exchange');
+    },
+    slotBefore: <$Img src={exchange.icon ?? undefined} alt="" />,
+    slotAfter: <LowestFeesDecoratorText />,
+  }));
+  const selectedChainOption = chains.find((item) => item.chainID === selectedChain);
+  const selectedExchangeOption = exchanges.find((item) => item.name === selectedExchange);
+
+  // If there's only one group, no need to differentiate between Low Fee or not
+  const items = [
+    lowFeeChains.length && {
+      group: 'low-fees',
+      groupLabel: nonLowFeeChains.length ? 'Low Fees' : DEFAULT_NETWORKS_LABEL,
+      items: [...exchangeItems, ...lowFeeChains],
+    },
+    nonLowFeeChains.length && {
+      group: 'other-networks',
+      groupLabel: lowFeeChains.length ? 'Other networks' : DEFAULT_NETWORKS_LABEL,
+      items: nonLowFeeChains,
+    },
+  ];
+
+  return (
+    <SearchSelectMenu items={items.filter(isTruthy)} label="Destination">
+      <div tw="row gap-0.5 text-color-text-2 font-base-book">
+        {selectedChainOption ? (
+          <>
+            <$Img src={selectedChainOption.logoURI ?? undefined} alt="" />{' '}
+            {selectedChainOption.chainName}
+          </>
+        ) : selectedExchangeOption ? (
+          <>
+            <$Img src={selectedExchangeOption.icon ?? undefined} alt="" />{' '}
+            {selectedExchangeOption.name}
+          </>
+        ) : (
+          stringGetter({ key: STRING_KEYS.SELECT_CHAIN })
+        )}
+      </div>
+    </SearchSelectMenu>
+  );
+};
+
+const $Img = tw.img`h-1.25 w-1.25 rounded-[50%]`;

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
@@ -19,8 +19,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { isTruthy } from '@/lib/isTruthy';
 
 import exchanges from '../../../../../public/configs/exchanges.json';
-import { HighestFeesDecoratorText } from '../HighestFeesText';
-import { LowestFeesDecoratorText } from '../LowestFeesText';
+import { FeeLevel, FeeLevelTag } from '../FeeLevelTag';
 
 type ElementProps = {
   selectedExchange?: string;
@@ -58,8 +57,10 @@ export const NetworkSelectMenu = ({
   const isKeplrWallet = sourceAccount.walletInfo?.name === WalletType.Keplr;
 
   const getFeeDecoratorComponentForChainId = (chainId: string) => {
-    if (isLowFeeChainId(chainId, TransferType.Withdraw)) return <LowestFeesDecoratorText />;
-    if (isHighFeeChainId(chainId, TransferType.Withdraw)) return <HighestFeesDecoratorText />;
+    if (isLowFeeChainId(chainId, TransferType.Withdraw))
+      return <FeeLevelTag feeLevel={FeeLevel.Low} />;
+    if (isHighFeeChainId(chainId, TransferType.Withdraw))
+      return <FeeLevelTag feeLevel={FeeLevel.High} />;
     return undefined;
   };
 
@@ -112,8 +113,8 @@ export const NetworkSelectMenu = ({
     onSelect: () => {
       onSelect(exchange.name, 'exchange');
     },
-    slotBefore: <$Img src={exchange.icon ?? undefined} alt="" />,
-    slotAfter: <LowestFeesDecoratorText />,
+    slotBefore: <$Img src={exchange.icon} alt="" />,
+    slotAfter: <FeeLevelTag feeLevel={FeeLevel.Low} />,
   }));
   const selectedChainOption = chains.find((item) => item.chainID === selectedChain);
   const selectedExchangeOption = exchanges.find((item) => item.name === selectedExchange);
@@ -142,8 +143,7 @@ export const NetworkSelectMenu = ({
           </>
         ) : selectedExchangeOption ? (
           <>
-            <$Img src={selectedExchangeOption.icon ?? undefined} alt="" />{' '}
-            {selectedExchangeOption.name}
+            <$Img src={selectedExchangeOption.icon} alt="" /> {selectedExchangeOption.name}
           </>
         ) : (
           stringGetter({ key: STRING_KEYS.SELECT_CHAIN })

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
@@ -105,7 +105,7 @@ export const NetworkSelectMenu = ({
     }
   );
 
-  // TODO: actually configure exchanges
+  // TODO [onboarding-rewrite]: configure exchanges
   const exchangeItems = Object.values(exchanges).map((exchange) => ({
     value: exchange.name,
     label: exchange.label,

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
@@ -13,7 +13,7 @@ import { SearchSelectMenu } from '@/components/SearchSelectMenu';
 import { isTruthy } from '@/lib/isTruthy';
 
 import exchanges from '../../../../../public/configs/exchanges.json';
-import { FeeLevel, FeeLevelTag } from '../FeeLevelTag';
+import { FeeLevelTag } from '../FeeLevelTag';
 
 type ElementProps = {
   selectedExchange?: string;
@@ -33,10 +33,8 @@ export const NetworkSelectMenu = ({
   const stringGetter = useStringGetter();
 
   const getFeeDecoratorComponentForChainId = (chainId: string) => {
-    if (isLowFeeChainId(chainId, TransferType.Withdraw))
-      return <FeeLevelTag feeLevel={FeeLevel.Low} />;
-    if (isHighFeeChainId(chainId, TransferType.Withdraw))
-      return <FeeLevelTag feeLevel={FeeLevel.High} />;
+    if (isLowFeeChainId(chainId, TransferType.Withdraw)) return <FeeLevelTag feeLevel="low" />;
+    if (isHighFeeChainId(chainId, TransferType.Withdraw)) return <FeeLevelTag feeLevel="high" />;
     return undefined;
   };
 
@@ -75,7 +73,7 @@ export const NetworkSelectMenu = ({
       onSelect(exchange.name, 'exchange');
     },
     slotBefore: <$Img src={exchange.icon} alt="" />,
-    slotAfter: <FeeLevelTag feeLevel={FeeLevel.Low} />,
+    slotAfter: <FeeLevelTag feeLevel="low" />,
   }));
   const selectedChainOption = chains.find((item) => item.chainID === selectedChain);
   const selectedExchangeOption = exchanges.find((item) => item.name === selectedExchange);


### PR DESCRIPTION
Followed by https://github.com/dydxprotocol/v4-web/pull/1156

Adds networkselectmenu.
Adds useSearchInputComponent prop that renders the SearchInput component instead, [as specified by figma mocks](https://www.figma.com/design/fMQodZKzn9B5aZTN5G0fLJ/dYdX-%E2%80%BA-Web?node-id=41402-168816&node-type=frame&t=HtXCnIXhOiY4jfOY-0)

**This will make our search inputs bigger in general since i'm increasing the size from 2 to 2.5rem**

NOTE: I opted to not use a general component override prop since we don't don't have a usecase for it yet and it feels like a great "rule of three" moment to avoid overengineering something we dont need

It's not quite identical to the figma specs due to:
- the existing search input component just looks slightly different (magnifying glass opposite direction)
- we don't have the capability to show fees for the network beforehand since they're dynamically calculated so i made my best attempt at a reasonable fallback design.
<img width="481" alt="image" src="https://github.com/user-attachments/assets/18d414e7-be15-4515-931d-4b7026b40a92">


example of the updated search input. i think it looks great TBH. but i can make the size an override prop if people feel strongly
<img width="722" alt="image" src="https://github.com/user-attachments/assets/85d192d7-a3ba-44bb-bf23-6e8d583154ca">

