### PR TITLE
feat: Use connect wallet button [OTE-887]

### DIFF
--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -19,6 +19,7 @@ type StyleProps = {
 type ElementProps = {
   label?: React.ReactNode;
   slotRight?: React.ReactNode;
+  preventDefault?: boolean;
   validationConfig?: {
     attached?: boolean;
     type: AlertType;
@@ -30,13 +31,23 @@ export type FormInputProps = ElementProps & StyleProps & InputProps;
 
 export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
   (
-    { id, label, slotRight, className, validationConfig, backgroundColorOverride, ...otherProps },
+    {
+      id,
+      label,
+      slotRight,
+      className,
+      validationConfig,
+      backgroundColorOverride,
+      preventDefault,
+      ...otherProps
+    },
     ref
   ) => (
     <$FormInputContainer className={className} isValidationAttached={validationConfig?.attached}>
       <$InputContainer hasLabel={!!label} hasSlotRight={!!slotRight}>
         {label ? (
           <$WithLabel
+            preventDefault={preventDefault}
             label={label}
             inputID={id}
             disabled={otherProps.disabled}

--- a/src/components/WithLabel.tsx
+++ b/src/components/WithLabel.tsx
@@ -6,15 +6,30 @@ type ElementProps = {
   label?: React.ReactNode;
   children?: React.ReactNode;
   inputID?: string;
+  preventDefault?: boolean;
 };
 
 type StyleProps = {
   className?: string;
 };
 
-export const WithLabel = ({ label, inputID, children, className }: ElementProps & StyleProps) => (
-  <$Container className={className} tw="grid gap-0.5 [--label-textColor:--color-text-1]">
-    <label htmlFor={inputID} tw="inlineRow text-[color:--label-textColor] font-mini-book">
+export const WithLabel = ({
+  label,
+  inputID,
+  children,
+  className,
+  preventDefault,
+}: ElementProps & StyleProps) => (
+  <$Container className={className} tw="grid [--label-textColor:--color-text-1]">
+    {/* Sometimes we don't want labels to trigger their contents' onClick properties */}
+    {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+    <label
+      htmlFor={inputID}
+      tw="inlineRow text-[color:--label-textColor] font-mini-book"
+      onClick={(e) => {
+        if (preventDefault) e.preventDefault();
+      }}
+    >
       {label}
     </label>
     {children}

--- a/src/constants/cctp.ts
+++ b/src/constants/cctp.ts
@@ -2,6 +2,7 @@ import { Asset } from '@skip-go/client';
 
 import cctpTokens from '../../public/configs/cctp.json';
 import { TransferType, TransferTypeType } from './abacus';
+import { SUPPORTED_COSMOS_CHAINS } from './graz';
 import { TransferType as NewTransferType } from './transfers';
 
 export type CctpTokenInfo = {
@@ -71,14 +72,15 @@ const lowestFeeTokensByChainIdMapWithdrawal = getMapOfLowestFeeTokensByChainId(
 const lowestFeeTokensByDenomDeposit = getMapOfLowestFeeTokensByDenom(TransferType.deposit);
 const lowestFeeTokensByDenomWithdrawal = getMapOfLowestFeeTokensByDenom(TransferType.withdrawal);
 
-// TODO: refactor these functions to include cosmos chains and denoms in lowest fees.
-// This will probably involve a non trivial amount of work so do in separate PR.
+// TODO [onboarding-rewrite]: refactor these functions to include cosmos chains and denoms in lowest fees.
+// We'll do this during the deposit flow rewrite. We may want separate functions for deposits and withdrawals.
 export const isLowFeeChainId = (chainId: string, type: NewTransferType) => {
   const lowFeeChainIdMap =
     type === NewTransferType.Deposit
       ? lowestFeeTokensByChainIdMapDeposit
       : lowestFeeTokensByChainIdMapWithdrawal;
-  return lowFeeChainIdMap[chainId];
+
+  return !!lowFeeChainIdMap[chainId] || SUPPORTED_COSMOS_CHAINS.includes(chainId);
 };
 
 export const isHighFeeChainId = (chainId: string, type: NewTransferType) => {

--- a/src/hooks/transfers/skipClient.tsx
+++ b/src/hooks/transfers/skipClient.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import {
   MsgWithdrawFromSubaccount,
@@ -17,17 +17,7 @@ import { RPCUrlsByChainId } from '@/lib/wagmi';
 import { useDydxClient } from '../useDydxClient';
 import { useEndpointsConfig } from '../useEndpointsConfig';
 
-type SkipContextType = ReturnType<typeof useSkipClientContext>;
-const SkipContext = createContext<SkipContextType>({} as SkipContextType);
-SkipContext.displayName = 'skipClient';
-
-export const SkipProvider = ({ ...props }) => (
-  <SkipContext.Provider value={useSkipClientContext()} {...props} />
-);
-
-export const useSkipClient = () => useContext(SkipContext);
-
-const useSkipClientContext = () => {
+export const useSkipClient = () => {
   const { solanaRpcUrl, nobleValidator, neutronValidator, osmosisValidator, validators } =
     useEndpointsConfig();
   const { compositeClient } = useDydxClient();

--- a/src/hooks/transfers/useTransfers.tsx
+++ b/src/hooks/transfers/useTransfers.tsx
@@ -292,8 +292,11 @@ export const useTransfers = () => {
       // If the user is connected via cosmos, set the address to whichever cosmos chain
       // that they have currently selected. Cosmos has a unique address per chain
       const calculatedCosmosAddress = toChainId && cosmosChainIdToAddressesMap[toChainId];
-      // This should never happen because a valid chainId should always be selected
-      setToAddress(calculatedCosmosAddress ?? '');
+      // If a user selects a non cosmos chain, we'll default to source address
+      // Doesn't really matter what address it is as long as it's a cosmos address.
+      // This will trigger a validation error so users will know to update the address
+      // or to reconnect with a wallet that supports that chain.
+      setToAddress(calculatedCosmosAddress ?? sourceAccount.address);
     } else {
       // If the user is connected to SVM or EVM, the sourceAccount.address is correct
       setToAddress(sourceAccount.address);

--- a/src/lib/__test__/addressUtils.spec.ts
+++ b/src/lib/__test__/addressUtils.spec.ts
@@ -1,6 +1,9 @@
+import { NOBLE_BECH32_PREFIX } from '@dydxprotocol/v4-client-js';
 import { describe, expect, it } from 'vitest';
 
-import { convertBech32Address } from '../addressUtils';
+import { NEUTRON_BECH32_PREFIX, OSMO_BECH32_PREFIX } from '@/constants/graz';
+
+import { convertBech32Address, isValidAddress } from '../addressUtils';
 
 describe('convertBech32Address', () => {
   const AXELAR_ADDRESS = 'axelar1vuedm6696nqmst4v73lchmx9vv3aw6c4j0zp3k';
@@ -25,6 +28,47 @@ describe('convertBech32Address', () => {
   it('can derive Cosmos Address from Axelar Address', () => {
     expect(convertBech32Address({ address: AXELAR_ADDRESS, bech32Prefix: 'cosmos' })).toEqual(
       COSMOS_ADDRESS
+    );
+  });
+});
+
+const EVM_ADDRESS = '0x0f7833777bfC9ef72D8B76AE954D3849DD71F829';
+const SVM_ADDRESS = '7AFKEVD1Q2wWTG78w7UEQcQs6Bvpt7SCRSytCgUknbnr';
+const COSMOS_ADDRESS = 'dydx1nhzuazjhyfu474er6v4ey8zn6wa5fy6g2dgp7s';
+describe('isValidAddress', () => {
+  it('returns false for no missing address', () => {
+    expect(isValidAddress({ network: 'evm' })).toBe(false);
+  });
+  it('returns false for evm network with non evm addresses', () => {
+    [SVM_ADDRESS, COSMOS_ADDRESS].forEach((address) => {
+      expect(isValidAddress({ network: 'evm', address })).toBe(false);
+    });
+  });
+  it('returns false for svm network with non svm addresses', () => {
+    [EVM_ADDRESS, COSMOS_ADDRESS].forEach((address) => {
+      expect(isValidAddress({ network: 'solana', address })).toBe(false);
+    });
+  });
+  it('returns false for cosmos network with non cosmos addresses', () => {
+    [SVM_ADDRESS, EVM_ADDRESS].forEach((address) => {
+      expect(isValidAddress({ network: 'cosmos', address, prefix: 'dydx' })).toBe(false);
+    });
+  });
+  it('returns false for cosmos network with incorrectly prefixed cosmos addresses', () => {
+    [NOBLE_BECH32_PREFIX, OSMO_BECH32_PREFIX, NEUTRON_BECH32_PREFIX].forEach((address) => {
+      expect(isValidAddress({ network: 'cosmos', address, prefix: 'dydx' })).toBe(false);
+    });
+  });
+  // TODO: figure out why viem throws 'expected uint8Array, got object' error in test env
+  // it('returns true for evm network with evm address', () => {
+  // expect(isValidAddress({ network: 'evm', address: EVM_ADDRESS })).toBe(true);
+  // });
+  it('returns true for svm network with svm address', () => {
+    expect(isValidAddress({ network: 'solana', address: SVM_ADDRESS })).toBe(true);
+  });
+  it('returns true for cosmos network with cosmos addresses', () => {
+    expect(isValidAddress({ network: 'cosmos', address: COSMOS_ADDRESS, prefix: 'dydx' })).toBe(
+      true
     );
   });
 });

--- a/src/lib/addressUtils.ts
+++ b/src/lib/addressUtils.ts
@@ -56,9 +56,10 @@ export function isValidAddress(input: MultiChainAddress): boolean {
   if (input.network === 'solana') {
     try {
       // Generating a publickey will demonstrate if an address is valid
-      // eslint-disable-next-line no-new
-      new PublicKey(input.address);
-      return true;
+      // https://solana.com/developers/cookbook/wallets/check-publickey
+      const publicKey = new PublicKey(input.address);
+      // Validate the public key with the `isOnCurve` method
+      return PublicKey.isOnCurve(publicKey.toBytes());
     } catch (_e) {
       return false;
     }

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/NetworkSelectMenu.tsx
@@ -2,6 +2,7 @@ import { Chain } from '@skip-go/client';
 import tw from 'twin.macro';
 
 import { cctpTokensByChainId, isHighFeeChainId, isLowFeeChainId } from '@/constants/cctp';
+import { SUPPORTED_COSMOS_CHAINS } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { MenuItem } from '@/constants/menus';
 import { TransferType } from '@/constants/transfers';
@@ -44,7 +45,7 @@ export const NetworkSelectMenu = ({
   const chainItems = chains
     .map((chain) => ({
       value: chain.chainID,
-      label: chain.chainName,
+      label: chain.prettyName,
       onSelect: () => {
         onSelectNetwork(chain.chainID);
       },
@@ -52,7 +53,7 @@ export const NetworkSelectMenu = ({
       slotAfter: getFeeDecoratorComponentForChainId(chain.chainID),
     }))
     .filter((chain) => {
-      return !!cctpTokensByChainId[chain.value];
+      return !!cctpTokensByChainId[chain.value] || SUPPORTED_COSMOS_CHAINS.includes(chain.value);
     });
 
   const { lowFeeChains, nonLowFeeChains } = chainItems.reduce(
@@ -88,15 +89,15 @@ export const NetworkSelectMenu = ({
       items: [...exchangeItems, ...lowFeeChains],
     },
     {
-      group: 'other-networks',
-      groupLabel: 'Other networks',
+      group: 'other-chains',
+      groupLabel: 'Other Chains',
       items: nonLowFeeChains,
     },
   ];
   const isPrivyDeposit = sourceAccount.walletInfo?.name === WalletType.Privy;
 
   return (
-    <SearchSelectMenu items={items.filter(isTruthy)} label="Destination" disabled={isPrivyDeposit}>
+    <SearchSelectMenu items={items.filter(isTruthy)} label="Chain" disabled={isPrivyDeposit}>
       <div tw="row gap-0.5 text-color-text-2 font-base-book">
         {selectedChainOption ? (
           <>

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/WithdrawForm.tsx
@@ -87,7 +87,9 @@ export const WithdrawForm = () => {
     txs,
     toToken,
     chainsForNetwork,
+    skipSupportedChains,
     routeLoading,
+    setToAddressToConnectedWalletAddress,
   } = useTransfers();
   const { skipClient } = useSkipClient();
 
@@ -421,22 +423,32 @@ export const WithdrawForm = () => {
         selectedChain={toChainId ?? undefined}
         onSelectNetwork={onSelectNetwork}
         onSelectExchange={onSelectExchange}
-        chains={chainsForNetwork}
+        chains={skipSupportedChains}
       />
       <FormInput
         type={InputType.Text}
         placeholder={stringGetter({ key: STRING_KEYS.ADDRESS })}
         onChange={onChangeAddress}
+        preventDefault
         value={toAddress ?? ''}
         label={
-          <span>
+          <span tw="row gap-[0.5ch]">
             {stringGetter({ key: STRING_KEYS.DESTINATION })}{' '}
             {isValidDestinationAddress ? (
-              <Icon
-                iconName={IconName.Check}
-                tw="mx-[1ch] my-0 text-[0.625rem] text-color-success"
-              />
-            ) : null}
+              <Icon iconName={IconName.Check} tw="my-0 text-[0.625rem] text-color-success" />
+            ) : (
+              <>
+                <div>•</div>
+                <button
+                  type="button"
+                  tw="text-color-accent"
+                  onClick={setToAddressToConnectedWalletAddress}
+                >
+                  {/* TODO [onboarding-rewrite]: localize this */}
+                  Use Connected Wallet
+                </button>
+              </>
+            )}
           </span>
         }
         validationConfig={
@@ -462,11 +474,11 @@ export const WithdrawForm = () => {
         onChange={onChangeAmount}
         value={debouncedAmount}
         label={
-          <div tw="flex">
+          <span tw="row gap-[0.5ch]">
             <div>{stringGetter({ key: STRING_KEYS.AMOUNT })}</div>
-            <div tw="ml-0.25 mr-0.25"> • </div>
+            <div>•</div>
             <div>{freeCollateral?.current?.toFixed(2)} USDC Held</div>
-          </div>
+          </span>
         }
         slotRight={
           <FormMaxInputToggleButton

--- a/src/views/forms/AccountManagementFormsNew/WithdrawForm/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementFormsNew/WithdrawForm/WithdrawForm.tsx
@@ -86,7 +86,6 @@ export const WithdrawForm = () => {
     route,
     txs,
     toToken,
-    chainsForNetwork,
     skipSupportedChains,
     routeLoading,
     setToAddressToConnectedWalletAddress,


### PR DESCRIPTION
Adds a smol "Use Connected Wallet" button in the withdraw form that sets the toAddress bar to the user's connected address, with some reasonable defaults/assumptions.

EVM -> uses connected wallet address from state
SVM -> uses connected wallet address from state
Cosmos -> grabs the wallet address for the given chain ID (cosmos provides a unique wallet address for each chain), or defaults to dydx if selected chain ID is **not** a supported cosmos chain ID

We intentionally do **not** gate this functionality by correctness. e.g. a user connected via phantom can select "ethereum" and the button will populate the input with their phantom SVM address. We have validation that will let users know that the address is invalid. This is a more intuitive experience than the button just not doing anything if conditions aren't met.

We also intentionally are **not** clearing the `toAddress` state when the user switches chains. We can add this if we find that users want this but it's added work for no clear benefit. 
In order to be confident what experience to serve, we need to know whether or not more users are switching chains because they want to use a different wallet (they would want to clear) or because they misclicked the chain they wanted (they would not want to clear). 

Metamask connected experience
https://www.loom.com/share/0dd8275d22d54e5ebb616c7e07a36bb3?sid=2d8a8c13-4226-43ef-93f3-559ce0377cf1

Keplr connected experience
https://www.loom.com/share/51f5add5555746289b1241e13e7d476d?sid=9324b764-565b-4467-b38d-f6b368717eea

Phantom connected experience
https://www.loom.com/share/768be3a51fd74d48b138d3582cc3304d?sid=c7257781-dc2d-4d97-a86a-6ae606034cc9