### PR TITLE
feat(uirefresh): component refresh - trade box [1/2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-abacus": "1.13.0",
     "@dydxprotocol/v4-client-js": "1.11.1",
-    "@dydxprotocol/v4-localization": "^1.1.222",
+    "@dydxprotocol/v4-localization": "^1.1.225",
     "@dydxprotocol/v4-proto": "^7.0.0-dev.0",
     "@emotion/is-prop-valid": "^1.3.0",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: 1.11.1
     version: 1.11.1
   '@dydxprotocol/v4-localization':
-    specifier: ^1.1.222
-    version: 1.1.222
+    specifier: ^1.1.225
+    version: 1.1.225
   '@dydxprotocol/v4-proto':
     specifier: ^7.0.0-dev.0
     version: 7.0.0-dev.0
@@ -2836,8 +2836,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.222:
-    resolution: {integrity: sha512-YR/YQrPpoZqOlb6kRV+uwi6F9eABLYDpW3/XbNkF6TyqM0DJWF6W5acAcmDycCc2qR9+RFhcZLJ7a6LRW4pbfg==}
+  /@dydxprotocol/v4-localization@1.1.225:
+    resolution: {integrity: sha512-n+exz6NB6qD2vzDGXT4j1GtLgp92iOi+eXojoasNDBtp8kFocUDFqS2YGTg0IxKsXWQJ8yszkJFQsILcJdwEtA==}
     dev: false
 
   /@dydxprotocol/v4-proto@7.0.0-dev.0:

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -5,6 +5,7 @@ import {
   ButtonShape,
   ButtonSize,
   ButtonState,
+  ButtonStyle,
   ButtonType,
 } from '@/constants/buttons';
 
@@ -50,5 +51,10 @@ ButtonStory.argTypes = {
     options: Object.values(ButtonShape),
     control: { type: 'select' },
     defaultValue: ButtonShape.Rectangle,
+  },
+  buttonStyle: {
+    options: Object.values(ButtonStyle),
+    control: { type: 'select' },
+    defaultValue: ButtonStyle.Default,
   },
 };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,13 @@ import { forwardRef } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { ButtonAction, ButtonShape, ButtonSize, ButtonState } from '@/constants/buttons';
+import {
+  ButtonAction,
+  ButtonShape,
+  ButtonSize,
+  ButtonState,
+  ButtonStyle,
+} from '@/constants/buttons';
 
 import { LoadingDots } from '@/components/Loading/LoadingDots';
 
@@ -28,6 +34,7 @@ type ElementProps = {
 type StyleProps = {
   action?: ButtonAction;
   state: Record<string, boolean | undefined>;
+  buttonStyle?: ButtonStyle;
   className?: string;
 };
 
@@ -40,6 +47,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
       size = ButtonSize.Base,
       shape = ButtonShape.Rectangle,
       state: stateConfig = ButtonState.Default,
+      buttonStyle = ButtonStyle.Default,
 
       children,
       slotLeft = null,
@@ -61,7 +69,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
     return (
       <StyledBaseButton
         disabled={!!state[ButtonState.Disabled] || !!state[ButtonState.Loading]}
-        {...{ ref, action, size, shape, state, ...otherProps }}
+        {...{ ref, action, size, shape, state, buttonStyle, ...otherProps }}
       >
         {state[ButtonState.Loading] ? (
           <>
@@ -83,92 +91,145 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 );
 
 const buttonActionVariants = {
-  [ButtonAction.Base]: css`
-    --button-textColor: var(--color-text-1);
-    --button-backgroundColor: var(--color-layer-5);
-    --button-border: solid var(--border-width) var(--color-border);
-  `,
-  [ButtonAction.Primary]: css`
-    --button-textColor: var(--color-text-button);
-    --button-backgroundColor: var(--color-accent);
-    --button-border: solid var(--border-width) var(--color-border-white);
-    --button-hover-filter: brightness(var(--hover-filter-variant));
-  `,
+  [ButtonAction.Base]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-1);
+      --button-backgroundColor: var(--color-layer-5);
+      --button-border: solid var(--border-width) var(--color-border);
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-text-1);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+    `,
+  },
+  [ButtonAction.Primary]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-button);
+      --button-backgroundColor: var(--color-accent);
+      --button-border: solid var(--border-width) var(--color-border-white);
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-accent);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+  },
 
-  [ButtonAction.Secondary]: css`
-    --button-textColor: var(--color-text-1);
-    --button-backgroundColor: var(--color-layer-3);
-    --button-border: solid var(--border-width) var(--color-border);
-  `,
+  [ButtonAction.Secondary]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-1);
+      --button-backgroundColor: var(--color-layer-3);
+      --button-border: solid var(--border-width) var(--color-border);
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-text-0);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+    `,
+  },
 
-  [ButtonAction.Create]: css`
-    --button-textColor: var(--color-text-button);
-    --button-backgroundColor: var(--color-green);
-    --button-border: solid var(--border-width) var(--color-border-white);
-    --button-hover-filter: brightness(var(--hover-filter-variant));
-  `,
+  [ButtonAction.Create]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-button);
+      --button-backgroundColor: var(--color-green);
+      --button-border: solid var(--border-width) var(--color-border-white);
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-green);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+  },
 
-  [ButtonAction.Destroy]: css`
-    --button-textColor: var(--color-text-button);
-    --button-backgroundColor: var(--color-red);
-    --button-border: solid var(--border-width) var(--color-border-white);
-    --button-hover-filter: brightness(var(--hover-filter-variant));
-  `,
+  [ButtonAction.Destroy]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-button);
+      --button-backgroundColor: var(--color-red);
+      --button-border: solid var(--border-width) var(--color-border-white);
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-red);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+  },
 
-  [ButtonAction.Navigation]: css`
-    --button-textColor: var(--color-text-1);
-    --button-backgroundColor: transparent;
-    --button-border: none;
-  `,
+  [ButtonAction.Navigation]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-text-1);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-text-1);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+    `,
+  },
 
-  [ButtonAction.Reset]: css`
-    --button-textColor: var(--color-red);
-    --button-backgroundColor: var(--color-layer-3);
-    --button-border: solid var(--border-width) var(--color-border-red);
-    --button-hover-filter: brightness(var(--hover-filter-variant));
-  `,
+  [ButtonAction.Reset]: {
+    [ButtonStyle.Default]: css`
+      --button-textColor: var(--color-red);
+      --button-backgroundColor: var(--color-layer-3);
+      --button-border: solid var(--border-width) var(--color-border-red);
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+    [ButtonStyle.WithoutBackground]: css`
+      --button-textColor: var(--color-red);
+      --button-backgroundColor: transparent;
+      --button-border: none;
+      --button-hover-filter: brightness(var(--hover-filter-variant));
+    `,
+  },
 };
 
