### PR TITLE
feat: add previous page to navigatePage [OTE-768]

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -139,6 +139,7 @@ export const AnalyticsEvents = unionize(
     // Navigation
     NavigatePage: ofType<{
       path: string;
+      previousPath: string;
     }>(),
     NavigateDialog: ofType<{
       type: DialogTypesTypes;

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { shallowEqual } from 'react-redux';
 import { useLocation } from 'react-router-dom';
@@ -150,14 +150,16 @@ export const useAnalytics = () => {
       );
     }
   }, [status]);
-
   // AnalyticsEvent.NavigatePage
   const location = useLocation();
-
+  const previousPathRef = useRef(location.pathname);
   useEffect(() => {
     // Ignore hashchange events from <iframe>s x_x
-    if (location.pathname.startsWith('/'))
-      track(AnalyticsEvents.NavigatePage({ path: location.pathname }));
+    if (location.pathname.startsWith('/')) {
+      const previousPath = previousPathRef.current;
+      track(AnalyticsEvents.NavigatePage({ path: location.pathname, previousPath }));
+      previousPathRef.current = location.pathname;
+    }
   }, [location]);
 
   // AnalyticsEvent.NavigateDialog


### PR DESCRIPTION
Uses a ref to track the previous location pathname outside of the react lifecycle. if people are spooked by this i'm happy to use another approach but it feels pretty stable to me