### PR TITLE
fix(pml-toggle): Fix Toggle + misc

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -55,6 +55,7 @@ export const AssetIcon = ({
 
 const $AssetIcon = styled.img`
   --asset-icon-size: 1em;
+  background-color: var(--color-white);
 
   height: var(--asset-icon-size);
   min-height: var(--asset-icon-size);

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -30,6 +30,7 @@ export enum LocalStorageKey {
   HasSeenLaunchIncentives = 'dydx.HasSeenLaunchIncentives',
   DefaultToAllMarketsInPositionsOrdersFills = 'dydx.DefaultToAllMarketsInPositionsOrdersFills',
   SelectedDisplayUnit = 'dydx.SelectedDisplayUnit',
+  ShouldHideLaunchableMarkets = 'dydx.shouldHideLaunchableMarkets',
 
   // Discoverability
   HasSeenElectionBannerTRUMPWIN = 'dydx.HasSeenElectionBannerTRUMPWIN',

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -19,6 +19,7 @@ import {
 
 import { useAppSelector } from '@/state/appTypes';
 import { getAssets } from '@/state/assetsSelectors';
+import { getShouldHideLaunchableMarkets } from '@/state/configsSelectors';
 import { getPerpetualMarkets, getPerpetualMarketsClobIds } from '@/state/perpetualsSelectors';
 
 import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
@@ -133,6 +134,8 @@ export const useMarketsData = ({
   const featureFlags = useAllStatsigGateValues();
   const unlaunchedMarkets = useMetadataService();
   const hasMarketIds = Object.keys(allPerpetualMarkets).length > 0;
+  const shouldHideLaunchableMarkets =
+    useAppSelector(getShouldHideLaunchableMarkets) || hideUnlaunchedMarkets;
 
   const markets = useMemo(() => {
     const listOfMarkets = Object.values(allPerpetualMarkets)
@@ -191,7 +194,7 @@ export const useMarketsData = ({
         );
       });
 
-    if (!hideUnlaunchedMarkets && testFlags.pml) {
+    if (!shouldHideLaunchableMarkets && testFlags.pml) {
       const unlaunchedMarketsData = Object.values(unlaunchedMarkets.data)
         .sort(sortByMarketCap)
         .map((market) => {

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -191,7 +191,7 @@ export const useMarketsData = ({
         );
       });
 
-    if (unlaunchedMarkets.data && !hideUnlaunchedMarkets && testFlags.pml) {
+    if (!hideUnlaunchedMarkets && testFlags.pml) {
       const unlaunchedMarketsData = Object.values(unlaunchedMarkets.data)
         .sort(sortByMarketCap)
         .map((market) => {

--- a/src/pages/trade/LaunchableMarket.tsx
+++ b/src/pages/trade/LaunchableMarket.tsx
@@ -18,6 +18,8 @@ import { LaunchMarketSidePanel } from '@/views/LaunchMarketSidePanel';
 import { useAppSelector } from '@/state/appTypes';
 import { getSelectedTradeLayout } from '@/state/layoutSelectors';
 
+import { testFlags } from '@/lib/testFlags';
+
 import { HorizontalPanel } from './HorizontalPanel';
 import { InnerPanel } from './InnerPanel';
 import { MarketSelectorAndStats } from './MarketSelectorAndStats';
@@ -31,6 +33,7 @@ const LaunchableMarket = () => {
   const tradeLayout = useAppSelector(getSelectedTradeLayout);
   const match = useMatch(`/${AppRoute.Trade}/:marketId`);
   const { marketId } = match?.params ?? {};
+  const { uiRefresh } = testFlags;
 
   const [isHorizontalPanelOpen, setIsHorizontalPanelOpen] = useState(true);
 
@@ -63,8 +66,9 @@ const LaunchableMarket = () => {
       </header>
 
       <$GridSection gridArea="Side" tw="grid-rows-[auto_minmax(0,1fr)]">
-        <AccountInfo />
+        {!uiRefresh && <AccountInfo />}
         <$LaunchMarketSidePanel launchableMarketId={marketId} />
+        {uiRefresh && <AccountInfo />}
       </$GridSection>
 
       <$GridSection gridArea="Inner">

--- a/src/state/configs.ts
+++ b/src/state/configs.ts
@@ -50,6 +50,7 @@ export interface ConfigsState {
   hasSeenLaunchIncentives: boolean;
   defaultToAllMarketsInPositionsOrdersFills: boolean;
   displayUnit: DisplayUnit;
+  shouldHideLaunchableMarkets: boolean;
 }
 
 const { uiRefresh } = testFlags;
@@ -67,6 +68,10 @@ const initialState: ConfigsState = {
   feeTiers: undefined,
   equityTiers: undefined,
   network: undefined,
+  shouldHideLaunchableMarkets: getLocalStorage({
+    key: LocalStorageKey.ShouldHideLaunchableMarkets,
+    defaultValue: false,
+  }),
   hasSeenLaunchIncentives: getLocalStorage({
     key: LocalStorageKey.HasSeenLaunchIncentives,
     defaultValue: false,
@@ -132,6 +137,10 @@ export const configsSlice = createSlice({
         })
       );
     },
+    setShouldHideLaunchableMarkets: (state: ConfigsState, action: PayloadAction<boolean>) => {
+      setLocalStorage({ key: LocalStorageKey.ShouldHideLaunchableMarkets, value: action.payload });
+      state.shouldHideLaunchableMarkets = action.payload;
+    },
   },
 });
 
@@ -142,4 +151,5 @@ export const {
   setConfigs,
   markLaunchIncentivesSeen,
   setDisplayUnit,
+  setShouldHideLaunchableMarkets,
 } = configsSlice.actions;

--- a/src/state/configsSelectors.ts
+++ b/src/state/configsSelectors.ts
@@ -56,3 +56,6 @@ export const getDefaultToAllMarketsInPositionsOrdersFills = (state: RootState) =
   state.configs.defaultToAllMarketsInPositionsOrdersFills;
 
 export const getSelectedDisplayUnit = (state: RootState) => state.configs.displayUnit;
+
+export const getShouldHideLaunchableMarkets = (state: RootState) =>
+  state.configs.shouldHideLaunchableMarkets;

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
@@ -22,6 +22,10 @@ import { NewTag } from '@/components/Tag';
 import { ToggleGroup } from '@/components/ToggleGroup';
 import { WithLabel } from '@/components/WithLabel';
 
+import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { setShouldHideLaunchableMarkets } from '@/state/configs';
+import { getShouldHideLaunchableMarkets } from '@/state/configsSelectors';
+
 import { testFlags } from '@/lib/testFlags';
 
 type MarketFilterProps = {
@@ -32,10 +36,6 @@ type MarketFilterProps = {
   hideNewMarketButton?: boolean;
   searchPlaceholderKey?: string;
   compactLayout?: boolean;
-
-  // Need both items to display unlaunchedMarketSwitch
-  shouldHideUnlaunchedMarkets?: boolean;
-  onShouldHideUnlaunchedMarketsChange?: (shouldHide: boolean) => void;
 };
 
 export const MarketFilter = ({
@@ -46,36 +46,42 @@ export const MarketFilter = ({
   hideNewMarketButton,
   compactLayout = false,
   searchPlaceholderKey = STRING_KEYS.MARKET_SEARCH_PLACEHOLDER,
-  shouldHideUnlaunchedMarkets,
-  onShouldHideUnlaunchedMarketsChange,
 }: MarketFilterProps) => {
   const stringGetter = useStringGetter();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const { hasPotentialMarketsData } = usePotentialMarkets();
   const { uiRefresh, pml: showLaunchMarkets } = testFlags;
   const showProposeButton = hasPotentialMarketsData && !hideNewMarketButton;
+  const shouldHideLaunchableMarkets = useAppSelector(getShouldHideLaunchableMarkets);
+
+  const onShouldHideLaunchableMarkets = useCallback(
+    (shouldHide: boolean) => {
+      dispatch(setShouldHideLaunchableMarkets(!shouldHide));
+    },
+    [dispatch]
+  );
 
   const unlaunchedMarketSwitch = useMemo(
     () =>
-      shouldHideUnlaunchedMarkets != null &&
-      onShouldHideUnlaunchedMarketsChange != null && (
+      testFlags.pml && (
         <WithLabel
           label={stringGetter({ key: STRING_KEYS.SHOW_LAUNCHABLE_MARKETS })}
           tw="flex flex-row items-center"
         >
           <Switch
             name="show-launchable"
-            checked={!shouldHideUnlaunchedMarkets}
-            onCheckedChange={onShouldHideUnlaunchedMarketsChange}
+            checked={!shouldHideLaunchableMarkets}
+            onCheckedChange={onShouldHideLaunchableMarkets}
             tw="font-mini-book"
           />
         </WithLabel>
       ),
-    [stringGetter, shouldHideUnlaunchedMarkets, onShouldHideUnlaunchedMarketsChange]
+    [stringGetter, onShouldHideLaunchableMarkets, shouldHideLaunchableMarkets]
   );
 
   const filterLaunchable = (filter: MarketFilters) => {
-    if (!shouldHideUnlaunchedMarkets) return true;
+    if (!shouldHideLaunchableMarkets) return true;
     return filter !== MarketFilters.LAUNCHABLE;
   };
 

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -65,7 +65,7 @@ export const MarketFilter = ({
         >
           <Switch
             name="show-launchable"
-            checked={shouldHideUnlaunchedMarkets}
+            checked={!shouldHideUnlaunchedMarkets}
             onCheckedChange={onShouldHideUnlaunchedMarketsChange}
             tw="font-mini-book"
           />
@@ -75,7 +75,7 @@ export const MarketFilter = ({
   );
 
   const filterLaunchable = (filter: MarketFilters) => {
-    if (shouldHideUnlaunchedMarkets) return true;
+    if (!shouldHideUnlaunchedMarkets) return true;
     return filter !== MarketFilters.LAUNCHABLE;
   };
 

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -53,7 +53,6 @@ const MarketsDropdownContent = ({
   const [filter, setFilter] = useState(MarketFilters.ALL);
   const stringGetter = useStringGetter();
   const [searchFilter, setSearchFilter] = useState<string>();
-  const [shouldHideUnlaunchedMarkets, setShouldHideUnlaunchedMarkets] = useState(false);
   const navigate = useNavigate();
   const featureFlags = useAllStatsigGateValues();
   const { hasPotentialMarketsData } = usePotentialMarkets();
@@ -62,7 +61,6 @@ const MarketsDropdownContent = ({
   const { filteredMarkets, marketFilters } = useMarketsData({
     filter,
     searchFilter,
-    hideUnlaunchedMarkets: shouldHideUnlaunchedMarkets,
   });
 
   const columns = useMemo(
@@ -212,8 +210,6 @@ const MarketsDropdownContent = ({
           filters={marketFilters}
           onChangeFilter={setFilter}
           onSearchTextChange={setSearchFilter}
-          shouldHideUnlaunchedMarkets={shouldHideUnlaunchedMarkets}
-          onShouldHideUnlaunchedMarketsChange={setShouldHideUnlaunchedMarkets}
         />
       </$Toolbar>
       {slotTop}

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -38,6 +38,7 @@ import { openDialog } from '@/state/dialogs';
 import { getCurrentInput, getInputTradeMarginMode } from '@/state/inputsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
+import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 import { isTruthy } from '@/lib/isTruthy';
 import { nullIfZero } from '@/lib/numbers';
 import { testFlags } from '@/lib/testFlags';
@@ -183,7 +184,11 @@ export const PlaceOrderButtonAndReceipt = ({
       {
         key: 'liquidation-price',
         label: (
-          <WithTooltip tooltip="liquidation-price" stringParams={{ SYMBOL: id ?? '' }} side="right">
+          <WithTooltip
+            tooltip="liquidation-price"
+            stringParams={{ SYMBOL: getDisplayableAssetFromBaseAsset(id) }}
+            side="right"
+          >
             {stringGetter({ key: STRING_KEYS.LIQUIDATION_PRICE })}
           </WithTooltip>
         ),

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -43,6 +43,7 @@ import { getSelectedLocale } from '@/state/localizationSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
+import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 import { MustBigNumber } from '@/lib/numbers';
 
 import { MarketLeverageInput } from './MarketLeverageInput';
@@ -214,7 +215,7 @@ export const TradeSizeInputs = () => {
         <>
           <WithTooltip
             tooltip={inputConfig.tooltipId as TooltipStringKeys}
-            stringParams={{ SYMBOL: id ?? '' }}
+            stringParams={{ SYMBOL: getDisplayableAssetFromBaseAsset(id) }}
             side="right"
           >
             {stringGetter({ key: STRING_KEYS.AMOUNT })}

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -43,13 +43,11 @@ export const MarketsTable = ({ className }: { className?: string }) => {
   const dispatch = useAppDispatch();
   const filter: MarketFilters = useAppSelector(getMarketFilter);
   const [searchFilter, setSearchFilter] = useState<string>();
-  const [shouldHideUnlaunchedMarkets, setShouldHideUnlaunchedMarkets] = useState(false);
   const navigate = useNavigate();
 
   const { filteredMarkets, marketFilters, hasMarketIds } = useMarketsData({
     filter,
     searchFilter,
-    hideUnlaunchedMarkets: shouldHideUnlaunchedMarkets,
   });
 
   const { hasPotentialMarketsData } = usePotentialMarkets();
@@ -253,8 +251,6 @@ export const MarketsTable = ({ className }: { className?: string }) => {
           filters={marketFilters}
           onChangeFilter={setFilter}
           onSearchTextChange={setSearchFilter}
-          shouldHideUnlaunchedMarkets={shouldHideUnlaunchedMarkets}
-          onShouldHideUnlaunchedMarketsChange={setShouldHideUnlaunchedMarkets}
         />
       </$Toolbar>
 

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -51,6 +51,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
     searchFilter,
     hideUnlaunchedMarkets: shouldHideUnlaunchedMarkets,
   });
+
   const { hasPotentialMarketsData } = usePotentialMarkets();
 
   const columns = useMemo<ColumnDef<MarketData>[]>(


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
- Fix `shouldHideLaunchableMarkets` toggle and convert from useState to redux state
- Give `AssetIcon` white background
- Fix position of `<AccountInfo>` component
- Fix tooltips that use `AssetId`

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<PlaceOrderAndButtonReceipt>`, `<TradeSizeInputs>`
  - use `getDisplayableAssetFromBaseAsset` to fix display of tooltip

- `<MarketFilter>`
  - Fix toggle (it was inverted)
  - Use dispatch and selector for `shouldHideLaunchableMarkets`

- `<LaunchableMarket>`
  - keep UI refresh conditional consistent with `<Trade>` page 

## Components

- `<AssetIcon>`
  - give `img` a white background for icons that use transparency

## Constants/Types

- `constants/localStorage`
  - add `shouldHideLaunchableMarkets` localStorageKey

## Hooks

- `hooks/useMarketsData`
  - use redux version of `shouldHideLaunchableMarkets`

## State

- `state/configs`, `state/configsSelectors`
  - add `shouldHideLaunchableMarkets` to configs and selectors to persist user session

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