-const getDisabledStateForButtonAction = (action?: ButtonAction) => {
-  switch (action) {
-    case ButtonAction.Navigation:
-      return css`
-        --button-textColor: var(--color-text-0);
-        --button-hover-filter: none;
-        --button-cursor: not-allowed;
-      `;
-    default:
-      return css`
-        --button-textColor: var(--color-text-0);
-        --button-backgroundColor: var(--color-layer-2);
-        --button-border: solid var(--border-width) var(--color-layer-6);
-        --button-hover-filter: none;
-        --button-cursor: not-allowed;
-      `;
+const getDisabledStateForButtonAction = (action?: ButtonAction, buttonStyle?: ButtonStyle) => {
+  if (action === ButtonAction.Navigation || buttonStyle === ButtonStyle.WithoutBackground) {
+    return css`
+      --button-textColor: var(--color-text-0);
+      --button-hover-filter: none;
+      --button-cursor: not-allowed;
+    `;
   }
+  return css`
+    --button-textColor: var(--color-text-0);
+    --button-backgroundColor: var(--color-layer-2);
+    --button-border: solid var(--border-width) var(--color-layer-6);
+    --button-hover-filter: none;
+    --button-cursor: not-allowed;
+  `;
 };
 
 const buttonStateVariants = (
-  action?: ButtonAction
+  action?: ButtonAction,
+  buttonStyle?: ButtonStyle
 ): Record<ButtonState, ReturnType<typeof css>> => ({
   [ButtonState.Default]: css``,
 
-  [ButtonState.Disabled]: getDisabledStateForButtonAction(action),
+  [ButtonState.Disabled]: getDisabledStateForButtonAction(action, buttonStyle),
 
   [ButtonState.Loading]: css`
-    ${() => buttonStateVariants(action)[ButtonState.Disabled]}
+    ${() => buttonStateVariants(action, buttonStyle)[ButtonState.Disabled]}
     min-width: 4em;
   `,
 });
 
 const StyledBaseButton = styled(BaseButton)<StyleProps>`
-  ${({ action }) => action && buttonActionVariants[action]}
+  ${({ action, buttonStyle }) => action && buttonStyle && buttonActionVariants[action][buttonStyle]}
 
-  ${({ action, state }) =>
+  ${({ action, state, buttonStyle }) =>
     state &&
     css`
       // Ordered from lowest to highest priority (ie. Disabled should overwrite Active and Loading states)
-      ${state[ButtonState.Loading] && buttonStateVariants(action)[ButtonState.Loading]}
-      ${state[ButtonState.Disabled] && buttonStateVariants(action)[ButtonState.Disabled]}
+      ${state[ButtonState.Loading] && buttonStateVariants(action, buttonStyle)[ButtonState.Loading]}
+      ${state[ButtonState.Disabled] &&
+      buttonStateVariants(action, buttonStyle)[ButtonState.Disabled]}
     `}
 `;

--- a/src/constants/buttons.ts
+++ b/src/constants/buttons.ts
@@ -36,3 +36,8 @@ export enum ButtonState {
   Disabled = 'Disabled',
   Loading = 'Loading',
 }
+
+export enum ButtonStyle {
+  Default = 'Default',
+  WithoutBackground = 'WithoutBackground',
+}

--- a/src/constants/tooltips/trade.ts
+++ b/src/constants/tooltips/trade.ts
@@ -130,6 +130,10 @@ export const tradeTooltips = {
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.MARGIN_USAGE_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.MARGIN_USAGE_BODY }),
   }),
+  'margin-used': ({ stringGetter }) => ({
+    title: stringGetter({ key: TOOLTIP_STRING_KEYS.MARGIN_USED_TITLE }),
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.MARGIN_USED_BODY }),
+  }),
   'maximum-leverage': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.MAXIMUM_LEVERAGE_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.MAXIMUM_LEVERAGE_BODY }),
@@ -161,6 +165,18 @@ export const tradeTooltips = {
   'partial-close-take-profit': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.PARTIAL_CLOSE_TAKE_PROFIT_TITLE }),
     body: stringGetter({ key: TOOLTIP_STRING_KEYS.PARTIAL_CLOSE_TAKE_PROFIT_BODY }),
