### PR TITLE
fix: accessors sometimes receive undefined apparently

### DIFF
--- a/src/components/visx/SparklineChart.tsx
+++ b/src/components/visx/SparklineChart.tsx
@@ -7,8 +7,8 @@ import styled from 'styled-components';
 interface SparklineChartProps<Datum extends {}> {
   data: Datum[];
   positive: boolean;
-  xAccessor: (_: Datum) => number;
-  yAccessor: (_: Datum) => number;
+  xAccessor: (_: Datum | undefined) => number;
+  yAccessor: (_: Datum | undefined) => number;
 }
 
 const theme = buildChartTheme({

--- a/src/components/visx/TimeSeriesChart.tsx
+++ b/src/components/visx/TimeSeriesChart.tsx
@@ -60,8 +60,8 @@ type ElementProps<Datum extends {}> = {
   > &
     Pick<ThresholdProps<Datum>, 'curve'> & {
       colorAccessor: GlyphSeriesProps<Datum>['colorAccessor'];
-      xAccessor: (_: Datum) => number;
-      yAccessor: (_: Datum) => number;
+      xAccessor: (_: Datum | undefined) => number;
+      yAccessor: (_: Datum | undefined) => number;
       getCurve?: (_: { zoom: number; zoomDomain: number }) => ThresholdProps<Datum>['curve']; // LineSeriesProps<Datum>['curve'];
       glyphSize?: GlyphSeriesProps<Datum>['size'];
       getGlyphSize?: (_: { datum: Datum; zoom: number }) => number;

--- a/src/pages/vaults/VaultPnlChart.tsx
+++ b/src/pages/vaults/VaultPnlChart.tsx
@@ -126,9 +126,10 @@ export const VaultPnlChart = ({ className }: VaultPnlChartProps) => {
       (pnlDiff ?? 0) / (pointsInView[0]?.equity || 1)
     : undefined;
 
-  const xAccessorFunc = useCallback((datum: VaultPnlDatum) => datum.date ?? 0, []);
+  const xAccessorFunc = useCallback((datum: VaultPnlDatum | undefined) => datum?.date ?? 0, []);
   const yAccessorFunc = useCallback(
-    (datum: VaultPnlDatum) => (selectedChart === 'pnl' ? datum.totalPnl ?? 0 : datum.equity ?? 0),
+    (datum: VaultPnlDatum | undefined) =>
+      selectedChart === 'pnl' ? datum?.totalPnl ?? 0 : datum?.equity ?? 0,
     [selectedChart]
   );
 

--- a/src/pages/vaults/VaultPositionsTable.tsx
+++ b/src/pages/vaults/VaultPositionsTable.tsx
@@ -153,8 +153,8 @@ export const VaultPositionsTable = ({ className }: { className?: string }) => {
                         x: index + 1,
                         y: elem,
                       }))}
-                      xAccessor={(datum) => datum.x}
-                      yAccessor={(datum) => datum.y}
+                      xAccessor={(datum) => datum?.x ?? 0}
+                      yAccessor={(datum) => datum?.y ?? 0}
                       positive={(thirtyDayPnl.absolute ?? 0) > 0}
                     />
                   )}

--- a/src/views/charts/DepthChart/index.tsx
+++ b/src/views/charts/DepthChart/index.tsx
@@ -247,8 +247,8 @@ export const DepthChart = ({
                     ].reverse()
                   : []
               }
-              xAccessor={(datum: DepthChartDatum) => datum.price}
-              yAccessor={(datum: DepthChartDatum) => datum.depth}
+              xAccessor={(datum: DepthChartDatum | undefined) => datum?.price ?? 0}
+              yAccessor={(datum: DepthChartDatum | undefined) => datum?.depth ?? 0}
               curve={curveStepAfter}
               lineProps={{ strokeWidth: 1.5 }}
               fillOpacity={0.2}

--- a/src/views/charts/FundingChart/index.tsx
+++ b/src/views/charts/FundingChart/index.tsx
@@ -82,8 +82,8 @@ export const FundingChart = ({ selectedLocale }: ElementProps) => {
       series={[
         {
           dataKey: 'funding-rate',
-          xAccessor: (datum) => datum.time,
-          yAccessor: (datum) => datum.fundingRate,
+          xAccessor: (datum) => datum?.time ?? 0,
+          yAccessor: (datum) => datum?.fundingRate ?? 0,
           colorAccessor: () => 'var(--color-text-1)',
           getCurve: ({ zoom }) => (zoom > 12 ? curveMonotoneX : curveStepAfter),
         },

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -92,8 +92,8 @@ export const LaunchableMarketChart = ({
     },
   ];
 
-  const xAccessorFunc = useCallback((datum: TradingViewBar) => datum.time, []);
-  const yAccessorFunc = useCallback((datum: TradingViewBar) => datum.close, []);
+  const xAccessorFunc = useCallback((datum: TradingViewBar | undefined) => datum?.time ?? 0, []);
+  const yAccessorFunc = useCallback((datum: TradingViewBar | undefined) => datum?.close ?? 0, []);
 
   const colorString = useMemo(() => {
     if (!candlesQuery.data || candlesQuery.data.length < 1) return 'var(--color-text-1)';

--- a/src/views/charts/PnlChart.tsx
+++ b/src/views/charts/PnlChart.tsx
@@ -236,8 +236,8 @@ export const PnlChart = ({
     [chartDotsBackground, isTablet]
   );
 
-  const xAccessorFunc = useCallback((datum: PnlDatum) => datum.createdAt, []);
-  const yAccessorFunc = useCallback((datum: PnlDatum) => datum.equity, []);
+  const xAccessorFunc = useCallback((datum: PnlDatum | undefined) => datum?.createdAt ?? 0, []);
+  const yAccessorFunc = useCallback((datum: PnlDatum | undefined) => datum?.equity ?? 0, []);
 
   const series = useMemo(
     () => [

--- a/src/views/charts/TradingRewardsChart.tsx
+++ b/src/views/charts/TradingRewardsChart.tsx
@@ -186,8 +186,14 @@ export const TradingRewardsChart = ({
 
   const onToggleInteract = () => setIsZooming(false);
 
-  const xAccessorFunc = useCallback((datum: TradingRewardsDatum) => datum.date, []);
-  const yAccessorFunc = useCallback((datum: TradingRewardsDatum) => datum.cumulativeAmount, []);
+  const xAccessorFunc = useCallback(
+    (datum: TradingRewardsDatum | undefined) => datum?.date ?? 0,
+    []
+  );
+  const yAccessorFunc = useCallback(
+    (datum: TradingRewardsDatum | undefined) => datum?.cumulativeAmount ?? 0,
+    []
+  );
 
   const series = useMemo(
     () => [

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -165,8 +165,8 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                       x: index + 1,
                       y: parseFloat(datum.toString()),
                     }))}
-                    xAccessor={(datum) => datum.x}
-                    yAccessor={(datum) => datum.y}
+                    xAccessor={(datum) => datum?.x ?? 0}
+                    yAccessor={(datum) => datum?.y ?? 0}
                     positive={MustBigNumber(priceChange24HPercent).gt(0)}
                   />
                 </div>


### PR DESCRIPTION
the library lies about the types and sometimes passes undefined so we should be forced to handle it to prevent errors. 