### PR TITLE
fix: fix truncation on pagination rows

### DIFF
--- a/src/components/Table/TablePaginationRow.tsx
+++ b/src/components/Table/TablePaginationRow.tsx
@@ -59,6 +59,7 @@ export const TablePaginationRow = ({
           value={pageNumberToDisplay(currentPage)}
           items={pages}
           onValueChange={(pageNumber: string) => setCurrentPage(Number(pageNumber) - 1)}
+          truncateLabel={false}
         />
         <IconButton
           {...buttonProps}

--- a/src/components/ToggleGroup.tsx
+++ b/src/components/ToggleGroup.tsx
@@ -27,6 +27,7 @@ type ElementProps<MenuItemValue extends string> = {
 type StyleProps = {
   className?: string;
   overflow?: 'scroll' | 'wrap';
+  truncateLabel?: boolean;
 };
 
 export const ToggleGroup = forwardRefFn(
@@ -40,6 +41,7 @@ export const ToggleGroup = forwardRefFn(
 
       className,
       overflow = 'scroll',
+      truncateLabel = true,
       size,
       shape = ButtonShape.Pill,
 
@@ -82,7 +84,7 @@ export const ToggleGroup = forwardRefFn(
                 {...buttonProps}
               >
                 {item.slotBefore}
-                <$Label>{item.label}</$Label>
+                {truncateLabel ? <$Label>{item.label}</$Label> : item.label}
                 {item.slotAfter}
               </ToggleButton>
             </Item>
@@ -110,8 +112,6 @@ const $Root = styled(Root)<{
 
 const $Label = styled.div`
   ${layoutMixins.textTruncate}
-  // don't truncate 2 characters
-  min-width: 1rem;
 `;
 
 const $HorizontalScrollContainer = styled.div<{


### PR DESCRIPTION
temp fix was breaking if pagination was in the hundreds, so just disabled truncation on buttons in pagination row
<img width="984" alt="Screenshot 2024-10-16 at 1 20 28 PM" src="https://github.com/user-attachments/assets/8c5af4f3-0a34-4f44-93fd-b55aed0fb708">