+  }),
+  'portfolio-value': ({ stringGetter }) => ({
+    title: stringGetter({ key: TOOLTIP_STRING_KEYS.PORTFOLIO_VALUE_TITLE }),
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.PORTFOLIO_VALUE_BODY }),
+  }),
+  'position-leverage': ({ stringGetter }) => ({
+    title: stringGetter({ key: TOOLTIP_STRING_KEYS.POSITION_LEVERAGE_TITLE }),
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.POSITION_LEVERAGE_BODY }),
+  }),
+  'position-margin': ({ stringGetter }) => ({
+    title: stringGetter({ key: TOOLTIP_STRING_KEYS.POSITION_MARGIN_TITLE }),
+    body: stringGetter({ key: TOOLTIP_STRING_KEYS.POSITION_MARGIN_BODY }),
   }),
   'post-only': ({ stringGetter }) => ({
     title: stringGetter({ key: TOOLTIP_STRING_KEYS.POST_ONLY_TITLE }),

--- a/src/pages/trade/MobileTopPanel.tsx
+++ b/src/pages/trade/MobileTopPanel.tsx
@@ -55,7 +55,9 @@ export const MobileTopPanel = ({
 
   const items = [
     {
-      content: <AccountInfo tw="[--account-info-section-height:--tabContent-height]" />,
+      content: (
+        <AccountInfo tw="[--account-info-section-height-deprecated:--tabContent-height] [--account-info-section-height:--tabContent-height]" />
+      ),
       label: stringGetter({ key: STRING_KEYS.WALLET }),
       value: Tab.Account,
       icon: IconName.Coins,

--- a/src/pages/trade/Trade.tsx
+++ b/src/pages/trade/Trade.tsx
@@ -35,6 +35,8 @@ import { VerticalPanel } from './VerticalPanel';
 const TradePage = () => {
   const tradePageRef = useRef<HTMLDivElement>(null);
 
+  const { uiRefresh, pml } = testFlags;
+
   const { isViewingUnlaunchedMarket } = useCurrentMarketId();
   const { isTablet } = useBreakpoints();
   const tradeLayout = useAppSelector(getSelectedTradeLayout);
@@ -45,7 +47,7 @@ const TradePage = () => {
   usePageTitlePriceUpdates();
   useTradeFormInputs();
 
-  if (isViewingUnlaunchedMarket && testFlags.pml) {
+  if (isViewingUnlaunchedMarket && pml) {
     return <LaunchableMarket />;
   }
 
@@ -80,8 +82,9 @@ const TradePage = () => {
       </header>
 
       <$GridSection gridArea="Side" tw="grid-rows-[auto_minmax(0,1fr)]">
-        <AccountInfo />
+        {!uiRefresh && <AccountInfo />}
         <TradeBox />
+        {uiRefresh && <AccountInfo />}
       </$GridSection>
 
       <$GridSection gridArea="Vertical">

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -27,7 +27,8 @@
   --tableHeader-height: 2.5rem;
   --tableHeader-height-mobile: 3.25rem;
 
-  --account-info-section-height: 7rem;
+  --account-info-section-height-deprecated: 7rem;
+  --account-info-section-height: 5.5rem;
   --position-details-width: 23rem;
 
   /* Auto grid constants */

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -28,7 +28,7 @@
   --tableHeader-height-mobile: 3.25rem;
 
   --account-info-section-height-deprecated: 7rem;
-  --account-info-section-height: 5.5rem;
+  --account-info-section-height: 6.25rem;
   --position-details-width: 23rem;
 
   /* Auto grid constants */

--- a/src/views/AccountInfo.tsx
+++ b/src/views/AccountInfo.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { OnboardingState } from '@/constants/account';
 import { STRING_KEYS } from '@/constants/localization';
 
+import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -23,6 +24,8 @@ type StyleProps = {
 
 export const AccountInfo: React.FC = ({ className }: StyleProps) => {
   const stringGetter = useStringGetter();
+  const { isTablet } = useBreakpoints();
+
   const onboardingState = useAppSelector(getOnboardingState);
   const canViewAccountInfo = useAppSelector(calculateCanViewAccount);
 
@@ -34,7 +37,9 @@ export const AccountInfo: React.FC = ({ className }: StyleProps) => {
       showAccountInfo={canViewAccountInfo}
       $uiRefreshEnabled={uiRefresh}
     >
-      {onboardingState === OnboardingState.AccountConnected || canViewAccountInfo || uiRefresh ? (
+      {onboardingState === OnboardingState.AccountConnected ||
+      canViewAccountInfo ||
+      (uiRefresh && !isTablet) ? (
         <AccountInfoSection />
       ) : (
         <$DisconnectedAccountInfoContainer>

--- a/src/views/AccountInfo.tsx
+++ b/src/views/AccountInfo.tsx
@@ -13,6 +13,8 @@ import { calculateCanViewAccount } from '@/state/accountCalculators';
 import { getOnboardingState } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
+import { testFlags } from '@/lib/testFlags';
+
 import { AccountInfoConnectedState } from './AccountInfo/AccountInfoConnectedState';
 
 type StyleProps = {
@@ -24,9 +26,15 @@ export const AccountInfo: React.FC = ({ className }: StyleProps) => {
   const onboardingState = useAppSelector(getOnboardingState);
   const canViewAccountInfo = useAppSelector(calculateCanViewAccount);
 
+  const { uiRefresh } = testFlags;
+
   return (
-    <$AccountInfoSectionContainer className={className} showAccountInfo={canViewAccountInfo}>
-      {onboardingState === OnboardingState.AccountConnected || canViewAccountInfo ? (
+    <$AccountInfoSectionContainer
+      className={className}
+      showAccountInfo={canViewAccountInfo}
+      $uiRefreshEnabled={uiRefresh}
+    >
+      {onboardingState === OnboardingState.AccountConnected || canViewAccountInfo || uiRefresh ? (
         <AccountInfoConnectedState />
       ) : (
         <$DisconnectedAccountInfoContainer>
@@ -59,13 +67,26 @@ const $DisconnectedAccountInfoContainer = styled.div`
   }
 `;
 
-const $AccountInfoSectionContainer = styled.div<{ showAccountInfo?: boolean }>`
+const $AccountInfoSectionContainer = styled.div<{
+  showAccountInfo?: boolean;
+  $uiRefreshEnabled: boolean;
+}>`
   ${layoutMixins.column}
-  height: var(--account-info-section-height);
-  min-height: var(--account-info-section-height);
 
-  ${({ showAccountInfo }) =>
+  ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled
+      ? css`
+          height: var(--account-info-section-height);
+          min-height: var(--account-info-section-height);
+        `
+      : css`
+          height: var(--account-info-section-height-deprecated);
+          min-height: var(--account-info-section-height-deprecated);
+        `}
+
+  ${({ showAccountInfo, $uiRefreshEnabled }) =>
     !showAccountInfo &&
+    !$uiRefreshEnabled &&
     css`
       padding: 1.125em 1.25em 0.875em;
     `}

--- a/src/views/AccountInfo.tsx
+++ b/src/views/AccountInfo.tsx
@@ -15,7 +15,7 @@ import { useAppSelector } from '@/state/appTypes';
 
 import { testFlags } from '@/lib/testFlags';
 
-import { AccountInfoConnectedState } from './AccountInfo/AccountInfoConnectedState';
+import { AccountInfoSection } from './AccountInfo/AccountInfoSection';
 
 type StyleProps = {
   className?: string;
@@ -35,7 +35,7 @@ export const AccountInfo: React.FC = ({ className }: StyleProps) => {
       $uiRefreshEnabled={uiRefresh}
     >
       {onboardingState === OnboardingState.AccountConnected || canViewAccountInfo || uiRefresh ? (
-        <AccountInfoConnectedState />
+        <AccountInfoSection />
       ) : (
         <$DisconnectedAccountInfoContainer>
           <p>

--- a/src/views/AccountInfo/AccountInfoConnectedState.tsx
+++ b/src/views/AccountInfo/AccountInfoConnectedState.tsx
@@ -1,14 +1,15 @@
 import { shallowEqual } from 'react-redux';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { Nullable, TradeState } from '@/constants/abacus';
-import { ButtonShape, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize, ButtonStyle } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { DydxChainAsset } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
+import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useComplianceState } from '@/hooks/useComplianceState';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -21,6 +22,7 @@ import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { MarginUsageRing } from '@/components/MarginUsageRing';
 import { OutputType } from '@/components/Output';
+import { WithSeparators } from '@/components/Separator';
 import { WithTooltip } from '@/components/WithTooltip';
 
 import { calculateIsAccountLoading } from '@/state/accountCalculators';
@@ -29,12 +31,17 @@ import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
 
 import { isNumber, MustBigNumber } from '@/lib/numbers';
+import { testFlags } from '@/lib/testFlags';
 
 import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
 
 enum AccountInfoItem {
-  AvailableBalance = 'available-balance',
   PortfolioValue = 'portfolio-value',
+  MarginUsed = 'margin-used',
+  RewardsEarned = 'rewards-earned',
+
+  // TODO: CT-1292 remove deprecated fields
+  AvailableBalance = 'available-balance',
 }
 
 const getUsageValue = (value: Nullable<TradeState<number>>) => {
@@ -46,14 +53,16 @@ const getUsageValue = (value: Nullable<TradeState<number>>) => {
 
 export const AccountInfoConnectedState = () => {
   const stringGetter = useStringGetter();
-
   const dispatch = useAppDispatch();
-  const { complianceState } = useComplianceState();
 
+  const { isTablet } = useBreakpoints();
+  const { complianceState } = useComplianceState();
   const { dydxAccounts } = useAccounts();
 
   const subAccount = useAppSelector(getSubaccount, shallowEqual);
   const isLoading = useAppSelector(calculateIsAccountLoading);
+
+  const { uiRefresh } = testFlags;
 
   const { freeCollateral: availableBalance, marginUsage } = subAccount ?? {};
   const portfolioValue = subAccount?.equity;
@@ -61,107 +70,181 @@ export const AccountInfoConnectedState = () => {
   const isPostOrderBalanceNegative =
     isNumber(availableBalance?.postOrder) && MustBigNumber(availableBalance?.postOrder).lt(0);
 
+  const withdrawButton = (
+    <$Button
+      state={{ isDisabled: !dydxAccounts }}
+      onClick={() => dispatch(openDialog(DialogTypes.Withdraw()))}
+      shape={ButtonShape.Rectangle}
+      size={ButtonSize.XSmall}
+      buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
+      action={uiRefresh ? ButtonAction.Primary : undefined}
+      $uiRefreshEnabled={uiRefresh}
+    >
+      {stringGetter({ key: STRING_KEYS.WITHDRAW })}
+    </$Button>
+  );
+
+  const depositButton = (
+    <$Button
+      state={{ isDisabled: !dydxAccounts }}
+      onClick={() => dispatch(openDialog(DialogTypes.Deposit()))}
+      shape={ButtonShape.Rectangle}
+      size={ButtonSize.XSmall}
+      buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
+      action={uiRefresh ? ButtonAction.Primary : undefined}
+      $uiRefreshEnabled={uiRefresh}
+    >
+      {stringGetter({ key: STRING_KEYS.DEPOSIT })}
+    </$Button>
+  );
+
+  const deprecatedActionButtons = (
+    <div tw="inlineRow gap-1">
+      {withdrawButton}
+      {complianceState === ComplianceStates.FULL_ACCESS && (
+        <>
+          {depositButton}
+          <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.TRANSFER })}>
+            <$IconButton
+              shape={ButtonShape.Square}
+              iconName={IconName.Send}
+              onClick={() =>
+                dispatch(openDialog(DialogTypes.Transfer({ selectedAsset: DydxChainAsset.USDC })))
+              }
+            />
+          </WithTooltip>
+        </>
+      )}
+    </div>
+  );
+
+  const depositWithdrawRow = (
+    <div tw="inlineRow gap-0.5 self-stretch">
+      <$WithSeparators layout="row" withSeparators>
+        {depositButton}
+        {complianceState === ComplianceStates.FULL_ACCESS && withdrawButton}
+      </$WithSeparators>
+    </div>
+  );
+
+  const deprecatedDetailItems = [
+    {
+      key: AccountInfoItem.PortfolioValue,
+      hideDiff: true,
+      hasError: false,
+      isPositive: MustBigNumber(portfolioValue?.postOrder).gt(
+        MustBigNumber(portfolioValue?.current)
+      ),
+      label: stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE }),
+      type: OutputType.Fiat,
+      value: portfolioValue,
+    },
+    {
+      key: AccountInfoItem.AvailableBalance,
+      hasError: isPostOrderBalanceNegative,
+      hideDiff: isPostOrderBalanceNegative,
+      isPositive: MustBigNumber(availableBalance?.postOrder).gt(
+        MustBigNumber(availableBalance?.current)
+      ),
+      label: stringGetter({ key: STRING_KEYS.AVAILABLE_BALANCE }),
+      type: OutputType.Fiat,
+      value:
+        MustBigNumber(availableBalance?.current).lt(0) && availableBalance?.postOrder === null
+          ? undefined
+          : availableBalance,
+      slotRight: (
+        <WithTooltip tooltip="cross-margin-usage">
+          <MarginUsageRing value={getUsageValue(marginUsage)} />
+        </WithTooltip>
+      ),
+    },
+  ].map(({ key, hasError, hideDiff = false, isPositive, label, type, value, slotRight }) => ({
+    key,
+    label: (
+      <$WithUsage>
+        {label}
+        {hasError ? <Icon iconName={IconName.CautionCircle} tw="text-color-error" /> : slotRight}
+      </$WithUsage>
+    ),
+    value: (
+      <AccountInfoDiffOutput
+        hasError={hasError}
+        hideDiff={hideDiff}
+        isPositive={isPositive}
+        type={type}
+        value={value}
+      />
+    ),
+  }));
+
+  const detailItems = [
+    {
+      key: AccountInfoItem.PortfolioValue,
+      label: (
+        <WithTooltip tooltip="margin-used">
+          {stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE })}
+        </WithTooltip>
+      ),
+      value: (
+        <AccountInfoDiffOutput
+          hasError={false}
+          hideDiff
+          isPositive={MustBigNumber(portfolioValue?.postOrder).gt(
+            MustBigNumber(portfolioValue?.current)
+          )}
+          type={OutputType.Fiat}
+          value={portfolioValue}
+        />
+      ),
+    },
+    {
+      key: AccountInfoItem.MarginUsed,
+      label: (
+        <WithTooltip tooltip="margin-used">
+          {stringGetter({ key: STRING_KEYS.MARGIN_USED })}
+        </WithTooltip>
+      ),
+      value: (
+        <>
+          <WithTooltip tooltip="cross-margin-usage">
+            <MarginUsageRing value={getUsageValue(marginUsage)} />
+          </WithTooltip>
+          <AccountInfoDiffOutput
+            hasError={false}
+            hideDiff
+            isPositive={MustBigNumber(marginUsage?.postOrder).gt(
+              MustBigNumber(marginUsage?.current)
+            )}
+            type={OutputType.Percent}
+            value={marginUsage}
+          />
+        </>
+      ),
+      valueSlotLeft: (
+        <WithTooltip tooltip="cross-margin-usage">
+          <MarginUsageRing value={getUsageValue(marginUsage)} />
+        </WithTooltip>
+      ),
+    },
+  ];
+
   return (
-    <$ConnectedAccountInfoContainer>
-      <header tw="spacedRow px-1.25 py-0 font-small-book">
-        <span>{stringGetter({ key: STRING_KEYS.ACCOUNT })}</span>
-        <div tw="inlineRow gap-1">
-          <$Button
-            state={{ isDisabled: !dydxAccounts }}
-            onClick={() => dispatch(openDialog(DialogTypes.Withdraw()))}
-            shape={ButtonShape.Rectangle}
-            size={ButtonSize.XSmall}
-          >
-            {stringGetter({ key: STRING_KEYS.WITHDRAW })}
-          </$Button>
-          {complianceState === ComplianceStates.FULL_ACCESS && (
-            <>
-              <$Button
-                state={{ isDisabled: !dydxAccounts }}
-                onClick={() => dispatch(openDialog(DialogTypes.Deposit()))}
-                shape={ButtonShape.Rectangle}
-                size={ButtonSize.XSmall}
-              >
-                {stringGetter({ key: STRING_KEYS.DEPOSIT })}
-              </$Button>
-              <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.TRANSFER })}>
-                <$IconButton
-                  shape={ButtonShape.Square}
-                  iconName={IconName.Send}
-                  onClick={() =>
-                    dispatch(
-                      openDialog(DialogTypes.Transfer({ selectedAsset: DydxChainAsset.USDC }))
-                    )
-                  }
-                />
-              </WithTooltip>
-            </>
-          )}
-        </div>
+    <$ConnectedAccountInfoContainer $uiRefreshEnabled={uiRefresh}>
+      <header tw="spacedRow px-1 py-0 font-small-book">
+        <span>
+          {stringGetter({ key: uiRefresh ? STRING_KEYS.YOUR_ACCOUNT : STRING_KEYS.ACCOUNT })}
+        </span>
+        {uiRefresh ? depositWithdrawRow : deprecatedActionButtons}
       </header>
-      <div tw="stack">
+      <$StackContainer $isTablet={isTablet}>
         <$Details
-          items={[
-            {
-              key: AccountInfoItem.PortfolioValue,
-              hideDiff: true,
-              hasError: false,
-              isPositive: MustBigNumber(portfolioValue?.postOrder).gt(
-                MustBigNumber(portfolioValue?.current)
-              ),
-              label: stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE }),
-              type: OutputType.Fiat,
-              value: portfolioValue,
-            },
-            {
-              key: AccountInfoItem.AvailableBalance,
-              hasError: isPostOrderBalanceNegative,
-              hideDiff: isPostOrderBalanceNegative,
-              isPositive: MustBigNumber(availableBalance?.postOrder).gt(
-                MustBigNumber(availableBalance?.current)
-              ),
-              label: stringGetter({ key: STRING_KEYS.AVAILABLE_BALANCE }),
-              type: OutputType.Fiat,
-              value:
-                MustBigNumber(availableBalance?.current).lt(0) &&
-                availableBalance?.postOrder === null
-                  ? undefined
-                  : availableBalance,
-              slotRight: (
-                <WithTooltip tooltip="cross-margin-usage">
-                  <MarginUsageRing value={getUsageValue(marginUsage)} />
-                </WithTooltip>
-              ),
-            },
-          ].map(
-            ({ key, hasError, hideDiff = false, isPositive, label, type, value, slotRight }) => ({
-              key,
-              label: (
-                <$WithUsage>
-                  {label}
-                  {hasError ? (
-                    <Icon iconName={IconName.CautionCircle} tw="text-color-error" />
-                  ) : (
-                    slotRight
-                  )}
-                </$WithUsage>
-              ),
-              value: (
-                <AccountInfoDiffOutput
-                  hasError={hasError}
-                  hideDiff={hideDiff}
-                  isPositive={isPositive}
-                  type={type}
-                  value={value}
-                />
-              ),
-            })
-          )}
+          items={uiRefresh ? detailItems : deprecatedDetailItems}
           layout="column"
           withOverflow={false}
           isLoading={isLoading}
+          $uiRefreshEnabled={uiRefresh}
         />
-      </div>
+      </$StackContainer>
     </$ConnectedAccountInfoContainer>
   );
 };
@@ -178,16 +261,31 @@ const $WithUsage = styled.div`
   }
 `;
 
-const $Details = styled(Details)`
-  clip-path: inset(0.5rem 1px);
-  padding: 0.25rem 1rem;
-
+const $Details = styled(Details)<{ $uiRefreshEnabled: boolean }>`
   font: var(--font-mini-book);
 
-  > * {
-    padding: 0;
-    display: flex;
-  }
+  ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled
+      ? css`
+          padding: 0 1rem;
+
+          > :first-child {
+            padding: 0;
+          }
+
+          > *:not(:first-child) {
+            padding: 0.5rem 0 0;
+          }
+        `
+      : css`
+          padding: 0.25rem 1rem;
+
+          > * {
+            padding: 0;
+            display: flex;
+            clip-path: inset(0.5rem 1px);
+          }
+        `}
 
   @media ${breakpoints.tablet} {
     clip-path: none;
@@ -197,20 +295,51 @@ const $Details = styled(Details)`
     }
   }
 `;
-const $ConnectedAccountInfoContainer = styled.div`
-  ${layoutMixins.column}
-  grid-template-rows: var(--tabs-height) 1fr;
+const $ConnectedAccountInfoContainer = styled.div<{ $uiRefreshEnabled: boolean }>`
+  ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled
+      ? css`
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          padding: 0.5rem 0;
+        `
+      : css`
+          ${layoutMixins.column}
+          grid-template-rows: var(--tabs-height) 1fr;
 
-  @media ${breakpoints.notTablet} {
-    ${layoutMixins.withOuterAndInnerBorders}
-    > *:last-child {
-      box-shadow: none;
-    }
-  }
+          @media ${breakpoints.notTablet} {
+            ${layoutMixins.withOuterAndInnerBorders}
+            > *:last-child {
+              box-shadow: none;
+            }
+          }
+        `};
 `;
 
-const $Button = styled(Button)`
-  margin-right: -0.3rem;
+const $StackContainer = styled.div<{ $isTablet: boolean }>`
+  ${layoutMixins.stack}
+
+  ${({ $isTablet }) =>
+    $isTablet &&
+    css`
+      flex: 1;
+    `}
+`;
+
+const $WithSeparators = styled(WithSeparators)`
+  --separatorHeight-padding: 0.5rem;
+`;
+
+const $Button = styled(Button)<{ $uiRefreshEnabled: boolean }>`
+  ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled
+      ? css`
+          --button-padding: 0;
+        `
+      : css`
+          margin-right: -0.3rem;
+        `};
 `;
 
 const $IconButton = styled(IconButton)`

--- a/src/views/AccountInfo/AccountInfoDiffOutput.tsx
+++ b/src/views/AccountInfo/AccountInfoDiffOutput.tsx
@@ -45,13 +45,8 @@ export const AccountInfoDiffOutput = ({
   );
 };
 const $DiffOutput = styled(DiffOutput)<{ withDiff?: boolean; $uiRefreshEnabled: boolean }>`
-  --diffOutput-value-font: ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
-  --diffOutput-newValue-font: ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
-  --diffOutput-valueWithDiff-font: ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
-
   --diffOutput-gap: 0.125rem;
-  font: var(--font-base-book);
+
+  font: ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
 `;

--- a/src/views/AccountInfo/AccountInfoDiffOutput.tsx
+++ b/src/views/AccountInfo/AccountInfoDiffOutput.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { Nullable, TradeState } from '@/constants/abacus';
 import { NumberSign } from '@/constants/numbers';
@@ -7,6 +7,7 @@ import { DiffOutput } from '@/components/DiffOutput';
 import { type OutputType } from '@/components/Output';
 
 import { isNumber } from '@/lib/numbers';
+import { testFlags } from '@/lib/testFlags';
 
 type ElementProps = {
   hasError?: boolean | null;
@@ -27,8 +28,11 @@ export const AccountInfoDiffOutput = ({
   const postOrderValue = value?.postOrder;
   const hasDiffPostOrder = isNumber(postOrderValue) && currentValue !== postOrderValue && !hideDiff;
 
+  const { uiRefresh } = testFlags;
+
   return (
     <$DiffOutput
+      $uiRefreshEnabled={uiRefresh}
       hasInvalidNewValue={!!hasError}
       sign={isPositive ? NumberSign.Positive : NumberSign.Negative}
       type={type}
@@ -40,10 +44,14 @@ export const AccountInfoDiffOutput = ({
     />
   );
 };
-const $DiffOutput = styled(DiffOutput)<{ withDiff?: boolean }>`
-  --diffOutput-value-font: var(--font-mini-book);
-  --diffOutput-valueWithDiff-font: var(--font-mini-book);
-  --diffOutput-newValue-font: var(--font-mini-book);
+const $DiffOutput = styled(DiffOutput)<{ withDiff?: boolean; $uiRefreshEnabled: boolean }>`
+  --diffOutput-value-font: ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
+  --diffOutput-newValue-font: ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
+  --diffOutput-valueWithDiff-font: ${({ $uiRefreshEnabled }) =>
+    $uiRefreshEnabled ? css`var(--font-small-book)` : css`var(--font-mini-book)`};
+
   --diffOutput-gap: 0.125rem;
   font: var(--font-base-book);
 `;

--- a/src/views/AccountInfo/AccountInfoSection.tsx
+++ b/src/views/AccountInfo/AccountInfoSection.tsx
@@ -38,7 +38,6 @@ import { AccountInfoDiffOutput } from './AccountInfoDiffOutput';
 enum AccountInfoItem {
   PortfolioValue = 'portfolio-value',
   MarginUsed = 'margin-used',
-  RewardsEarned = 'rewards-earned',
 
   // TODO: CT-1292 remove deprecated fields
   AvailableBalance = 'available-balance',
@@ -51,7 +50,7 @@ const getUsageValue = (value: Nullable<TradeState<number>>) => {
   return (hasDiffPostOrder ? postOrderValue : currentValue) ?? 0;
 };
 
-export const AccountInfoConnectedState = () => {
+export const AccountInfoSection = () => {
   const stringGetter = useStringGetter();
   const dispatch = useAppDispatch();
 

--- a/src/views/AccountInfo/AccountInfoSection.tsx
+++ b/src/views/AccountInfo/AccountInfoSection.tsx
@@ -67,14 +67,14 @@ export const AccountInfoSection = () => {
   const portfolioValue = subAccount?.equity;
 
   const isPostOrderBalanceNegative =
-    isNumber(availableBalance?.postOrder) && MustBigNumber(availableBalance?.postOrder).lt(0);
+    isNumber(availableBalance?.postOrder) && MustBigNumber(availableBalance.postOrder).lt(0);
 
   const withdrawButton = (
     <$Button
       state={{ isDisabled: !dydxAccounts }}
       onClick={() => dispatch(openDialog(DialogTypes.Withdraw()))}
       shape={ButtonShape.Rectangle}
-      size={ButtonSize.XSmall}
+      size={uiRefresh ? ButtonSize.Small : ButtonSize.XSmall}
       buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
       action={uiRefresh ? ButtonAction.Primary : undefined}
       $uiRefreshEnabled={uiRefresh}
@@ -88,7 +88,7 @@ export const AccountInfoSection = () => {
       state={{ isDisabled: !dydxAccounts }}
       onClick={() => dispatch(openDialog(DialogTypes.Deposit()))}
       shape={ButtonShape.Rectangle}
-      size={ButtonSize.XSmall}
+      size={uiRefresh ? ButtonSize.Small : ButtonSize.XSmall}
       buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
       action={uiRefresh ? ButtonAction.Primary : undefined}
       $uiRefreshEnabled={uiRefresh}
@@ -134,7 +134,11 @@ export const AccountInfoSection = () => {
       isPositive: MustBigNumber(portfolioValue?.postOrder).gt(
         MustBigNumber(portfolioValue?.current)
       ),
-      label: stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE }),
+      label: (
+        <WithTooltip tooltip="portfolio-value" side="right">
+          {stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE })}
+        </WithTooltip>
+      ),
       type: OutputType.Fiat,
       value: portfolioValue,
     },
@@ -152,19 +156,22 @@ export const AccountInfoSection = () => {
           ? undefined
           : availableBalance,
       slotRight: (
-        <WithTooltip tooltip="cross-margin-usage">
+        <WithTooltip tooltip="cross-margin-usage" side="right">
           <MarginUsageRing value={getUsageValue(marginUsage)} />
         </WithTooltip>
       ),
     },
   ].map(({ key, hasError, hideDiff = false, isPositive, label, type, value, slotRight }) => ({
     key,
-    label: (
-      <$WithUsage>
-        {label}
-        {hasError ? <Icon iconName={IconName.CautionCircle} tw="text-color-error" /> : slotRight}
-      </$WithUsage>
-    ),
+    label:
+      hasError || slotRight ? (
+        <$WithUsage>
+          {label}
+          {hasError ? <Icon iconName={IconName.CautionCircle} tw="text-color-error" /> : slotRight}
+        </$WithUsage>
+      ) : (
+        label
+      ),
     value: (
       <AccountInfoDiffOutput
         hasError={hasError}
@@ -180,7 +187,7 @@ export const AccountInfoSection = () => {
     {
       key: AccountInfoItem.PortfolioValue,
       label: (
-        <WithTooltip tooltip="margin-used">
+        <WithTooltip tooltip="portfolio-value" side="left">
           {stringGetter({ key: STRING_KEYS.PORTFOLIO_VALUE })}
         </WithTooltip>
       ),
@@ -199,18 +206,17 @@ export const AccountInfoSection = () => {
     {
       key: AccountInfoItem.MarginUsed,
       label: (
-        <WithTooltip tooltip="margin-used">
+        <WithTooltip tooltip="margin-used" side="left">
           {stringGetter({ key: STRING_KEYS.MARGIN_USED })}
         </WithTooltip>
       ),
       value: (
         <>
-          <WithTooltip tooltip="cross-margin-usage">
+          <WithTooltip tooltip="cross-margin-usage" side="left">
             <MarginUsageRing value={getUsageValue(marginUsage)} />
           </WithTooltip>
           <AccountInfoDiffOutput
             hasError={false}
-            hideDiff
             isPositive={MustBigNumber(marginUsage?.postOrder).gt(
               MustBigNumber(marginUsage?.current)
             )}
@@ -218,11 +224,6 @@ export const AccountInfoSection = () => {
             value={marginUsage}
           />
         </>
-      ),
-      valueSlotLeft: (
-        <WithTooltip tooltip="cross-margin-usage">
-          <MarginUsageRing value={getUsageValue(marginUsage)} />
-        </WithTooltip>
       ),
     },
   ];
@@ -261,22 +262,18 @@ const $WithUsage = styled.div`
 `;
 
 const $Details = styled(Details)<{ $uiRefreshEnabled: boolean }>`
-  font: var(--font-mini-book);
-
   ${({ $uiRefreshEnabled }) =>
     $uiRefreshEnabled
       ? css`
+          font: var(--font-small-book);
           padding: 0 1rem;
 
-          > :first-child {
-            padding: 0;
-          }
-
-          > *:not(:first-child) {
-            padding: 0.5rem 0 0;
+          > * {
+            padding: 0 0 0.5rem;
           }
         `
       : css`
+          font: var(--font-mini-book);
           padding: 0.25rem 1rem;
 
           > * {

--- a/src/views/AccountInfo/AccountInfoSection.tsx
+++ b/src/views/AccountInfo/AccountInfoSection.tsx
@@ -279,7 +279,6 @@ const $Details = styled(Details)<{ $uiRefreshEnabled: boolean }>`
           > * {
             padding: 0;
             display: flex;
-            clip-path: inset(0.5rem 1px);
           }
         `}
 

--- a/src/views/AccountInfo/AccountInfoSection.tsx
+++ b/src/views/AccountInfo/AccountInfoSection.tsx
@@ -228,7 +228,7 @@ export const AccountInfoSection = () => {
   ];
 
   return (
-    <$ConnectedAccountInfoContainer $uiRefreshEnabled={uiRefresh}>
+    <$Container $uiRefreshEnabled={uiRefresh}>
       <header tw="spacedRow px-1 py-0 font-small-book">
         <span>
           {stringGetter({ key: uiRefresh ? STRING_KEYS.YOUR_ACCOUNT : STRING_KEYS.ACCOUNT })}
@@ -244,7 +244,7 @@ export const AccountInfoSection = () => {
           $uiRefreshEnabled={uiRefresh}
         />
       </$StackContainer>
-    </$ConnectedAccountInfoContainer>
+    </$Container>
   );
 };
 
@@ -294,7 +294,7 @@ const $Details = styled(Details)<{ $uiRefreshEnabled: boolean }>`
     }
   }
 `;
-const $ConnectedAccountInfoContainer = styled.div<{ $uiRefreshEnabled: boolean }>`
+const $Container = styled.div<{ $uiRefreshEnabled: boolean }>`
   ${({ $uiRefreshEnabled }) =>
     $uiRefreshEnabled
       ? css`

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -167,11 +167,7 @@ export const PlaceOrderButtonAndReceipt = ({
       {
         key: 'liquidation-price',
         label: (
-          <WithTooltip
-            tooltip="liquidation-price"
-            stringParams={{ SYMBOL: id ?? '' }}
-            side="right"
-          >
+          <WithTooltip tooltip="liquidation-price" stringParams={{ SYMBOL: id ?? '' }} side="right">
             {stringGetter({ key: STRING_KEYS.LIQUIDATION_PRICE })}
           </WithTooltip>
         ),

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -25,6 +25,7 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getCurrentMarketPositionData, getSubaccountId } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
 import { openDialog } from '@/state/dialogs';
 import { getCurrentInput, getInputTradeMarginMode } from '@/state/inputsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
@@ -74,6 +75,8 @@ export const PlaceOrderButtonAndReceipt = ({
   const canAccountTrade = useAppSelector(calculateCanAccountTrade);
   const subaccountNumber = useAppSelector(getSubaccountId);
   const currentInput = useAppSelector(getCurrentInput);
+
+  const { id } = orEmptyObj(useAppSelector(getCurrentMarketAssetData, shallowEqual));
   const { tickSizeDecimals } = orEmptyObj(useAppSelector(getCurrentMarketConfig, shallowEqual));
   const { liquidationPrice, equity, leverage, notionalTotal, adjustedImf } = orEmptyObj(
     useAppSelector(getCurrentMarketPositionData, shallowEqual)
@@ -163,7 +166,15 @@ export const PlaceOrderButtonAndReceipt = ({
       },
       {
         key: 'liquidation-price',
-        label: stringGetter({ key: STRING_KEYS.LIQUIDATION_PRICE }),
+        label: (
+          <WithTooltip
+            tooltip="liquidation-price"
+            stringParams={{ SYMBOL: id ?? '' }}
+            side="right"
+          >
+            {stringGetter({ key: STRING_KEYS.LIQUIDATION_PRICE })}
+          </WithTooltip>
+        ),
         value: (
           <DiffOutput
             useGrouping
@@ -177,12 +188,20 @@ export const PlaceOrderButtonAndReceipt = ({
       },
       {
         key: 'position-margin',
-        label: stringGetter({ key: STRING_KEYS.POSITION_MARGIN }),
+        label: (
+          <WithTooltip tooltip="position-margin" side="right">
+            {stringGetter({ key: STRING_KEYS.POSITION_MARGIN })}
+          </WithTooltip>
+        ),
         value: renderMarginValue(),
       },
       {
         key: 'position-leverage',
-        label: stringGetter({ key: STRING_KEYS.POSITION_LEVERAGE }),
+        label: (
+          <WithTooltip tooltip="position-leverage" side="right">
+            {stringGetter({ key: STRING_KEYS.POSITION_LEVERAGE })}
+          </WithTooltip>
+        ),
         value: (
           <DiffOutput
             useGrouping

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -23,7 +23,7 @@ import { isOrderStatusClearable } from '@/lib/orders';
 import { testFlags } from '@/lib/testFlags';
 
 type ElementProps = {
-g  orderId: string;
+  orderId: string;
   orderFlags: Nullable<number>;
   status: OrderStatus;
   isDisabled?: boolean;

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -6,12 +6,15 @@ import styled, { css } from 'styled-components';
 
 import { AbacusOrderStatus, type OrderStatus } from '@/constants/abacus';
 import { ButtonShape } from '@/constants/buttons';
+import { STRING_KEYS } from '@/constants/localization';
 
+import { useStringGetter } from '@/hooks/useStringGetter';
 import { useSubaccount } from '@/hooks/useSubaccount';
 
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { ActionsTableCell } from '@/components/Table/ActionsTableCell';
+import { WithTooltip } from '@/components/WithTooltip';
 
 import { clearOrder } from '@/state/account';
 import { useAppDispatch } from '@/state/appTypes';
@@ -28,6 +31,8 @@ type ElementProps = {
 
 export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: ElementProps) => {
   const dispatch = useAppDispatch();
+  const stringGetter = useStringGetter();
+
   const { uiRefresh } = testFlags;
 
   const [isCanceling, setIsCanceling] = useState(false);
@@ -48,22 +53,24 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
 
   return (
     <ActionsTableCell>
-      <$CancelButton
-        key="cancelorder"
-        iconName={IconName.Close}
-        iconSize="0.875em"
-        shape={ButtonShape.Square}
-        $uiRefreshEnabled={uiRefresh}
-        {...(isOrderStatusClearable(status)
-          ? { onClick: () => dispatch(clearOrder(orderId)) }
-          : {
-              onClick: onCancel,
-              state: {
-                isLoading: isCanceling,
-                isDisabled: isCancelDisabled,
-              },
-            })}
-      />
+      <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.CANCEL_ORDER })}>
+        <$CancelButton
+          key="cancelorder"
+          iconName={IconName.Close}
+          iconSize="0.875em"
+          shape={ButtonShape.Square}
+          $uiRefreshEnabled={uiRefresh}
+          {...(isOrderStatusClearable(status)
+            ? { onClick: () => dispatch(clearOrder(orderId)) }
+            : {
+                onClick: onCancel,
+                state: {
+                  isLoading: isCanceling,
+                  isDisabled: isCancelDisabled,
+                },
+              })}
+        />
+      </WithTooltip>
     </ActionsTableCell>
   );
 };

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -23,7 +23,7 @@ import { isOrderStatusClearable } from '@/lib/orders';
 import { testFlags } from '@/lib/testFlags';
 
 type ElementProps = {
-  orderId: string;
+g  orderId: string;
   orderFlags: Nullable<number>;
   status: OrderStatus;
   isDisabled?: boolean;
@@ -53,7 +53,15 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
 
   return (
     <ActionsTableCell>
-      <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.CANCEL_ORDER })}>
+      <WithTooltip
+        side="left"
+        tw="[--tooltip-backgroundColor:--color-layer-5]"
+        tooltipString={
+          isOrderStatusClearable(status)
+            ? stringGetter({ key: STRING_KEYS.CLEAR })
+            : stringGetter({ key: STRING_KEYS.CANCEL_ORDER })
+        }
+      >
         <$CancelButton
           key="cancelorder"
           iconName={IconName.Close}

--- a/src/views/tables/PositionsTable/PositionsActionsCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsActionsCell.tsx
@@ -127,14 +127,16 @@ export const PositionsActionsCell = ({
           />
         </WithTooltip>
       )}
-      <$TriggersButton
-        key="share"
-        onClick={openShareDialog}
-        iconName={IconName.Share}
-        shape={ButtonShape.Square}
-        disabled={isDisabled}
-        $uiRefreshEnabled={uiRefresh}
-      />
+      <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.SHARE })}>
+        <$TriggersButton
+          key="share"
+          onClick={openShareDialog}
+          iconName={IconName.Share}
+          shape={ButtonShape.Square}
+          disabled={isDisabled}
+          $uiRefreshEnabled={uiRefresh}
+        />
+      </WithTooltip>
       {showClosePositionAction && (
         <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.CLOSE_POSITION })}>
           <$CloseButtonToggle


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
1. [Flagged] Moves the account info section to the bottom of the trade box
2. Adds some missing tooltips (unrelated)
3. Added a new "withoutBackground" style to Button because I was tired of adding `background: transparent; border: none` everywhere and I wanted it to work with the different button states

Does not:
- Does not update the cross | isolated margin selector (that will come in a follow up because it hasn't yet been mocked)
- Mobile web could look better, but i'll follow up; this approximately matches the current state of world
 
<!-- Overall purpose of the PR -->

| | DesktopWeb | Mobile | DesktopWeb- unflagged | Mobile - unflagged |
| ---- | ---- | ---- | ---- | ---- |
| Connected | <img width="1248" alt="Screenshot 2024-10-18 at 4 02 16 PM" src="https://github.com/user-attachments/assets/b0e35429-719f-4f51-a8ff-e2b01d1aa747"> | <img width="946" alt="Screenshot 2024-10-18 at 4 02 01 PM" src="https://github.com/user-attachments/assets/2111471e-b9a8-4732-aadc-aafdb71ba2af"> | <img width="1253" alt="Screenshot 2024-10-18 at 4 03 43 PM" src="https://github.com/user-attachments/assets/beed8487-6057-4b97-8d1a-ce5346f94735"> | <img width="923" alt="Screenshot 2024-10-18 at 4 03 57 PM" src="https://github.com/user-attachments/assets/e0c061ed-edb4-4255-9cdc-3dcf6a87701c"> | 
| Disconnected | <img width="1300" alt="Screenshot 2024-10-18 at 4 01 44 PM" src="https://github.com/user-attachments/assets/621be251-8ad3-4560-96a4-8fba5b7b352d"> | <img width="949" alt="Screenshot 2024-10-18 at 4 01 54 PM" src="https://github.com/user-attachments/assets/d16960c2-7b7d-42c1-8b98-d2c67bca3a36"> | <img width="1245" alt="Screenshot 2024-10-18 at 4 03 34 PM" src="https://github.com/user-attachments/assets/e50d6d51-9633-4c3b-a609-2cebf7ee0c06"> | <img width="920" alt="Screenshot 2024-10-18 at 4 04 07 PM" src="https://github.com/user-attachments/assets/5d54d898-09f2-439d-a70f-18f62c8be310"> | 






| Tooltip | Tooltip | Tooltip | Tooltip | Tooltip |
| ---- | ---- | ---- | ---- | ---- | 
| <img width="198" alt="Screenshot 2024-10-18 at 2 56 38 PM" src="https://github.com/user-attachments/assets/a929429c-83f5-4bc1-83de-8667c7e0bde5"> | <img width="164" alt="Screenshot 2024-10-18 at 2 56 34 PM" src="https://github.com/user-attachments/assets/5384b03b-fa47-455d-8f37-b56a80f9cb38"> | <img width="494" alt="Screenshot 2024-10-18 at 2 56 22 PM" src="https://github.com/user-attachments/assets/d41c53e8-0047-450c-a331-a20987e7ad7f"> | <img width="505" alt="Screenshot 2024-10-18 at 2 56 18 PM" src="https://github.com/user-attachments/assets/d868394f-82f2-4646-a4d9-2c55d9b83676"> | <img width="559" alt="Screenshot 2024-10-18 at 2 56 14 PM" src="https://github.com/user-attachments/assets/65c2e59a-2bcb-415b-97eb-7c337e170d91"> |



| | Default | WithoutBackground | 
| ---- | ---- | ---- |
| Loading | <img width="119" alt="Screenshot 2024-10-18 at 2 44 22 PM" src="https://github.com/user-attachments/assets/12cdcffa-e377-4696-affd-29cc40764ebd"> | <img width="66" alt="Screenshot 2024-10-18 at 2 44 16 PM" src="https://github.com/user-attachments/assets/a287964e-3e11-4131-9926-bfcb2b814dbd"> |
| Primary | <img width="161" alt="Screenshot 2024-10-18 at 2 50 29 PM" src="https://github.com/user-attachments/assets/f42d98fd-c104-4c7a-b06e-c22fabac1e6a"> | <img width="109" alt="Screenshot 2024-10-18 at 2 50 25 PM" src="https://github.com/user-attachments/assets/a7ea6e5c-103e-4602-8718-65a926b7974b"> |
| Primary - disabled | <img width="124" alt="Screenshot 2024-10-18 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cc95d3d9-7c78-47fd-88f9-71d959b0157c"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> | 
| Secondary | <img width="137" alt="Screenshot 2024-10-18 at 2 50 57 PM" src="https://github.com/user-attachments/assets/a26e42b9-e101-47cf-8943-85d647812d89"> | <img width="123" alt="Screenshot 2024-10-18 at 2 51 01 PM" src="https://github.com/user-attachments/assets/2322cac8-4deb-495e-9fa0-e9ace03c0faa"> |
| Secondary - disabled | <img width="124" alt="Screenshot 2024-10-18 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cc95d3d9-7c78-47fd-88f9-71d959b0157c"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> | 
| Create | <img width="133" alt="Screenshot 2024-10-18 at 2 51 42 PM" src="https://github.com/user-attachments/assets/a8f3e025-59c6-420b-89b9-2695680cc681"> | <img width="111" alt="Screenshot 2024-10-18 at 2 51 39 PM" src="https://github.com/user-attachments/assets/b4fc0007-45bc-4fb2-9797-c0c14f83b956"> |
| Create - disabled | <img width="124" alt="Screenshot 2024-10-18 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cc95d3d9-7c78-47fd-88f9-71d959b0157c"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> | 
| Destroy | <img width="132" alt="Screenshot 2024-10-18 at 2 51 46 PM" src="https://github.com/user-attachments/assets/78d6b5ea-0776-4c8f-85c0-4aa97fe4264b"> | <img width="138" alt="Screenshot 2024-10-18 at 2 51 51 PM" src="https://github.com/user-attachments/assets/40b6dd1b-1143-411f-9079-e16a81696023"> |
| Destroy - disabled | <img width="124" alt="Screenshot 2024-10-18 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cc95d3d9-7c78-47fd-88f9-71d959b0157c"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> |
| Navigation | <img width="120" alt="Screenshot 2024-10-18 at 2 52 54 PM" src="https://github.com/user-attachments/assets/2316cdc6-aa90-48ae-96b3-2bdeba543a98"> | <img width="120" alt="Screenshot 2024-10-18 at 2 52 54 PM" src="https://github.com/user-attachments/assets/2316cdc6-aa90-48ae-96b3-2bdeba543a98"> |
| Navigation - disabled | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> |
| Base | <img width="127" alt="Screenshot 2024-10-18 at 2 49 44 PM" src="https://github.com/user-attachments/assets/8e6791eb-fa5b-491a-80f5-a9cdb43fc803"> | <img width="134" alt="Screenshot 2024-10-18 at 2 49 49 PM" src="https://github.com/user-attachments/assets/42f53fca-a349-4179-b8c1-5fb10ad9bb07"> |
| Base - disabled | <img width="124" alt="Screenshot 2024-10-18 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cc95d3d9-7c78-47fd-88f9-71d959b0157c"> | <img width="119" alt="Screenshot 2024-10-18 at 2 45 25 PM" src="https://github.com/user-attachments/assets/c356ba1d-0c88-4a22-84e1-6e5d3fb8700f"> | 





<!-- Reorder/delete the following sections accordingly: -->

## Views

- `pages/Trade`
  - [Flagged] Move account info box to be on bottom instead of top

- `<AccountInfo>`
  - update to logic to always show `AcountInfoConnectedState`/`AccountInfoSection` if `uiRefresh` is enabled + adjustment of height

- rename: `<AccountInfoConnectedState>` -> `<AccountInfoSection>`
  - since this is being used when `uiRefresh` is enabled for both logged in + logged out views
  - Add new `MarginUsed` key to `AccountInfoItem`

- `<PlaceOrderButtonAndReceipt>`
  - add missing tooltips for liquidation price, position margin  and position leverage 
  
- `<OrderActionsCell>`
  - add missing tooltip for cancel order button

- `<PositionsActionsCell>`
  - add missing tooltip for share button

## Components

- `<Button>`
  - Add a `buttonStyle` prop + type: `Default` is the current world (where all the buttons have backgrounds + borders - except navigation); `WithoutBackground` is the transparent background + no border
    - Added disabled variants, play around with button stories to see styling

## Styles/Mixins

- `styles/constants.css`
  - Shrink account info section height when flagged  
  
## Constants/Types

- `constants/buttons.ts`
  - Add `ButtonStyle = Default | WithoutBackground`

- `constants/tooltips/trade.ts`
  - A bunch of tooltip

## Packages

- `v4-localization`
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
