### PR TITLE
feat: dismissable affiliate banner

### DIFF
--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -21,6 +21,8 @@ import { TelegramInviteBanner } from '@/views/TelegramInviteBanner';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
 import { calculateShouldRenderActionsInPositionsTable } from '@/state/accountCalculators';
+import { useAppSelector } from '@/state/appTypes';
+import { getDismissedAffiliateBanner } from '@/state/dismissableSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
 
@@ -41,6 +43,7 @@ export const Overview = () => {
   const shouldShowTelegramInvite =
     dydxAddress && feedbackRequestWalletAddresses?.includes(dydxAddress);
   const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
+  const dismissedAffiliateBanner = useAppSelector(getDismissedAffiliateBanner);
 
   const handleViewUnopenedIsolatedOrders = useCallback(() => {
     navigate(`${AppRoute.Portfolio}/${PortfolioRoute.Orders}`, {
@@ -55,6 +58,12 @@ export const Overview = () => {
 
   return (
     <div>
+      {affiliatesEnabled && !dismissedAffiliateBanner && !isTablet && (
+        <DetachedSection>
+          <AffiliatesBanner withClose />
+        </DetachedSection>
+      )}
+
       {shouldShowTelegramInvite && (
         <DetachedSection>
           <TelegramInviteBanner />
@@ -69,7 +78,7 @@ export const Overview = () => {
         <AccountDetailsAndHistory />
       </DetachedSection>
 
-      {affiliatesEnabled && (
+      {affiliatesEnabled && isTablet && (
         <DetachedSection>
           <AffiliatesBanner />
         </DetachedSection>

--- a/src/state/dismissable.ts
+++ b/src/state/dismissable.ts
@@ -3,10 +3,12 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export interface DismissableState {
   hasSeenPredictionMarketIntroDialog: boolean;
+  dismissedAffiliateBanner: boolean;
 }
 
 const initialState: DismissableState = {
   hasSeenPredictionMarketIntroDialog: false,
+  dismissedAffiliateBanner: false,
 };
 
 export const dismissableSlice = createSlice({
@@ -16,7 +18,11 @@ export const dismissableSlice = createSlice({
     setHasSeenPredictionMarketIntroDialog: (state, action: PayloadAction<boolean>) => {
       state.hasSeenPredictionMarketIntroDialog = action.payload;
     },
+    setDismissedAffiliateBanner: (state, action: PayloadAction<boolean>) => {
+      state.dismissedAffiliateBanner = action.payload;
+    },
   },
 });
 
-export const { setHasSeenPredictionMarketIntroDialog } = dismissableSlice.actions;
+export const { setHasSeenPredictionMarketIntroDialog, setDismissedAffiliateBanner } =
+  dismissableSlice.actions;

--- a/src/state/dismissableSelectors.ts
+++ b/src/state/dismissableSelectors.ts
@@ -2,3 +2,6 @@ import { type RootState } from './_store';
 
 export const getHasSeenPredictionMarketIntroDialog = (state: RootState) =>
   state.dismissable.hasSeenPredictionMarketIntroDialog;
+
+export const getDismissedAffiliateBanner = (state: RootState) =>
+  state.dismissable.dismissedAffiliateBanner;

--- a/src/state/migrations/2.ts
+++ b/src/state/migrations/2.ts
@@ -23,6 +23,7 @@ export function migration2(state: PersistedState | undefined): V2State {
     ...state,
     dismissable: {
       hasSeenPredictionMarketIntroDialog: hasSeenPredictionMarketsIntro ?? false,
+      dismissedAffiliateBanner: false,
     },
   };
 }

--- a/src/views/AffiliatesBanner.tsx
+++ b/src/views/AffiliatesBanner.tsx
@@ -5,7 +5,7 @@ import {
   AFFILIATES_FEE_DISCOUNT_USD,
   DEFAULT_AFFILIATES_EARN_PER_MONTH_USD,
 } from '@/constants/affiliates';
-import { ButtonAction, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
@@ -19,13 +19,15 @@ import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Button } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
+import { IconButton } from '@/components/IconButton';
 import { Link } from '@/components/Link';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getGridBackground } from '@/state/configsSelectors';
 import { openDialog } from '@/state/dialogs';
+import { setDismissedAffiliateBanner } from '@/state/dismissable';
 
-export const AffiliatesBanner = () => {
+export const AffiliatesBanner = ({ withClose = false }: { withClose?: boolean }) => {
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
@@ -89,8 +91,16 @@ export const AffiliatesBanner = () => {
   return (
     <$Background
       backgroundImagePath={background}
-      tw="row mb-1 mt-1 justify-between gap-0.5 bg-color-layer-1 pl-1 pr-2"
+      tw="row mb-1 justify-between gap-0.5 bg-color-layer-1 pl-1 pr-2"
     >
+      {withClose && (
+        <$CloseButton
+          iconName={IconName.Close}
+          shape={ButtonShape.Circle}
+          size={ButtonSize.XSmall}
+          onClick={() => dispatch(setDismissedAffiliateBanner(true))}
+        />
+      )}
       <div tw="row">
         <img src="/affiliates-hedgie.png" alt="affiliates hedgie" tw="mt-1 h-8" />
         <div tw="column items-start gap-0.5">
@@ -123,6 +133,8 @@ const $Background = styled.div<{ backgroundImagePath: string }>`
   --color-border: transparent;
   ${layoutMixins.withOuterBorderClipped}
 
+  position: relative;
+
   ${({ backgroundImagePath }) => css`
     background: url(${backgroundImagePath});
   `}
@@ -144,4 +156,10 @@ const $Triangle = styled.div`
   border-top: 0.5rem solid transparent;
   border-bottom: 0.5rem solid transparent;
   border-right: 0.5rem solid var(--color-layer-6);
+`;
+
+const $CloseButton = styled(IconButton)`
+  position: absolute;
+  right: 0.5rem;
+  top: 0.5rem;
 `;


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2024-10-17 at 1 20 59 PM" src="https://github.com/user-attachments/assets/6215710b-3062-4b78-b873-0601644a5856">


On desktop, move the affiliate banner to top of overview page and allow it to be dismissable.