### PR TITLE
fix: match launch market button to updated search filter size

### DIFF
--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -63,7 +63,7 @@ export const MarketFilter = ({
   const launchMarketButton = uiRefresh ? (
     <Button
       onClick={() => navigate(`${AppRoute.Markets}/${MarketsRoute.New}`)}
-      size={ButtonSize.XSmall}
+      size={ButtonSize.Small}
       shape={ButtonShape.Pill}
       action={ButtonAction.Primary}
     >


### PR DESCRIPTION
| before | after | 
| ---- | ---- |
| <img width="690" alt="Screenshot 2024-10-22 at 6 36 55 PM" src="https://github.com/user-attachments/assets/f479b7ab-22f4-420a-85e1-85c13d184ca8"> | <img width="660" alt="Screenshot 2024-10-22 at 6 38 24 PM" src="https://github.com/user-attachments/assets/a265cb88-aa42-4d95-abc0-a7e8632a4193"> |


