### PR TITLE
chore: separating app UI configs slice

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -23,7 +23,7 @@ import {
   AppThemeSystemSetting,
   setAppColorMode,
   setAppThemeSetting,
-} from '@/state/configs';
+} from '@/state/appUiConfigs';
 import { setLocaleLoaded, setSelectedLocale } from '@/state/localization';
 
 import './ladle.css';
@@ -65,7 +65,7 @@ export const StoryWrapper: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <Provider store={store}>
-      <div tw="flex flex-row items-center gap-[8px] ">
+      <div tw="flex flex-row items-center gap-[8px]">
         <h4>Active Theme:</h4>
         <SelectMenu value={theme} onValueChange={setTheme}>
           {[

--- a/src/components/DisplayUnitTag.tsx
+++ b/src/components/DisplayUnitTag.tsx
@@ -7,8 +7,8 @@ import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
 import { DisplayUnit } from '@/constants/trade';
 
 import { useAppSelector } from '@/state/appTypes';
-import { setDisplayUnit } from '@/state/configs';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+import { setDisplayUnit } from '@/state/appUiConfigs';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 
 import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 

--- a/src/components/QrCode.tsx
+++ b/src/components/QrCode.tsx
@@ -4,8 +4,8 @@ import QRCodeStyling, { Options } from 'qr-code-styling';
 import styled from 'styled-components';
 
 import { useAppSelector } from '@/state/appTypes';
-import { AppTheme } from '@/state/configs';
-import { getAppTheme } from '@/state/configsSelectors';
+import { AppTheme } from '@/state/appUiConfigs';
+import { getAppTheme } from '@/state/appUiConfigsSelectors';
 
 type ElementProps = {
   value: string;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -24,13 +24,7 @@ export enum LocalStorageKey {
   LastViewedMarket = 'dydx.LastViewedMarket',
   SelectedLocale = 'dydx.SelectedLocale',
   SelectedNetwork = 'dydx.SelectedNetwork',
-  SelectedTheme = 'dydx.SelectedTheme',
-  SelectedColorMode = 'dydx.SelectedColorMode',
   SelectedTradeLayout = 'dydx.SelectedTradeLayout',
-  HasSeenLaunchIncentives = 'dydx.HasSeenLaunchIncentives',
-  DefaultToAllMarketsInPositionsOrdersFills = 'dydx.DefaultToAllMarketsInPositionsOrdersFills',
-  SelectedDisplayUnit = 'dydx.SelectedDisplayUnit',
-  ShouldHideLaunchableMarkets = 'dydx.shouldHideLaunchableMarkets',
 
   // Discoverability
   HasSeenElectionBannerTRUMPWIN = 'dydx.HasSeenElectionBannerTRUMPWIN',

--- a/src/constants/styles/colors.ts
+++ b/src/constants/styles/colors.ts
@@ -1,6 +1,6 @@
 import type { ThemeName } from 'public/tradingview/charting_library';
 
-import { AppColorMode, AppTheme } from '@/state/configs';
+import { AppColorMode, AppTheme } from '@/state/appUiConfigs';
 
 export const THEME_NAMES: Record<AppTheme, ThemeName> = {
   [AppTheme.Classic]: 'Classic',

--- a/src/hooks/tradingView/useChartLines.tsx
+++ b/src/hooks/tradingView/useChartLines.tsx
@@ -21,7 +21,7 @@ import {
   getIsAccountConnected,
 } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 import {
   cancelOrderFailed,
   cancelOrderSubmitted,

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -18,7 +18,7 @@ import type { TvWidget } from '@/constants/tvchart';
 
 import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 import { updateChartConfig } from '@/state/tradingView';

--- a/src/hooks/tradingView/useTradingViewDatafeed.ts
+++ b/src/hooks/tradingView/useTradingViewDatafeed.ts
@@ -30,7 +30,7 @@ import { Themes } from '@/styles/themes';
 import { store } from '@/state/_store';
 import { getMarketFills } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { setCandles } from '@/state/perpetuals';
 import {

--- a/src/hooks/tradingView/useTradingViewDatafeed.ts
+++ b/src/hooks/tradingView/useTradingViewDatafeed.ts
@@ -233,7 +233,7 @@ export const useTradingViewDatafeed = (
               );
             }
 
-            const volumeUnit = store.getState().configs.displayUnit;
+            const volumeUnit = store.getState().appUiConfigs.displayUnit;
 
             const bars = [
               ...cachedBars,

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -14,7 +14,7 @@ import { SUPPORTED_LOCALE_BASE_TAGS } from '@/constants/localization';
 import type { TvWidget } from '@/constants/tvchart';
 
 import { useAppSelector } from '@/state/appTypes';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 import { updateLaunchableMarketsChartConfig } from '@/state/tradingView';
 import { getTvChartConfig } from '@/state/tradingViewSelectors';

--- a/src/hooks/tradingView/useTradingViewTheme.ts
+++ b/src/hooks/tradingView/useTradingViewTheme.ts
@@ -4,8 +4,8 @@ import { THEME_NAMES } from '@/constants/styles/colors';
 import type { ChartLine, TvWidget } from '@/constants/tvchart';
 
 import { useAppSelector } from '@/state/appTypes';
-import { AppColorMode, AppTheme } from '@/state/configs';
-import { getAppColorMode, getAppTheme } from '@/state/configsSelectors';
+import { AppColorMode, AppTheme } from '@/state/appUiConfigs';
+import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 
 import { assertNever } from '@/lib/assertNever';
 import { getChartLineColors, getWidgetOverrides } from '@/lib/tradingView/utils';

--- a/src/hooks/useAppThemeAndColorMode.tsx
+++ b/src/hooks/useAppThemeAndColorMode.tsx
@@ -5,8 +5,13 @@ import { ThemeProvider } from 'styled-components';
 import { Themes } from '@/styles/themes';
 
 import { useAppSelector } from '@/state/appTypes';
-import { AppColorMode, AppTheme, AppThemeSetting, AppThemeSystemSetting } from '@/state/configs';
-import { getAppColorMode, getAppThemeSetting } from '@/state/configsSelectors';
+import {
+  AppColorMode,
+  AppTheme,
+  AppThemeSetting,
+  AppThemeSystemSetting,
+} from '@/state/appUiConfigs';
+import { getAppColorMode, getAppThemeSetting } from '@/state/appUiConfigsSelectors';
 
 import { assertNever } from '@/lib/assertNever';
 

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -18,8 +18,8 @@ import {
 } from '@/hooks/usePerpetualMarketSparklines';
 
 import { useAppSelector } from '@/state/appTypes';
+import { getShouldHideLaunchableMarkets } from '@/state/appUiConfigsSelectors';
 import { getAssets } from '@/state/assetsSelectors';
-import { getShouldHideLaunchableMarkets } from '@/state/configsSelectors';
 import { getPerpetualMarkets, getPerpetualMarketsClobIds } from '@/state/perpetualsSelectors';
 
 import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';

--- a/src/hooks/usePreferenceMenu.tsx
+++ b/src/hooks/usePreferenceMenu.tsx
@@ -15,8 +15,11 @@ import { useStringGetter } from '@/hooks/useStringGetter';
 import { Switch } from '@/components/Switch';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { OtherPreference, setDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configs';
-import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configsSelectors';
+import {
+  OtherPreference,
+  setDefaultToAllMarketsInPositionsOrdersFills,
+} from '@/state/appUiConfigs';
+import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/appUiConfigsSelectors';
 import { setSelectedTradeLayout } from '@/state/layout';
 import { getSelectedTradeLayout } from '@/state/layoutSelectors';
 

--- a/src/icons/chaos-labs.tsx
+++ b/src/icons/chaos-labs.tsx
@@ -1,6 +1,6 @@
 import { useAppSelector } from '@/state/appTypes';
-import { AppTheme } from '@/state/configs';
-import { getAppTheme } from '@/state/configsSelectors';
+import { AppTheme } from '@/state/appUiConfigs';
+import { getAppTheme } from '@/state/appUiConfigsSelectors';
 
 export const ChaosLabsIcon: React.FC = () => {
   const appTheme = useAppSelector(getAppTheme);

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -29,7 +29,7 @@ import { NetworkSelectMenu } from '@/views/menus/NetworkSelectMenu';
 import { NotificationsMenu } from '@/views/menus/NotificationsMenu';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getHasSeenLaunchIncentives } from '@/state/configsSelectors';
+import { getHasSeenLaunchIncentives } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
 
 import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -12,7 +12,7 @@ import type { ChartLineType } from '@/constants/tvchart';
 
 import { Themes } from '@/styles/themes';
 
-import { AppTheme, type AppColorMode } from '@/state/configs';
+import { AppTheme, type AppColorMode } from '@/state/appUiConfigs';
 
 import { getDisplayableTickerFromMarket } from '../assetUtils';
 import { testFlags } from '../testFlags';

--- a/src/pages/token/LaunchIncentivesPanel.tsx
+++ b/src/pages/token/LaunchIncentivesPanel.tsx
@@ -24,7 +24,7 @@ import { Panel } from '@/components/Panel';
 import { TagSize, WarningTag } from '@/components/Tag';
 
 import { useAppDispatch } from '@/state/appTypes';
-import { markLaunchIncentivesSeen } from '@/state/configs';
+import { markLaunchIncentivesSeen } from '@/state/appUiConfigs';
 import { openDialog } from '@/state/dialogs';
 
 export const LaunchIncentivesPanel = ({ className }: { className?: string }) => {

--- a/src/pages/token/StakingRewardPanel.tsx
+++ b/src/pages/token/StakingRewardPanel.tsx
@@ -21,7 +21,7 @@ import { Panel } from '@/components/Panel';
 import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getStakingRewards } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getChartDotBackground } from '@/state/configsSelectors';
+import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
 
 import { BigNumberish } from '@/lib/numbers';

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -38,8 +38,8 @@ import {
   getTradeInfoNumbers,
 } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
+import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/appUiConfigsSelectors';
 import { getAssetImageUrl } from '@/state/assetsSelectors';
-import { getDefaultToAllMarketsInPositionsOrdersFills } from '@/state/configsSelectors';
 import { getHasUncommittedOrders } from '@/state/localOrdersSelectors';
 import { getCurrentMarketAssetId, getCurrentMarketId } from '@/state/perpetualsSelectors';
 

--- a/src/pages/vaults/VaultPnlChart.tsx
+++ b/src/pages/vaults/VaultPnlChart.tsx
@@ -22,7 +22,7 @@ import { TriangleIndicator } from '@/components/TriangleIndicator';
 import { TimeSeriesChart } from '@/components/visx/TimeSeriesChart';
 
 import { useAppSelector } from '@/state/appTypes';
-import { getChartDotBackground } from '@/state/configsSelectors';
+import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { MustBigNumber, getNumberSign } from '@/lib/numbers';

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -49,7 +49,7 @@ const rootReducer = combineReducers(reducers);
 
 const persistConfig = {
   key: 'root',
-  version: 2,
+  version: 3,
   storage,
   whitelist: ['affiliates', 'dismissable', 'tradingView', 'wallet', 'appUiConfigs'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),

--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -8,6 +8,7 @@ import { accountSlice } from './account';
 import { affiliatesSlice } from './affiliates';
 import { appSlice } from './app';
 import appMiddleware from './appMiddleware';
+import { appUiConfigsSlice } from './appUiConfigs';
 import { assetsSlice } from './assets';
 import { configsSlice } from './configs';
 import { dialogsSlice } from './dialogs';
@@ -28,6 +29,7 @@ const reducers = {
   account: accountSlice.reducer,
   affiliates: affiliatesSlice.reducer,
   app: appSlice.reducer,
+  appUiConfigs: appUiConfigsSlice.reducer,
   assets: assetsSlice.reducer,
   configs: configsSlice.reducer,
   dialogs: dialogsSlice.reducer,
@@ -49,7 +51,7 @@ const persistConfig = {
   key: 'root',
   version: 2,
   storage,
-  whitelist: ['affiliates', 'dismissable', 'tradingView', 'wallet'],
+  whitelist: ['affiliates', 'dismissable', 'tradingView', 'wallet', 'appUiConfigs'],
   migrate: customCreateMigrate({ debug: process.env.NODE_ENV !== 'production' }),
 };
 

--- a/src/state/appUiConfigs.ts
+++ b/src/state/appUiConfigs.ts
@@ -1,11 +1,9 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { AnalyticsEvents } from '@/constants/analytics';
-import { LocalStorageKey } from '@/constants/localStorage';
 import { DisplayUnit } from '@/constants/trade';
 
 import { track } from '@/lib/analytics/analytics';
-import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
 import { testFlags } from '@/lib/testFlags';
 
 export enum AppTheme {
@@ -42,31 +40,13 @@ export interface AppUIConfigsState {
 
 const { uiRefresh } = testFlags;
 
-const initialState: AppUIConfigsState = {
-  appThemeSetting: getLocalStorage({
-    key: LocalStorageKey.SelectedTheme,
-    defaultValue: uiRefresh ? AppTheme.Dark : AppTheme.Classic,
-  }),
-  appColorMode: getLocalStorage({
-    key: LocalStorageKey.SelectedColorMode,
-    defaultValue: AppColorMode.GreenUp,
-  }),
-  hasSeenLaunchIncentives: getLocalStorage({
-    key: LocalStorageKey.HasSeenLaunchIncentives,
-    defaultValue: false,
-  }),
-  defaultToAllMarketsInPositionsOrdersFills: getLocalStorage({
-    key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
-    defaultValue: true,
-  }),
-  displayUnit: getLocalStorage({
-    key: LocalStorageKey.SelectedDisplayUnit,
-    defaultValue: DisplayUnit.Asset,
-  }),
-  shouldHideLaunchableMarkets: getLocalStorage({
-    key: LocalStorageKey.ShouldHideLaunchableMarkets,
-    defaultValue: false,
-  }),
+export const initialState: AppUIConfigsState = {
+  appThemeSetting: uiRefresh ? AppTheme.Dark : AppTheme.Classic,
+  appColorMode: AppColorMode.GreenUp,
+  hasSeenLaunchIncentives: false,
+  defaultToAllMarketsInPositionsOrdersFills: true,
+  displayUnit: DisplayUnit.Asset,
+  shouldHideLaunchableMarkets: false,
 };
 
 export const appUiConfigsSlice = createSlice({
@@ -77,29 +57,21 @@ export const appUiConfigsSlice = createSlice({
       state: AppUIConfigsState,
       { payload }: PayloadAction<boolean>
     ) => {
-      setLocalStorage({
-        key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
-        value: payload,
-      });
       state.defaultToAllMarketsInPositionsOrdersFills = payload;
     },
     setAppThemeSetting: (state: AppUIConfigsState, { payload }: PayloadAction<AppThemeSetting>) => {
-      setLocalStorage({ key: LocalStorageKey.SelectedTheme, value: payload });
       state.appThemeSetting = payload;
     },
     setAppColorMode: (state: AppUIConfigsState, { payload }: PayloadAction<AppColorMode>) => {
-      setLocalStorage({ key: LocalStorageKey.SelectedColorMode, value: payload });
       state.appColorMode = payload;
     },
     markLaunchIncentivesSeen: (state: AppUIConfigsState) => {
-      setLocalStorage({ key: LocalStorageKey.HasSeenLaunchIncentives, value: true });
       state.hasSeenLaunchIncentives = true;
     },
     setShouldHideLaunchableMarkets: (
       state: AppUIConfigsState,
       { payload }: PayloadAction<boolean>
     ) => {
-      setLocalStorage({ key: LocalStorageKey.ShouldHideLaunchableMarkets, value: payload });
       state.shouldHideLaunchableMarkets = payload;
     },
     setDisplayUnit: (
@@ -113,7 +85,6 @@ export const appUiConfigsSlice = createSlice({
       }>
     ) => {
       const { newDisplayUnit, entryPoint, assetId } = payload;
-      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: newDisplayUnit });
       state.displayUnit = newDisplayUnit;
       track(
         AnalyticsEvents.DisplayUnitToggled({

--- a/src/state/appUiConfigs.ts
+++ b/src/state/appUiConfigs.ts
@@ -1,0 +1,136 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import { AnalyticsEvents } from '@/constants/analytics';
+import { LocalStorageKey } from '@/constants/localStorage';
+import { DisplayUnit } from '@/constants/trade';
+
+import { track } from '@/lib/analytics/analytics';
+import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
+import { testFlags } from '@/lib/testFlags';
+
+export enum AppTheme {
+  Classic = 'Classic',
+  Dark = 'Dark',
+  Light = 'Light',
+}
+
+export enum AppThemeSystemSetting {
+  System = 'System',
+}
+
+export type AppThemeSetting = AppTheme | AppThemeSystemSetting;
+
+export enum AppColorMode {
+  GreenUp = 'GreenUp',
+  RedUp = 'RedUp',
+}
+
+export enum OtherPreference {
+  DisplayAllMarketsDefault = 'DisplayAllMarketsDefault',
+  GasToken = 'GasToken',
+  ReverseLayout = 'ReverseLayout',
+}
+
+export interface AppUIConfigsState {
+  appThemeSetting: AppThemeSetting;
+  appColorMode: AppColorMode;
+  hasSeenLaunchIncentives: boolean;
+  defaultToAllMarketsInPositionsOrdersFills: boolean;
+  displayUnit: DisplayUnit;
+  shouldHideLaunchableMarkets: boolean;
+}
+
+const { uiRefresh } = testFlags;
+
+const initialState: AppUIConfigsState = {
+  appThemeSetting: getLocalStorage({
+    key: LocalStorageKey.SelectedTheme,
+    defaultValue: uiRefresh ? AppTheme.Dark : AppTheme.Classic,
+  }),
+  appColorMode: getLocalStorage({
+    key: LocalStorageKey.SelectedColorMode,
+    defaultValue: AppColorMode.GreenUp,
+  }),
+  hasSeenLaunchIncentives: getLocalStorage({
+    key: LocalStorageKey.HasSeenLaunchIncentives,
+    defaultValue: false,
+  }),
+  defaultToAllMarketsInPositionsOrdersFills: getLocalStorage({
+    key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
+    defaultValue: true,
+  }),
+  displayUnit: getLocalStorage({
+    key: LocalStorageKey.SelectedDisplayUnit,
+    defaultValue: DisplayUnit.Asset,
+  }),
+  shouldHideLaunchableMarkets: getLocalStorage({
+    key: LocalStorageKey.ShouldHideLaunchableMarkets,
+    defaultValue: false,
+  }),
+};
+
+export const appUiConfigsSlice = createSlice({
+  name: 'appUiConfigs',
+  initialState,
+  reducers: {
+    setDefaultToAllMarketsInPositionsOrdersFills: (
+      state: AppUIConfigsState,
+      { payload }: PayloadAction<boolean>
+    ) => {
+      setLocalStorage({
+        key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
+        value: payload,
+      });
+      state.defaultToAllMarketsInPositionsOrdersFills = payload;
+    },
+    setAppThemeSetting: (state: AppUIConfigsState, { payload }: PayloadAction<AppThemeSetting>) => {
+      setLocalStorage({ key: LocalStorageKey.SelectedTheme, value: payload });
+      state.appThemeSetting = payload;
+    },
+    setAppColorMode: (state: AppUIConfigsState, { payload }: PayloadAction<AppColorMode>) => {
+      setLocalStorage({ key: LocalStorageKey.SelectedColorMode, value: payload });
+      state.appColorMode = payload;
+    },
+    markLaunchIncentivesSeen: (state: AppUIConfigsState) => {
+      setLocalStorage({ key: LocalStorageKey.HasSeenLaunchIncentives, value: true });
+      state.hasSeenLaunchIncentives = true;
+    },
+    setShouldHideLaunchableMarkets: (
+      state: AppUIConfigsState,
+      { payload }: PayloadAction<boolean>
+    ) => {
+      setLocalStorage({ key: LocalStorageKey.ShouldHideLaunchableMarkets, value: payload });
+      state.shouldHideLaunchableMarkets = payload;
+    },
+    setDisplayUnit: (
+      state: AppUIConfigsState,
+      {
+        payload,
+      }: PayloadAction<{
+        newDisplayUnit: DisplayUnit;
+        entryPoint: string;
+        assetId: string;
+      }>
+    ) => {
+      const { newDisplayUnit, entryPoint, assetId } = payload;
+      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: newDisplayUnit });
+      state.displayUnit = newDisplayUnit;
+      track(
+        AnalyticsEvents.DisplayUnitToggled({
+          entryPoint,
+          assetId,
+          newDisplayUnit,
+        })
+      );
+    },
+  },
+});
+
+export const {
+  setDefaultToAllMarketsInPositionsOrdersFills,
+  setAppThemeSetting,
+  setAppColorMode,
+  markLaunchIncentivesSeen,
+  setShouldHideLaunchableMarkets,
+  setDisplayUnit,
+} = appUiConfigsSlice.actions;

--- a/src/state/appUiConfigsSelectors.ts
+++ b/src/state/appUiConfigsSelectors.ts
@@ -1,0 +1,51 @@
+import type { RootState } from './_store';
+import { AppTheme, AppThemeSetting, AppThemeSystemSetting } from './appUiConfigs';
+
+export const getAppThemeSetting = (state: RootState): AppThemeSetting =>
+  state.appUiConfigs.appThemeSetting;
+
+export const getAppTheme = (state: RootState): AppTheme => {
+  switch (state.appUiConfigs.appThemeSetting) {
+    case AppThemeSystemSetting.System:
+      return globalThis.matchMedia('(prefers-color-scheme: dark)').matches
+        ? AppTheme.Dark
+        : AppTheme.Light;
+    default:
+      return state.appUiConfigs.appThemeSetting;
+  }
+};
+
+const ChartDotBackgrounds = {
+  [AppTheme.Dark]: '/chart-dots-background-dark.svg',
+  [AppTheme.Classic]: '/chart-dots-background-dark.svg',
+  [AppTheme.Light]: '/chart-dots-background-light.svg',
+};
+
+const GridBackgrounds = {
+  [AppTheme.Dark]: '/grid-background-dark.svg',
+  [AppTheme.Classic]: '/grid-background-dark.svg',
+  [AppTheme.Light]: '/grid-background-light.svg',
+};
+
+export const getChartDotBackground = (state: RootState): string => {
+  const appTheme = getAppTheme(state);
+  return ChartDotBackgrounds[appTheme];
+};
+
+export const getGridBackground = (state: RootState): string => {
+  const appTheme = getAppTheme(state);
+  return GridBackgrounds[appTheme];
+};
+
+export const getAppColorMode = (state: RootState) => state.appUiConfigs.appColorMode;
+
+export const getHasSeenLaunchIncentives = (state: RootState) =>
+  state.appUiConfigs.hasSeenLaunchIncentives;
+
+export const getDefaultToAllMarketsInPositionsOrdersFills = (state: RootState) =>
+  state.appUiConfigs.defaultToAllMarketsInPositionsOrdersFills;
+
+export const getSelectedDisplayUnit = (state: RootState) => state.appUiConfigs.displayUnit;
+
+export const getShouldHideLaunchableMarkets = (state: RootState) =>
+  state.appUiConfigs.shouldHideLaunchableMarkets;

--- a/src/state/configs.ts
+++ b/src/state/configs.ts
@@ -9,147 +9,30 @@ import type {
   NetworkConfigs,
   Nullable,
 } from '@/constants/abacus';
-import { AnalyticsEvents } from '@/constants/analytics';
-import { LocalStorageKey } from '@/constants/localStorage';
-import { DisplayUnit } from '@/constants/trade';
-
-import { track } from '@/lib/analytics/analytics';
-import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
-import { testFlags } from '@/lib/testFlags';
-
-export enum AppTheme {
-  Classic = 'Classic',
-  Dark = 'Dark',
-  Light = 'Light',
-}
-
-export enum AppThemeSystemSetting {
-  System = 'System',
-}
-
-export type AppThemeSetting = AppTheme | AppThemeSystemSetting;
-
-export enum AppColorMode {
-  GreenUp = 'GreenUp',
-  RedUp = 'RedUp',
-}
-
-export enum OtherPreference {
-  DisplayAllMarketsDefault = 'DisplayAllMarketsDefault',
-  GasToken = 'GasToken',
-  ReverseLayout = 'ReverseLayout',
-}
 
 export interface ConfigsState {
-  appThemeSetting: AppThemeSetting;
-  appColorMode: AppColorMode;
   feeTiers?: kollections.List<FeeTier>;
   equityTiers?: EquityTiers;
   feeDiscounts?: FeeDiscount[];
   network?: NetworkConfigs;
-  hasSeenLaunchIncentives: boolean;
-  defaultToAllMarketsInPositionsOrdersFills: boolean;
-  displayUnit: DisplayUnit;
-  shouldHideLaunchableMarkets: boolean;
 }
 
-const { uiRefresh } = testFlags;
-
 const initialState: ConfigsState = {
-  appThemeSetting: getLocalStorage({
-    key: LocalStorageKey.SelectedTheme,
-    defaultValue: uiRefresh ? AppTheme.Dark : AppTheme.Classic,
-  }),
-  appColorMode: getLocalStorage({
-    key: LocalStorageKey.SelectedColorMode,
-    defaultValue: AppColorMode.GreenUp,
-  }),
   feeDiscounts: undefined,
   feeTiers: undefined,
   equityTiers: undefined,
   network: undefined,
-  shouldHideLaunchableMarkets: getLocalStorage({
-    key: LocalStorageKey.ShouldHideLaunchableMarkets,
-    defaultValue: false,
-  }),
-  hasSeenLaunchIncentives: getLocalStorage({
-    key: LocalStorageKey.HasSeenLaunchIncentives,
-    defaultValue: false,
-  }),
-  defaultToAllMarketsInPositionsOrdersFills: getLocalStorage({
-    key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
-    defaultValue: true,
-  }),
-  displayUnit: getLocalStorage({
-    key: LocalStorageKey.SelectedDisplayUnit,
-    defaultValue: DisplayUnit.Asset,
-  }),
 };
 
 export const configsSlice = createSlice({
-  name: 'Inputs',
+  name: 'Configs',
   initialState,
   reducers: {
-    setDefaultToAllMarketsInPositionsOrdersFills: (
-      state: ConfigsState,
-      { payload }: PayloadAction<boolean>
-    ) => {
-      setLocalStorage({
-        key: LocalStorageKey.DefaultToAllMarketsInPositionsOrdersFills,
-        value: payload,
-      });
-      state.defaultToAllMarketsInPositionsOrdersFills = payload;
-    },
-    setAppThemeSetting: (state: ConfigsState, { payload }: PayloadAction<AppThemeSetting>) => {
-      setLocalStorage({ key: LocalStorageKey.SelectedTheme, value: payload });
-      state.appThemeSetting = payload;
-    },
-    setAppColorMode: (state: ConfigsState, { payload }: PayloadAction<AppColorMode>) => {
-      setLocalStorage({ key: LocalStorageKey.SelectedColorMode, value: payload });
-      state.appColorMode = payload;
-    },
     setConfigs: (state: ConfigsState, action: PayloadAction<Nullable<Configs>>) => ({
       ...state,
       ...action.payload,
     }),
-    markLaunchIncentivesSeen: (state: ConfigsState) => {
-      setLocalStorage({ key: LocalStorageKey.HasSeenLaunchIncentives, value: true });
-      state.hasSeenLaunchIncentives = true;
-    },
-    setDisplayUnit: (
-      state: ConfigsState,
-      {
-        payload,
-      }: PayloadAction<{
-        newDisplayUnit: DisplayUnit;
-        entryPoint: string;
-        assetId: string;
-      }>
-    ) => {
-      const { newDisplayUnit, entryPoint, assetId } = payload;
-      setLocalStorage({ key: LocalStorageKey.SelectedDisplayUnit, value: newDisplayUnit });
-      state.displayUnit = newDisplayUnit;
-      track(
-        AnalyticsEvents.DisplayUnitToggled({
-          entryPoint,
-          assetId,
-          newDisplayUnit,
-        })
-      );
-    },
-    setShouldHideLaunchableMarkets: (state: ConfigsState, action: PayloadAction<boolean>) => {
-      setLocalStorage({ key: LocalStorageKey.ShouldHideLaunchableMarkets, value: action.payload });
-      state.shouldHideLaunchableMarkets = action.payload;
-    },
   },
 });
 
-export const {
-  setDefaultToAllMarketsInPositionsOrdersFills,
-  setAppThemeSetting,
-  setAppColorMode,
-  setConfigs,
-  markLaunchIncentivesSeen,
-  setDisplayUnit,
-  setShouldHideLaunchableMarkets,
-} = configsSlice.actions;
+export const { setConfigs } = configsSlice.actions;

--- a/src/state/configsSelectors.ts
+++ b/src/state/configsSelectors.ts
@@ -1,44 +1,5 @@
 import type { RootState } from './_store';
 import { createAppSelector } from './appTypes';
-import { AppTheme, AppThemeSetting, AppThemeSystemSetting } from './configs';
-
-export const getAppThemeSetting = (state: RootState): AppThemeSetting =>
-  state.configs.appThemeSetting;
-
-export const getAppTheme = (state: RootState): AppTheme => {
-  switch (state.configs.appThemeSetting) {
-    case AppThemeSystemSetting.System:
-      return globalThis.matchMedia('(prefers-color-scheme: dark)').matches
-        ? AppTheme.Dark
-        : AppTheme.Light;
-    default:
-      return state.configs.appThemeSetting;
-  }
-};
-
-const ChartDotBackgrounds = {
-  [AppTheme.Dark]: '/chart-dots-background-dark.svg',
-  [AppTheme.Classic]: '/chart-dots-background-dark.svg',
-  [AppTheme.Light]: '/chart-dots-background-light.svg',
-};
-
-const GridBackgrounds = {
-  [AppTheme.Dark]: '/grid-background-dark.svg',
-  [AppTheme.Classic]: '/grid-background-dark.svg',
-  [AppTheme.Light]: '/grid-background-light.svg',
-};
-
-export const getChartDotBackground = (state: RootState): string => {
-  const appTheme = getAppTheme(state);
-  return ChartDotBackgrounds[appTheme];
-};
-
-export const getGridBackground = (state: RootState): string => {
-  const appTheme = getAppTheme(state);
-  return GridBackgrounds[appTheme];
-};
-
-export const getAppColorMode = (state: RootState) => state.configs.appColorMode;
 
 export const getFeeTiers = createAppSelector([(state: RootState) => state.configs.feeTiers], (t) =>
   t?.toArray()
@@ -48,14 +9,3 @@ export const getStatefulOrderEquityTiers = createAppSelector(
   [(state: RootState) => state.configs.equityTiers?.statefulOrderEquityTiers],
   (t) => t?.toArray()
 );
-
-export const getHasSeenLaunchIncentives = (state: RootState) =>
-  state.configs.hasSeenLaunchIncentives;
-
-export const getDefaultToAllMarketsInPositionsOrdersFills = (state: RootState) =>
-  state.configs.defaultToAllMarketsInPositionsOrdersFills;
-
-export const getSelectedDisplayUnit = (state: RootState) => state.configs.displayUnit;
-
-export const getShouldHideLaunchableMarkets = (state: RootState) =>
-  state.configs.shouldHideLaunchableMarkets;

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -4,11 +4,13 @@ import { MigrationConfig } from 'redux-persist/lib/createMigrate';
 import { migration0 } from './migrations/0';
 import { migration1 } from './migrations/1';
 import { migration2 } from './migrations/2';
+import { migration3 } from './migrations/3';
 
 export const migrations = {
   0: migration0,
   1: migration1,
   2: migration2,
+  3: migration3,
 } as const;
 
 /*

--- a/src/state/migrations/3.ts
+++ b/src/state/migrations/3.ts
@@ -1,0 +1,47 @@
+import { PersistedState } from 'redux-persist';
+
+import { AppUIConfigsState, initialState as appUiConfigsInitialState } from '../appUiConfigs';
+import { parseStorageItem } from './utils';
+
+export type V3State = PersistedState & {
+  appUiConfigs: AppUIConfigsState;
+};
+
+export type AppUiConfigsKeys = keyof typeof appUiConfigsInitialState;
+
+export const appUiConfigsLocalStorageKeys = {
+  appThemeSetting: 'dydx.SelectedTheme',
+  appColorMode: 'dydx.SelectedColorMode',
+  hasSeenLaunchIncentives: 'dydx.HasSeenLaunchIncentives',
+  defaultToAllMarketsInPositionsOrdersFills: 'dydx.DefaultToAllMarketsInPositionsOrdersFills',
+  displayUnit: 'dydx.SelectedDisplayUnit',
+  shouldHideLaunchableMarkets: 'dydx.ShouldHideLaunchableMarkets',
+} satisfies Record<AppUiConfigsKeys, string>;
+
+/**
+ * 4th migration, moving over the app ui configs localStorage items
+ *
+ */
+export function migration3(state: PersistedState | undefined): V3State {
+  if (!state) throw new Error('state must be defined');
+
+  const appUiConfigs = Object.entries(appUiConfigsLocalStorageKeys).reduce(
+    (acc, [key, localStorageKey]) => {
+      const value = parseStorageItem(localStorage.getItem(localStorageKey));
+      return {
+        ...acc,
+        [key]: value ?? appUiConfigsInitialState[key as AppUiConfigsKeys],
+      };
+    },
+    {} as AppUIConfigsState
+  );
+
+  Object.values(appUiConfigsLocalStorageKeys).forEach((localStorageKey) => {
+    localStorage.removeItem(localStorageKey);
+  });
+
+  return {
+    ...state,
+    appUiConfigs,
+  };
+}

--- a/src/state/migrations/3.ts
+++ b/src/state/migrations/3.ts
@@ -8,6 +8,7 @@ export type V3State = PersistedState & {
 };
 
 export type AppUiConfigsKeys = keyof typeof appUiConfigsInitialState;
+export type AppUIConfigsMappableLocalStorageKeys = keyof typeof appUiConfigsLocalStorageKeys;
 
 export const appUiConfigsLocalStorageKeys = {
   appThemeSetting: 'dydx.SelectedTheme',
@@ -16,7 +17,7 @@ export const appUiConfigsLocalStorageKeys = {
   defaultToAllMarketsInPositionsOrdersFills: 'dydx.DefaultToAllMarketsInPositionsOrdersFills',
   displayUnit: 'dydx.SelectedDisplayUnit',
   shouldHideLaunchableMarkets: 'dydx.ShouldHideLaunchableMarkets',
-} satisfies Record<AppUiConfigsKeys, string>;
+};
 
 /**
  * 4th migration, moving over the app ui configs localStorage items

--- a/src/state/migrations/__test__/3.test.ts
+++ b/src/state/migrations/__test__/3.test.ts
@@ -9,7 +9,11 @@ import {
 } from '@/state/appUiConfigs';
 
 import { V2State } from '../2';
-import { AppUiConfigsKeys, appUiConfigsLocalStorageKeys, migration3 } from '../3';
+import {
+  appUiConfigsLocalStorageKeys,
+  AppUIConfigsMappableLocalStorageKeys,
+  migration3,
+} from '../3';
 
 const V2_STATE: V2State = {
   _persist: { version: 2, rehydrated: true },
@@ -19,6 +23,7 @@ const V2_STATE: V2State = {
   },
 };
 
+// values for testing -- they should be different than default / intial state
 const oppositeUiConfigsLocalStorageValues = {
   appThemeSetting: AppTheme.Light,
   appColorMode: AppColorMode.RedUp,
@@ -26,7 +31,7 @@ const oppositeUiConfigsLocalStorageValues = {
   defaultToAllMarketsInPositionsOrdersFills: false,
   displayUnit: DisplayUnit.Fiat,
   shouldHideLaunchableMarkets: true,
-} satisfies Record<AppUiConfigsKeys, any>;
+} satisfies Record<AppUIConfigsMappableLocalStorageKeys, any>;
 
 describe('migration3', () => {
   afterEach(() => {
@@ -46,7 +51,7 @@ describe('migration3', () => {
   it('should copy localStorage values to app ui configs object', () => {
     Object.entries(oppositeUiConfigsLocalStorageValues).forEach(([key, value]) => {
       localStorage.setItem(
-        appUiConfigsLocalStorageKeys[key as AppUiConfigsKeys],
+        appUiConfigsLocalStorageKeys[key as AppUIConfigsMappableLocalStorageKeys],
         JSON.stringify(value)
       );
     });

--- a/src/state/migrations/__test__/3.test.ts
+++ b/src/state/migrations/__test__/3.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DisplayUnit } from '@/constants/trade';
+
+import {
+  AppColorMode,
+  AppTheme,
+  initialState as appUiConfigsInitialState,
+} from '@/state/appUiConfigs';
+
+import { V2State } from '../2';
+import { AppUiConfigsKeys, appUiConfigsLocalStorageKeys, migration3 } from '../3';
+
+const V2_STATE: V2State = {
+  _persist: { version: 2, rehydrated: true },
+  dismissable: {
+    hasSeenPredictionMarketIntroDialog: false,
+    dismissedAffiliateBanner: false,
+  },
+};
+
+const oppositeUiConfigsLocalStorageValues = {
+  appThemeSetting: AppTheme.Light,
+  appColorMode: AppColorMode.RedUp,
+  hasSeenLaunchIncentives: true,
+  defaultToAllMarketsInPositionsOrdersFills: false,
+  displayUnit: DisplayUnit.Fiat,
+  shouldHideLaunchableMarkets: true,
+} satisfies Record<AppUiConfigsKeys, any>;
+
+describe('migration3', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should add the app ui configs to default values', () => {
+    const result = migration3(V2_STATE);
+    expect(result.appUiConfigs).toMatchObject(appUiConfigsInitialState);
+  });
+
+  it('should overwrite the app ui configs if values exist', () => {
+    const result = migration3(V2_STATE);
+    expect(result.appUiConfigs).toMatchObject(appUiConfigsInitialState);
+  });
+
+  it('should copy localStorage values to app ui configs object', () => {
+    Object.entries(oppositeUiConfigsLocalStorageValues).forEach(([key, value]) => {
+      localStorage.setItem(
+        appUiConfigsLocalStorageKeys[key as AppUiConfigsKeys],
+        JSON.stringify(value)
+      );
+    });
+
+    const result = migration3(V2_STATE);
+
+    expect(result.appUiConfigs).toMatchObject(oppositeUiConfigsLocalStorageValues);
+
+    // Check if localStorage items were removed
+    Object.values(appUiConfigsLocalStorageKeys).forEach((localStorageKey) => {
+      expect(localStorage.getItem(localStorageKey)).toBeNull();
+    });
+  });
+});

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -1,7 +1,7 @@
 import { BrightnessFilterToken, ColorToken, OpacityToken } from '@/constants/styles/base';
 import type { Theme, ThemeColorBase } from '@/constants/styles/colors';
 
-import { AppColorMode, AppTheme } from '@/state/configs';
+import { AppColorMode, AppTheme } from '@/state/appUiConfigs';
 
 import { generateFadedColorVariant } from '@/lib/styles';
 import { testFlags } from '@/lib/testFlags';

--- a/src/views/AffiliatesBanner.tsx
+++ b/src/views/AffiliatesBanner.tsx
@@ -23,7 +23,7 @@ import { IconButton } from '@/components/IconButton';
 import { Link } from '@/components/Link';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getGridBackground } from '@/state/configsSelectors';
+import { getGridBackground } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
 import { setDismissedAffiliateBanner } from '@/state/dismissable';
 

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -21,7 +21,7 @@ import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 import { Tag } from '@/components/Tag';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
 import { getCurrentInput } from '@/state/inputsSelectors';
 import {

--- a/src/views/CanvasOrderbook/OrderbookControls.tsx
+++ b/src/views/CanvasOrderbook/OrderbookControls.tsx
@@ -14,8 +14,8 @@ import { Output, OutputType } from '@/components/Output';
 import { ToggleGroup } from '@/components/ToggleGroup';
 
 import { useAppSelector } from '@/state/appTypes';
-import { setDisplayUnit } from '@/state/configs';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+import { setDisplayUnit } from '@/state/appUiConfigs';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 import { getCurrentMarketConfig } from '@/state/perpetualsSelectors';
 
 import abacusStateManager from '@/lib/abacus';

--- a/src/views/DisplaySettings.tsx
+++ b/src/views/DisplaySettings.tsx
@@ -19,8 +19,8 @@ import {
   setAppColorMode,
   setAppThemeSetting,
   type AppThemeSetting,
-} from '@/state/configs';
-import { getAppColorMode, getAppThemeSetting } from '@/state/configsSelectors';
+} from '@/state/appUiConfigs';
+import { getAppColorMode, getAppThemeSetting } from '@/state/appUiConfigsSelectors';
 
 import { testFlags } from '@/lib/testFlags';
 

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -23,8 +23,8 @@ import { ToggleGroup } from '@/components/ToggleGroup';
 import { WithLabel } from '@/components/WithLabel';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { setShouldHideLaunchableMarkets } from '@/state/configs';
-import { getShouldHideLaunchableMarkets } from '@/state/configsSelectors';
+import { setShouldHideLaunchableMarkets } from '@/state/appUiConfigs';
+import { getShouldHideLaunchableMarkets } from '@/state/appUiConfigsSelectors';
 
 import { testFlags } from '@/lib/testFlags';
 

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -24,7 +24,7 @@ import { WithTooltip } from '@/components/WithTooltip';
 import { NextFundingTimer } from '@/views/NextFundingTimer';
 
 import { useAppSelector } from '@/state/appTypes';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 import {
   getCurrentMarketConfig,
   getCurrentMarketData,

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -31,7 +31,7 @@ import { ToggleGroup } from '@/components/ToggleGroup';
 import { TimeSeriesChart } from '@/components/visx/TimeSeriesChart';
 
 import { useAppSelector } from '@/state/appTypes';
-import { getChartDotBackground } from '@/state/configsSelectors';
+import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';

--- a/src/views/charts/PnlChart.tsx
+++ b/src/views/charts/PnlChart.tsx
@@ -28,7 +28,7 @@ import {
   getSubaccountId,
 } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
-import { getChartDotBackground } from '@/state/configsSelectors';
+import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 
 import abacusStateManager from '@/lib/abacus';
 import { formatRelativeTime } from '@/lib/dateTime';

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -18,7 +18,7 @@ import { useDydxClient } from '@/hooks/useDydxClient';
 import usePrevious from '@/hooks/usePrevious';
 
 import { useAppSelector } from '@/state/appTypes';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 import { getCurrentMarketConfig, getCurrentMarketId } from '@/state/perpetualsSelectors';
 
 import { orEmptyObj } from '@/lib/typeUtils';

--- a/src/views/dialogs/StakingRewardDialog.tsx
+++ b/src/views/dialogs/StakingRewardDialog.tsx
@@ -28,7 +28,7 @@ import {
 
 import { getSubaccountEquity } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
-import { getChartDotBackground } from '@/state/configsSelectors';
+import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 
 import { track } from '@/lib/analytics/analytics';
 import { BigNumberish, MustBigNumber } from '@/lib/numbers';

--- a/src/views/forms/TradeForm/TradeSizeInputs.tsx
+++ b/src/views/forms/TradeForm/TradeSizeInputs.tsx
@@ -30,9 +30,9 @@ import { WithTooltip } from '@/components/WithTooltip';
 
 import { getIsAccountConnected } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { setDisplayUnit } from '@/state/appUiConfigs';
+import { getSelectedDisplayUnit } from '@/state/appUiConfigsSelectors';
 import { getCurrentMarketAssetData } from '@/state/assetsSelectors';
-import { setDisplayUnit } from '@/state/configs';
-import { getSelectedDisplayUnit } from '@/state/configsSelectors';
 import { setTradeFormInputs } from '@/state/inputs';
 import {
   getInputTradeOptions,

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -49,8 +49,8 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 
 import { getOnboardingState, getSubaccount } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
-import { AppTheme } from '@/state/configs';
-import { getAppTheme } from '@/state/configsSelectors';
+import { AppTheme } from '@/state/appUiConfigs';
+import { getAppTheme } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
 
 import { isTruthy } from '@/lib/isTruthy';


### PR DESCRIPTION
separate ui configs from configs slice, and run migration to redux persist

testing:
- locally change theme to light on main branch
- switch to this branch and see if it's still light
- restart chrome and check if it's still light