### PR TITLE
feat(uirefresh): update navigation bar tab styling

### DIFF
--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -220,8 +220,9 @@ const $Root = styled(Root)`
     ${layoutMixins.row}
     align-items: stretch;
 
-    margin: calc((var(--navigationMenu-height) - var(--navigationMenu-item-height)) / 2) 0;
+    padding: calc((var(--navigationMenu-height) - var(--navigationMenu-item-height)) / 2) 0;
     height: max-content;
+    // min-height: calc(100% - (var(--navigationMenu-height) - var(--navigationMenu-item-height)) / 2);
   }
   &[data-orientation='vertical'] {
     ${layoutMixins.column}
@@ -432,7 +433,7 @@ const $NavItem = styled(NavItem)<NavItemStyleProps>`
   --item-checked-textColor: var(--navigationMenu-item-checked-textColor);
   --item-highlighted-backgroundColor: var(--navigationMenu-item-highlighted-backgroundColor);
   --item-highlighted-textColor: var(--navigationMenu-item-highlighted-textColor);
-  --item-radius: var(--navigationMenu-item-radius);
+  // --item-radius: var(--navigationMenu-item-radius);
   --item-padding: var(--navigationMenu-item-padding);
 
   ${layoutMixins.scrollSnapItem}

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -184,7 +184,7 @@ export const NavigationMenu = <MenuItemValue extends string, MenuGroupValue exte
   );
 
   return (
-    <$Root orientation={orientation} dir={dir} className={className} $dividerStyling={dividerStyle}>
+    <$Root orientation={orientation} dir={dir} className={className}>
       {slotBefore}
 
       {items.map((group) => (
@@ -220,7 +220,7 @@ export const NavigationMenu = <MenuItemValue extends string, MenuGroupValue exte
     </$Root>
   );
 };
-const $Root = styled(Root)<{ $dividerStyling: 'tab' | 'underline' }>`
+const $Root = styled(Root)`
   /* Params */
   --navigationMenu-height: auto;
 
@@ -454,14 +454,19 @@ const $NavItem = styled(NavItem)<NavItemStyleProps>`
     subitems?.length
       ? css`
           ${popoverMixins.trigger}
-          --trigger-open-backgroundColor: ${$dividerStyling === 'tab'
-            ? css`var(--navigationMenu-tab-item-checked-backgroundColor)`
-            : css`var(--navigationMenu-underline-item-checked-backgroundColor)`};
-          ${$dividerStyling === 'underline' &&
-          css`
-            --trigger-active-filter: none;
-            --trigger-hover-filter: none;
-          `}
+          ${$dividerStyling === 'tab'
+            ? css`
+                --trigger-open-backgroundColor: var(
+                  --navigationMenu-tab-item-checked-backgroundColor
+                );
+              `
+            : css`
+                --trigger-open-backgroundColor: var(
+                  --navigationMenu-underline-item-checked-backgroundColor
+                );
+                --trigger-active-filter: none;
+                --trigger-hover-filter: none;
+              `};
         `
       : css`
           &:hover:not(:active) {

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -34,6 +34,7 @@ import { openDialog } from '@/state/dialogs';
 
 import { isTruthy } from '@/lib/isTruthy';
 import { testFlags } from '@/lib/testFlags';
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 
 export const HeaderDesktop = () => {
   const stringGetter = useStringGetter();
@@ -179,7 +180,12 @@ export const HeaderDesktop = () => {
       <VerticalSeparator />
 
       <$NavigationScrollBar>
-        <$NavigationMenu items={navItems} orientation="horizontal" />
+        <$NavigationMenu
+          items={navItems}
+          orientation="horizontal"
+          $uiRefreshEnabled={uiRefreshEnabled}
+          dividerStyle={uiRefreshEnabled ? 'underline' : 'tab'}
+        />
       </$NavigationScrollBar>
 
       <div role="separator" />
@@ -290,16 +296,22 @@ const $NavigationScrollBar = styled.div`
   ${layoutMixins.scrollAreaFade}
 `;
 
-const $NavigationMenu = styled(NavigationMenu)`
+const navigationMenuType = getSimpleStyledOutputType(
+  NavigationMenu,
+  {} as { $uiRefreshEnabled: boolean }
+);
+
+const $NavigationMenu = styled(NavigationMenu)<{ $uiRefreshEnabled: boolean }>`
   & {
     --navigationMenu-height: var(--stickyArea-topHeight);
-    --navigationMenu-item-height: var(--stickyArea-topHeight);
+    --navigationMenu-item-height: ${({ $uiRefreshEnabled }) =>
+      $uiRefreshEnabled ? css`var(--stickyArea-topHeight)` : css`var(--trigger-height)`};
   }
 
   ${layoutMixins.scrollArea}
-  padding: 0 0.5rem;
+  padding: 0 1rem;
   scroll-padding: 0 0.5rem;
-` as typeof NavigationMenu;
+` as typeof navigationMenuType;
 
 const $NavBefore = styled.div<{
   $uiRefreshEnabled: boolean;

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -293,7 +293,7 @@ const $NavigationScrollBar = styled.div`
 const $NavigationMenu = styled(NavigationMenu)`
   & {
     --navigationMenu-height: var(--stickyArea-topHeight);
-    --navigationMenu-item-height: var(--trigger-height);
+    --navigationMenu-item-height: var(--stickyArea-topHeight);
   }
 
   ${layoutMixins.scrollArea}

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -314,7 +314,7 @@ const $NavigationMenu = styled(NavigationMenu)<{ $uiRefreshEnabled: boolean }>`
 ` as typeof navigationMenuType;
 
 const $NavBefore = styled.div<{
-  $uiRefreshEnabled: boolean;g
+  $uiRefreshEnabled: boolean;
 }>`
   ${({ $uiRefreshEnabled }) => css`
     ${$uiRefreshEnabled

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -32,9 +32,9 @@ import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getHasSeenLaunchIncentives } from '@/state/configsSelectors';
 import { openDialog } from '@/state/dialogs';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { testFlags } from '@/lib/testFlags';
-import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 
 export const HeaderDesktop = () => {
   const stringGetter = useStringGetter();
@@ -314,7 +314,7 @@ const $NavigationMenu = styled(NavigationMenu)<{ $uiRefreshEnabled: boolean }>`
 ` as typeof navigationMenuType;
 
 const $NavBefore = styled.div<{
-  $uiRefreshEnabled: boolean;
+  $uiRefreshEnabled: boolean;g
 }>`
   ${({ $uiRefreshEnabled }) => css`
     ${$uiRefreshEnabled

--- a/src/styles/popoverMixins.ts
+++ b/src/styles/popoverMixins.ts
@@ -22,8 +22,8 @@ export const popoverMixins = {
     --trigger-open-backgroundColor: var(--color-layer-1);
     --trigger-open-textColor: var(--color-text-2);
 
-    --trigger-active-filter: brightness(var(--active-filter));
-    --trigger-hover-filter: brightness(var(--hover-filter-base));
+    // --trigger-active-filter: brightness(var(--active-filter));
+    // --trigger-hover-filter: brightness(var(--hover-filter-base));
 
     display: flex;
     align-items: center;
@@ -48,7 +48,8 @@ export const popoverMixins = {
     }
 
     &[data-state='open'] {
-      background-color: var(--trigger-open-backgroundColor);
+      // background-color: var(--trigger-open-backgroundColor);
+      box-shadow: inset 0 -2px 0 var(--color-accent);
       color: var(--trigger-open-textColor);
     }
   `,
@@ -225,29 +226,31 @@ export const popoverMixins = {
       cursor: not-allowed;
     }
 
-    &:not([data-disabled]) {
-      /* &:hover, */
-      /* :not(:has(* > [data-highlighted])) > &:hover, */
-      &[data-radix-collection-item]:hover, // @radix-ui/react-navigation-menu
-      /* &:focus-visible, */
-      &[aria-selected="true"], // cmdk
-      &[data-highlighted] // @radix-ui
-      {
-        filter: brightness(var(--hover-filter-base));
-        background-color: var(--item-highlighted-backgroundColor);
-        color: var(--item-highlighted-textColor, var(--trigger-textColor, inherit)) !important;
-        outline: none;
-      }
-    }
+    // &:not([data-disabled]) {
+    //   /* &:hover, */
+    //   /* :not(:has(* > [data-highlighted])) > &:hover, */
+    //   &[data-radix-collection-item]:hover, // @radix-ui/react-navigation-menu
+    //   /* &:focus-visible, */
+    //   &[aria-selected="true"], // cmdk
+    //   &[data-highlighted] // @radix-ui
+    //   {
+    //     filter: brightness(var(--hover-filter-base));
+    //     background-color: var(--item-highlighted-backgroundColor);
+    //     color: var(--item-highlighted-textColor, var(--trigger-textColor, inherit)) !important;
+    //     outline: none;
+    //   }
+    // }
 
     &[data-state='checked'], // @radix-ui
     &[aria-current='page'] // <a>
     {
-      background-color: var(
-        --item-checked-backgroundColor,
-        var(--trigger-selected-color, var(--popover-backgroundColor, inherit))
-      );
+    //   background-color: var(
+    //     --item-checked-backgroundColor,
+    //     var(--trigger-selected-color, var(--popover-backgroundColor, inherit))
+    //   );
       color: var(--item-checked-textColor, var(--trigger-textColor, inherit));
+      box-shadow: inset 0 -2px 0 var(--color-accent);
+
     }
   `,
 } satisfies Record<string, ReturnType<typeof css>>;

--- a/src/styles/popoverMixins.ts
+++ b/src/styles/popoverMixins.ts
@@ -22,8 +22,8 @@ export const popoverMixins = {
     --trigger-open-backgroundColor: var(--color-layer-1);
     --trigger-open-textColor: var(--color-text-2);
 
-    // --trigger-active-filter: brightness(var(--active-filter));
-    // --trigger-hover-filter: brightness(var(--hover-filter-base));
+    --trigger-active-filter: brightness(var(--active-filter));
+    --trigger-hover-filter: brightness(var(--hover-filter-base));
 
     display: flex;
     align-items: center;
@@ -49,7 +49,6 @@ export const popoverMixins = {
 
     &[data-state='open'] {
       // background-color: var(--trigger-open-backgroundColor);
-      box-shadow: inset 0 -2px 0 var(--color-accent);
       color: var(--trigger-open-textColor);
     }
   `,
@@ -226,30 +225,29 @@ export const popoverMixins = {
       cursor: not-allowed;
     }
 
-    // &:not([data-disabled]) {
-    //   /* &:hover, */
-    //   /* :not(:has(* > [data-highlighted])) > &:hover, */
-    //   &[data-radix-collection-item]:hover, // @radix-ui/react-navigation-menu
-    //   /* &:focus-visible, */
-    //   &[aria-selected="true"], // cmdk
-    //   &[data-highlighted] // @radix-ui
-    //   {
-    //     filter: brightness(var(--hover-filter-base));
-    //     background-color: var(--item-highlighted-backgroundColor);
-    //     color: var(--item-highlighted-textColor, var(--trigger-textColor, inherit)) !important;
-    //     outline: none;
-    //   }
-    // }
+    &:not([data-disabled]) {
+      /* &:hover, */
+      /* :not(:has(* > [data-highlighted])) > &:hover, */
+      &[data-radix-collection-item]:hover, // @radix-ui/react-navigation-menu
+      /* &:focus-visible, */
+      &[aria-selected="true"], // cmdk
+      &[data-highlighted] // @radix-ui
+      {
+        filter: brightness(var(--hover-filter-base));
+        background-color: var(--item-highlighted-backgroundColor);
+        color: var(--item-highlighted-textColor, var(--trigger-textColor, inherit)) !important;
+        outline: none;
+      }
+    }
 
     &[data-state='checked'], // @radix-ui
     &[aria-current='page'] // <a>
     {
-    //   background-color: var(
-    //     --item-checked-backgroundColor,
-    //     var(--trigger-selected-color, var(--popover-backgroundColor, inherit))
-    //   );
+      background-color: var(
+        --item-checked-backgroundColor,
+        var(--trigger-selected-color, var(--popover-backgroundColor, inherit))
+      );
       color: var(--item-checked-textColor, var(--trigger-textColor, inherit));
-      box-shadow: inset 0 -2px 0 var(--color-accent);
 
     }
   `,

--- a/src/styles/popoverMixins.ts
+++ b/src/styles/popoverMixins.ts
@@ -48,7 +48,7 @@ export const popoverMixins = {
     }
 
     &[data-state='open'] {
-      // background-color: var(--trigger-open-backgroundColor);
+      background-color: var(--trigger-open-backgroundColor);
       color: var(--trigger-open-textColor);
     }
   `,
@@ -248,7 +248,6 @@ export const popoverMixins = {
         var(--trigger-selected-color, var(--popover-backgroundColor, inherit))
       );
       color: var(--item-checked-textColor, var(--trigger-textColor, inherit));
-
     }
   `,
 } satisfies Record<string, ReturnType<typeof css>>;


### PR DESCRIPTION
known existing bug that I did not fix:
- when truncated, the "more" dropdown is also truncated :( tix [here](https://linear.app/dydx/issue/CT-1265/more-dropdown-gets-cut-off)

| w/o flag | w/ flag |
| ---- | ---- |
| <img width="1203" alt="Screenshot 2024-10-22 at 5 57 49 PM" src="https://github.com/user-attachments/assets/6415432a-b2a2-4d05-8f5c-ac863d47b4a7"> | <img width="1217" alt="Screenshot 2024-10-22 at 5 58 36 PM" src="https://github.com/user-attachments/assets/daed0354-9807-44f4-a5cb-4ab6bea9c7c2"> |



<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
