### PR TITLE
fix(horizontal-panel): Use displayable asset in Toolbar

### DIFF
--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -43,6 +43,7 @@ import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configsSel
 import { getHasUncommittedOrders } from '@/state/localOrdersSelectors';
 import { getCurrentMarketAssetId, getCurrentMarketId } from '@/state/perpetualsSelectors';
 
+import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { shortenNumberForDisplay } from '@/lib/numbers';
 import { testFlags } from '@/lib/testFlags';
@@ -396,7 +397,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
                               tw="text-[1.5em]"
                             />
                           ),
-                          label: currentMarketAssetId,
+                          label: getDisplayableAssetFromBaseAsset(currentMarketAssetId),
                         }
                       : { label: stringGetter({ key: STRING_KEYS.MARKET }) }),
                   },


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Fix non ui-refresh toolbar

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<HorizontalPanel>`
  - use `getDisplayableAssetFromBaseAsset` on `currentMarketAssetId`

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
