### PR TITLE
chore: support negative boolean test flags

### DIFF
--- a/src/lib/abacus/index.ts
+++ b/src/lib/abacus/index.ts
@@ -40,7 +40,7 @@ import {
 } from '@/constants/abacus';
 import { Hdkey } from '@/constants/account';
 import { DEFAULT_MARKETID } from '@/constants/markets';
-import { CURRENT_ABACUS_DEPLOYMENT, isDev, type DydxNetwork } from '@/constants/networks';
+import { CURRENT_ABACUS_DEPLOYMENT, type DydxNetwork } from '@/constants/networks';
 import { StatsigFlags } from '@/constants/statsig';
 import {
   CLEARED_CLOSE_POSITION_INPUTS,
@@ -139,7 +139,7 @@ class AbacusStateManager {
     );
 
     const appConfigs = AbacusAppConfig.Companion.forWebAppWithIsolatedMargins;
-    appConfigs.staticTyping = testFlags.enableStaticTyping || isDev;
+    appConfigs.staticTyping = testFlags.enableStaticTyping;
     appConfigs.metadataService = testFlags.pml;
 
     this.stateManager = new AsyncAbacusStateManager(

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -1,7 +1,15 @@
-import { isDev, isTestnet } from '@/constants/networks';
+import { isDev, isMainnet } from '@/constants/networks';
 
 class TestFlags {
   public queryParams: { [key: string]: string };
+
+  private isValueExplicitlyFalse = (value: string) =>
+    ['false', '0', 'no', 'off'].includes(value.toLowerCase());
+
+  private booleanFlag = (value?: string, defaultTrue?: boolean) => {
+    if (!value) return defaultTrue ?? false;
+    return !this.isValueExplicitlyFalse(value);
+  };
 
   constructor() {
     this.queryParams = {};
@@ -27,7 +35,7 @@ class TestFlags {
   }
 
   get displayInitializingMarkets() {
-    return !!this.queryParams.displayinitializingmarkets;
+    return this.booleanFlag(this.queryParams.displayinitializingmarkets);
   }
 
   get addressOverride(): string | undefined {
@@ -35,7 +43,7 @@ class TestFlags {
   }
 
   get enableVaults() {
-    return !!this.queryParams.vaults || isDev || isTestnet;
+    return this.booleanFlag(this.queryParams.vaults, !isMainnet);
   }
 
   get referrer() {
@@ -43,15 +51,15 @@ class TestFlags {
   }
 
   get enablePredictionMarketPerp() {
-    return !!this.queryParams.prediction || isDev;
+    return this.booleanFlag(this.queryParams.prediction, isDev);
   }
 
   get pml() {
-    return !!this.queryParams.pml || isDev || isTestnet;
+    return this.booleanFlag(this.queryParams.pml, !isMainnet);
   }
 
   get showLimitClose() {
-    return !!this.queryParams.limitclose;
+    return this.booleanFlag(this.queryParams.limitclose);
   }
 
   get referralCode() {
@@ -59,11 +67,11 @@ class TestFlags {
   }
 
   get enableStaticTyping() {
-    return !!this.queryParams.statictyping;
+    return this.booleanFlag(this.queryParams.statictyping, isDev);
   }
 
   get uiRefresh() {
-    return !!this.queryParams.uirefresh || isDev;
+    return this.booleanFlag(this.queryParams.uirefresh, isDev);
   }
 
   get onboardingRewrite() {


### PR DESCRIPTION
it can be useful to explicitly set a test flag to false to check if that's the culprit e.g. static typing, or easier testing during dev to switch test flags on or off

added a helper function `booleanFlag(flag, defaultTrueEnvironment)`

