### PR TITLE
feat(uirefresh): new user wizard - generate keys

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -76,7 +76,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
             {withContentOnLoading && slotLeft}
             {withContentOnLoading && children}
             {withContentOnLoading && slotRight}
-            <LoadingDots size={3} />
+            {!withContentOnLoading && <LoadingDots size={3} />}
           </>
         ) : (
           <>

--- a/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
+++ b/src/views/dialogs/OnboardingDialog/GenerateKeys.tsx
@@ -212,6 +212,10 @@ export const GenerateKeys = ({ status, setStatus, onKeysDerived = () => {} }: El
           .filter(isTruthy)
           .map((step) => (
             <$StatusCard key={step.status} active={status === step.status}>
+              <div>
+                <h3>{step.title}</h3>
+                <p>{step.description}</p>
+              </div>
               {status < step.status ? (
                 <LoadingSpinner disabled />
               ) : status === step.status ? (
@@ -219,16 +223,12 @@ export const GenerateKeys = ({ status, setStatus, onKeysDerived = () => {} }: El
               ) : (
                 <GreenCheckCircle tw="[--icon-size:2.375rem]" />
               )}
-              <div>
-                <h3>{step.title}</h3>
-                <p>{step.description}</p>
-              </div>
             </$StatusCard>
           ))}
       </div>
 
       <$Footer>
-        <label htmlFor="remember-me" tw="spacedRow font-base-book">
+        <label htmlFor="remember-me" tw="spacedRow text-color-text-1 font-small-bold">
           <WithTooltip withIcon tooltip="remember-me">
             {stringGetter({ key: STRING_KEYS.REMEMBER_ME })}
           </WithTooltip>
@@ -243,7 +243,7 @@ export const GenerateKeys = ({ status, setStatus, onKeysDerived = () => {} }: El
         {error && <AlertMessage type={AlertType.Error}>{error}</AlertMessage>}
         <WithReceipt
           slotReceipt={
-            <div tw="p-1 text-color-text-0 font-small-book">
+            <div tw="p-1 text-center text-color-text-0 font-small-medium">
               <span>
                 {stringGetter({
                   key: STRING_KEYS.FREE_SIGNING,
@@ -270,41 +270,45 @@ export const GenerateKeys = ({ status, setStatus, onKeysDerived = () => {} }: El
             </Button>
           ) : (
             <Button
+              tw="font-small-bold"
               action={ButtonAction.Primary}
               onClick={onClickSendRequestOrTryAgain}
+              withContentOnLoading
               state={{
                 isLoading: isDeriving,
                 isDisabled: status !== EvmDerivedAccountStatus.NotDerived,
               }}
             >
-              {!error
+              {isDeriving
                 ? stringGetter({
-                    key: STRING_KEYS.SEND_REQUEST,
+                    key: STRING_KEYS.CHECK_WALLET_FOR_REQUEST,
                   })
-                : stringGetter({
-                    key: STRING_KEYS.TRY_AGAIN,
-                  })}
+                : !error
+                  ? stringGetter({
+                      key: STRING_KEYS.SEND_REQUEST,
+                    })
+                  : stringGetter({
+                      key: STRING_KEYS.TRY_AGAIN,
+                    })}
             </Button>
           )}
         </WithReceipt>
-        <span tw="text-center text-color-text-0 font-base-book">
-          {stringGetter({ key: STRING_KEYS.CHECK_WALLET_FOR_REQUEST })}
-        </span>
       </$Footer>
     </>
   );
 };
 const $StatusCard = styled.div<{ active?: boolean }>`
-  ${layoutMixins.row}
+  ${layoutMixins.spacedRow}
   gap: 1rem;
   background-color: var(--color-layer-4);
   padding: 1rem;
+  border: var(--border);
   border-radius: 0.625rem;
 
   ${({ active }) =>
     active &&
     css`
-      background-color: var(--color-layer-6);
+      background-color: var(--color-layer-5);
     `}
   > div {
     ${layoutMixins.column}
@@ -316,8 +320,8 @@ const $StatusCard = styled.div<{ active?: boolean }>`
     }
 
     p {
-      color: var(--color-text-1);
-      font: var(--font-small-regular);
+      color: var(--color-text-0);
+      font: var(--font-small-medium);
     }
   }
 `;


### PR DESCRIPTION
figma [mock](https://www.figma.com/design/fMQodZKzn9B5aZTN5G0fLJ/dYdX-%E2%80%BA-Web?node-id=42754-198329&node-type=frame&t=iPyae9XP1sscvOTU-0). 

figured we could get away with not flagging since it's not a big diff / mainly just swapping the side of the check mark and text.

Updated `Button` `withContentOnLoading` behavior.

https://github.com/user-attachments/assets/c25ec4a9-a48a-46d1-ba72-794dccedff2e



