### PR TITLE
fix: fix button styling nits

### DIFF
--- a/src/components/CollapsibleTabs.tsx
+++ b/src/components/CollapsibleTabs.tsx
@@ -13,6 +13,8 @@ import {
 } from '@radix-ui/react-tabs';
 import styled, { css, keyframes } from 'styled-components';
 
+import { ButtonShape, ButtonStyle } from '@/constants/buttons';
+
 import { layoutMixins } from '@/styles/layoutMixins';
 import { tabMixins } from '@/styles/tabMixins';
 
@@ -23,7 +25,6 @@ import { Tag } from '@/components/Tag';
 import { Toolbar } from '@/components/Toolbar';
 
 import { testFlags } from '@/lib/testFlags';
-import { ButtonShape } from '@/constants/buttons';
 
 type ElementProps<TabItemsValue> = {
   defaultTab?: TabItemsValue;
@@ -100,7 +101,7 @@ export const CollapsibleTabs = <TabItemsValue extends string>({
               <$IconButton
                 iconName={IconName.Caret}
                 isToggle
-                $uiRefreshEnabled={uiRefresh}
+                buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
                 shape={uiRefresh ? ButtonShape.Square : ButtonShape.Circle}
               />
             </CollapsibleTrigger>
@@ -242,16 +243,9 @@ const $Header = styled.header`
   z-index: 2;
 `;
 
-const $IconButton = styled(IconButton)<{ $uiRefreshEnabled: boolean }>`
+const $IconButton = styled(IconButton)`
   --button-icon-size: 1em;
   ${$CollapsibleRoot}[data-state='closed'] & {
     rotate: -0.5turn;
   }
-
-  ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled &&
-    css`
-      --button-border: none;
-      --button-backgroundColor: transparent;
-    `};
 `;

--- a/src/components/CollapsibleTabs.tsx
+++ b/src/components/CollapsibleTabs.tsx
@@ -23,6 +23,7 @@ import { Tag } from '@/components/Tag';
 import { Toolbar } from '@/components/Toolbar';
 
 import { testFlags } from '@/lib/testFlags';
+import { ButtonShape } from '@/constants/buttons';
 
 type ElementProps<TabItemsValue> = {
   defaultTab?: TabItemsValue;
@@ -96,7 +97,12 @@ export const CollapsibleTabs = <TabItemsValue extends string>({
           <Toolbar tw="inlineRow">
             {currentTab?.slotToolbar ?? slotToolbar}
             <CollapsibleTrigger asChild>
-              <$IconButton iconName={IconName.Caret} isToggle $uiRefreshEnabled={uiRefresh} />
+              <$IconButton
+                iconName={IconName.Caret}
+                isToggle
+                $uiRefreshEnabled={uiRefresh}
+                shape={uiRefresh ? ButtonShape.Square : ButtonShape.Circle}
+              />
             </CollapsibleTrigger>
           </Toolbar>
         </$Header>

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef, type ElementType } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { ButtonAction, ButtonShape, ButtonSize, ButtonState } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize, ButtonState, ButtonStyle } from '@/constants/buttons';
 
 import { Button, ButtonStateConfig } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
@@ -18,7 +18,7 @@ type ElementProps = {
 };
 
 type StyleProps = {
-  withoutBackground?: boolean;
+  buttonStyle?: ButtonStyle;
 };
 
 export type IconButtonProps = ElementProps & ToggleButtonProps & StyleProps;
@@ -38,7 +38,7 @@ export const IconButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Icon
       onClick,
       onPressedChange,
       className,
-      withoutBackground = false,
+      buttonStyle = ButtonStyle.Default,
 
       ...otherProps
     },
@@ -52,7 +52,7 @@ export const IconButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Icon
         shape={shape}
         href={href}
         onPressedChange={onPressedChange ?? (onClick as any)} // TODO fix types
-        $withoutBackground={withoutBackground}
+        $withoutBackground={buttonStyle === ButtonStyle.WithoutBackground}
         {...otherProps}
       >
         <Icon iconName={iconName} iconComponent={iconComponent} />
@@ -65,7 +65,7 @@ export const IconButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Icon
         shape={shape}
         href={href}
         onClick={onClick}
-        $withoutBackground={withoutBackground}
+        buttonStyle={buttonStyle}
         {...otherProps}
       >
         <Icon iconName={iconName} iconComponent={iconComponent} size={iconSize} />
@@ -90,10 +90,8 @@ const withoutBackgroundMixin = css`
   --button-backgroundColor: transparent;
 `;
 
-const $IconButton = styled(Button)<{ $withoutBackground?: boolean }>`
+const $IconButton = styled(Button)`
   ${buttonMixin}
-
-  ${({ $withoutBackground }) => $withoutBackground && withoutBackgroundMixin}
 `;
 
 const $IconToggleButton = styled(ToggleButton)<{ $withoutBackground?: boolean }>`

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -2,7 +2,13 @@ import { forwardRef, type ElementType } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { ButtonAction, ButtonShape, ButtonSize, ButtonState, ButtonStyle } from '@/constants/buttons';
+import {
+  ButtonAction,
+  ButtonShape,
+  ButtonSize,
+  ButtonState,
+  ButtonStyle,
+} from '@/constants/buttons';
 
 import { Button, ButtonStateConfig } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -7,6 +7,7 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { Input, InputType, type InputProps } from '@/components/Input';
+import { ButtonStyle } from '@/constants/buttons';
 
 type ElementProps = {
   onTextChange?: (value: string) => void;
@@ -41,7 +42,7 @@ export const SearchInput = ({ placeholder, onTextChange, className }: SearchInpu
             setValue('');
             onTextChange?.('');
           }}
-          withoutBackground
+          buttonStyle={ButtonStyle.WithoutBackground}
         />
       )}
     </$Search>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -2,12 +2,13 @@ import { useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
+import { ButtonStyle } from '@/constants/buttons';
+
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { Input, InputType, type InputProps } from '@/components/Input';
-import { ButtonStyle } from '@/constants/buttons';
 
 type ElementProps = {
   onTextChange?: (value: string) => void;

--- a/src/components/WithTooltip.tsx
+++ b/src/components/WithTooltip.tsx
@@ -30,6 +30,7 @@ type ElementProps = {
 type StyleProps = {
   align?: 'start' | 'center' | 'end';
   side?: 'top' | 'right' | 'bottom' | 'left';
+  sideOffset?: number;
   className?: string;
 };
 
@@ -43,6 +44,7 @@ export const WithTooltip = ({
   children,
   align,
   side,
+  sideOffset,
   className,
   slotTooltip,
 }: ElementProps & StyleProps) => {
@@ -85,7 +87,7 @@ export const WithTooltip = ({
         </Trigger>
 
         <Portal>
-          <$Content sideOffset={8} side={side} align={align} className={className} asChild>
+          <$Content sideOffset={sideOffset ?? 8} side={side} align={align} className={className} asChild>
             {slotTooltip ?? (
               <dl>
                 {tooltipTitle && <dt>{tooltipTitle}</dt>}

--- a/src/components/WithTooltip.tsx
+++ b/src/components/WithTooltip.tsx
@@ -87,7 +87,13 @@ export const WithTooltip = ({
         </Trigger>
 
         <Portal>
-          <$Content sideOffset={sideOffset ?? 8} side={side} align={align} className={className} asChild>
+          <$Content
+            sideOffset={sideOffset ?? 8}
+            side={side}
+            align={align}
+            className={className}
+            asChild
+          >
             {slotTooltip ?? (
               <dl>
                 {tooltipTitle && <dt>{tooltipTitle}</dt>}

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled, { css, keyframes } from 'styled-components';
 
 import { Nullable } from '@/constants/abacus';
-import { ButtonSize } from '@/constants/buttons';
+import { ButtonSize, ButtonStyle } from '@/constants/buttons';
 import { LocalStorageKey } from '@/constants/localStorage';
 import { STRING_KEYS } from '@/constants/localization';
 import { MarketFilters, PREDICTION_MARKET, type MarketData } from '@/constants/markets';
@@ -184,7 +184,7 @@ const MarketsDropdownContent = ({
             tw="[--button-icon-size:0.8em]"
             onClick={() => setHasSeenElectionBannerTrupmWin(true)}
             iconName={IconName.Close}
-            withoutBackground
+            buttonStyle={ButtonStyle.WithoutBackground}
           />
         </$MarketDropdownBanner>
       );

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -269,7 +269,7 @@ export const ClosePositionForm = ({
         id="close-position-amount"
         label={
           <>
-            {stringGetter({ key: STRING_KEYS.AMOUNT })}
+            <span>{stringGetter({ key: STRING_KEYS.AMOUNT })}</span>
             {id && <Tag>{id}</Tag>}
           </>
         }

--- a/src/views/menus/NotificationsMenu.tsx
+++ b/src/views/menus/NotificationsMenu.tsx
@@ -4,7 +4,7 @@ import { groupBy } from 'lodash';
 import { useDispatch } from 'react-redux';
 import styled, { css } from 'styled-components';
 
-import { ButtonAction, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonSize, ButtonStyle } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { NotificationStatus, type Notification } from '@/constants/notifications';
@@ -144,7 +144,7 @@ export const NotificationsMenu = ({
           <IconButton
             iconName={IconName.Gear}
             onClick={() => dispatch(openDialog(DialogTypes.Preferences()))}
-            withoutBackground
+            buttonStyle={ButtonStyle.WithoutBackground}
           />
         </div>
       }

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -5,7 +5,7 @@ import { OrderFlags } from '@dydxprotocol/v4-client-js';
 import styled, { css } from 'styled-components';
 
 import { AbacusOrderStatus, type OrderStatus } from '@/constants/abacus';
-import { ButtonShape } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonStyle } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
@@ -55,6 +55,7 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
     <ActionsTableCell>
       <WithTooltip
         side="left"
+        sideOffset={0}
         tw="[--tooltip-backgroundColor:--color-layer-5]"
         tooltipString={
           isOrderStatusClearable(status)
@@ -67,7 +68,7 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
           iconName={IconName.Close}
           iconSize="0.875em"
           shape={ButtonShape.Square}
-          $uiRefreshEnabled={uiRefresh}
+          buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
           {...(isOrderStatusClearable(status)
             ? { onClick: () => dispatch(clearOrder(orderId)) }
             : {
@@ -82,14 +83,8 @@ export const OrderActionsCell = ({ orderId, orderFlags, status, isDisabled }: El
     </ActionsTableCell>
   );
 };
-const $CancelButton = styled(IconButton)<{ $uiRefreshEnabled: boolean }>`
+const $CancelButton = styled(IconButton)`
   --button-hover-textColor: var(--color-red);
-
-  ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled &&
-    css`
-      --button-backgroundColor: transparent;
-      --button-border: none;
-      width: min-content;
-    `}
+  --button-textColor: var(--color-text-0);
+  min-width: var(--button-width);
 `;

--- a/src/views/tables/OrdersTable/OrderActionsCell.tsx
+++ b/src/views/tables/OrdersTable/OrderActionsCell.tsx
@@ -2,10 +2,10 @@ import { useCallback, useState } from 'react';
 
 import { type Nullable } from '@dydxprotocol/v4-abacus';
 import { OrderFlags } from '@dydxprotocol/v4-client-js';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { AbacusOrderStatus, type OrderStatus } from '@/constants/abacus';
-import { ButtonAction, ButtonShape, ButtonStyle } from '@/constants/buttons';
+import { ButtonShape, ButtonStyle } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';

--- a/src/views/tables/PositionsTable/PositionsActionsCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsActionsCell.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
 import { AbacusPositionSides, Nullable, SubaccountOrder } from '@/constants/abacus';
-import { ButtonShape } from '@/constants/buttons';
+import { ButtonShape, ButtonStyle } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes, TradeBoxDialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -113,7 +113,7 @@ export const PositionsActionsCell = ({
   };
 
   return (
-    <$ActionsTableCell $uiRefreshEnabled={uiRefresh}>
+    <$ActionsTableCell $uiRefreshEnabled={uiRefresh} tw="mr-[-0.5rem]">
       {!isDisabled && complianceState === ComplianceStates.FULL_ACCESS && !uiRefresh && (
         <WithTooltip
           tooltipString={stringGetter({ key: STRING_KEYS.EDIT_TAKE_PROFIT_STOP_LOSS_TRIGGERS })}
@@ -134,6 +134,7 @@ export const PositionsActionsCell = ({
           iconName={IconName.Share}
           shape={ButtonShape.Square}
           disabled={isDisabled}
+          buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
           $uiRefreshEnabled={uiRefresh}
         />
       </WithTooltip>
@@ -151,7 +152,7 @@ export const PositionsActionsCell = ({
             iconName={IconName.Close}
             shape={ButtonShape.Square}
             disabled={isDisabled}
-            $uiRefreshEnabled={uiRefresh}
+            buttonStyle={uiRefresh ? ButtonStyle.WithoutBackground : ButtonStyle.Default}
           />
         </WithTooltip>
       )}
@@ -163,12 +164,12 @@ const $ActionsTableCell = styled(ActionsTableCell)<{ $uiRefreshEnabled: boolean 
   ${({ $uiRefreshEnabled }) =>
     $uiRefreshEnabled &&
     css`
-      --toolbar-margin: 1rem;
+      --toolbar-margin: 0.25rem;
     `}
 `;
 
 const $TriggersButton = styled(IconButton)<{ $uiRefreshEnabled: boolean }>`
-  --button-icon-size: 1.5em;
+  --button-icon-size: 1.25em;
   --button-textColor: var(--color-text-0);
   --button-hover-textColor: var(--color-text-1);
 
@@ -176,22 +177,11 @@ const $TriggersButton = styled(IconButton)<{ $uiRefreshEnabled: boolean }>`
     $uiRefreshEnabled &&
     css`
       --button-icon-size: 1em;
-      --button-backgroundColor: transparent;
-      --button-border: none;
-      width: min-content;
     `}
 `;
 
-const $CloseButtonToggle = styled(IconButton)<{ $uiRefreshEnabled: boolean }>`
+const $CloseButtonToggle = styled(IconButton)`
   --button-icon-size: 1em;
   --button-hover-textColor: var(--color-red);
   --button-toggle-on-textColor: var(--color-red);
-
-  ${({ $uiRefreshEnabled }) =>
-    $uiRefreshEnabled &&
-    css`
-      --button-backgroundColor: transparent;
-      --button-border: none;
-      width: min-content;
-    `}
 `;

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -7,7 +7,7 @@ import {
   type AbacusPositionSides,
   type SubaccountOrder,
 } from '@/constants/abacus';
-import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
+import { ButtonAction, ButtonShape, ButtonSize, ButtonStyle } from '@/constants/buttons';
 import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -100,6 +100,7 @@ export const PositionsTriggersCell = ({
         size={ButtonSize.XSmall}
         onClick={onViewOrders ?? undefined}
         disabled={isDisabled}
+        buttonStyle={ButtonStyle.WithoutBackground}
       >
         <$Label>{stringGetter({ key: STRING_KEYS.VIEW_ORDERS })}</$Label>
       </$ViewOrdersButton>
@@ -110,11 +111,13 @@ export const PositionsTriggersCell = ({
     <WithTooltip
       tooltipString={stringGetter({ key: STRING_KEYS.EDIT_TAKE_PROFIT_STOP_LOSS_TRIGGERS })}
     >
-      <$EditButton
+      <IconButton
         key="edit-triggers"
         iconName={IconName.Pencil}
         shape={ButtonShape.Square}
         onClick={openTriggersDialog}
+        action={ButtonAction.Secondary}
+        buttonStyle={ButtonStyle.WithoutBackground}
       />
     </WithTooltip>
   );
@@ -228,7 +231,7 @@ const $TableCell = styled(TableCell)`
   gap: 0.75em;
   justify-content: center;
 
-  --output-width: 70px;
+  --output-width: 80px;
 `;
 
 const $Container = styled.div<{ $align: 'right' | 'left' }>`
@@ -270,23 +273,11 @@ const $Output = styled(Output)<{
           `}
 `;
 
-const ButtonStyle = css`
-  --button-backgroundColor: transparent;
-  --button-border: none;
-  --button-width: min-content;
-`;
-
-const $EditButton = styled(IconButton)`
-  ${ButtonStyle}
-  --button-textColor: var(--color-text-0);
-  --button-padding: 0 1em 0 0;
-`;
-
 const $ViewOrdersButton = styled(Button)`
-  ${ButtonStyle}
   --button-height: 100%;
   --button-textColor: var(--color-accent);
-  --button-padding: 0;
+  --button-padding: 0 0.5em;
+  margin: 0 -0.5em;
 
   max-width: 100%;
 `;


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
follow ups from https://github.com/dydxprotocol/v4-web/pull/1178#discussion_r1809130025 and consolidated styling of `IconButton` and `Button`

<img width="1251" alt="Screenshot 2024-10-21 at 2 17 01 PM" src="https://github.com/user-attachments/assets/b9a47eee-c906-4e06-a905-b5ff9b039053">
<img width="1273" alt="Screenshot 2024-10-21 at 2 14 27 PM" src="https://github.com/user-attachments/assets/ca7f4e07-e916-4af1-8ac8-ae9d18ee5124">
<img width="1269" alt="Screenshot 2024-10-21 at 12 56 38 PM" src="https://github.com/user-attachments/assets/fed6a629-458f-443f-9809-d5a10cd1ca8f">
<img width="1238" alt="Screenshot 2024-10-21 at 12 56 09 PM" src="https://github.com/user-attachments/assets/85867c06-a90e-48aa-8fdd-a9eb73809088">
<img width="338" alt="Screenshot 2024-10-21 at 2 40 41 PM" src="https://github.com/user-attachments/assets/551c4ae0-6086-408a-883a-185cee321146">

<!-- Overall purpose of the PR -->

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<ClosePositionForm>`
  - Wrap text in span so that tag is properly positioned after it

- `<OrderActionsCell>`
  - Replaced `$uiRefreshEnabled` styling with `buttonStyle` prop
  - Fixed width so that the focus looks correct

- `<PositionActionsCell>`
  - Replaced `$uiRefreshEnabled` styling with `buttonStyle` prop
  - Fixed width so that the focus looks correct
  - Reduced icon size a bit, checked with both flag on and off

- `<PositionTriggersCell>`
  - Fixed width so that the focus looks correct

## Components

- `<CollapsibleTabs>`
  - Update to `Square` when `uiRefresh` enabled so that focus outlines match
  - Replaced `$uiRefreshEnabled` styling with `IconButton` prop

- `<IconButton>`
  - Replaced `withoutBackground` styleprop with `buttonStyle` style prop to match `Button` props

- `<WithTooltip>`
  - Allow caller to override `sideOffset`

