### PR TITLE
fix: markets table improvements

### DIFF
--- a/src/components/Table/AssetTableCell.tsx
+++ b/src/components/Table/AssetTableCell.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { Nullable } from '@/constants/abacus';
 import { STRING_KEYS } from '@/constants/localization';
@@ -7,11 +7,11 @@ import { MarketData } from '@/constants/markets';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import breakpoints from '@/styles/breakpoints';
+import { layoutMixins } from '@/styles/layoutMixins';
 
 import { AssetIcon } from '@/components/AssetIcon';
 import { Tag } from '@/components/Tag';
 
-import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 import { calculateMarketMaxLeverage } from '@/lib/marketsHelpers';
 import { orEmptyObj } from '@/lib/typeUtils';
 
@@ -28,14 +28,15 @@ interface AssetTableCellProps {
       >
     | null
     | undefined;
+  truncateAssetName?: boolean;
+  children?: React.ReactNode;
   className?: string;
-  stacked?: boolean;
 }
 
 export const AssetTableCell = (props: AssetTableCellProps) => {
   const stringGetter = useStringGetter();
-  const { symbol, name, stacked, configs, className } = props;
-
+  const { symbol, name, configs, truncateAssetName, children, className } = props;
+  const stacked = !!children;
   const { imageUrl, initialMarginFraction, effectiveInitialMarginFraction, isUnlaunched } =
     orEmptyObj(configs);
 
@@ -58,14 +59,12 @@ export const AssetTableCell = (props: AssetTableCellProps) => {
     >
       <$TableCellContent stacked={stacked}>
         <div tw="row gap-0.5">
-          <$Asset stacked={stacked}>{name}</$Asset>
+          <$Asset stacked={stacked} truncateAssetName={truncateAssetName}>
+            {name}
+          </$Asset>
           <Tag>{isUnlaunched ? stringGetter({ key: STRING_KEYS.LAUNCHABLE }) : maxLeverage}</Tag>
         </div>
-        {stacked ? (
-          <span tw="text-color-text-0 font-mini-medium">
-            {symbol && getDisplayableAssetFromBaseAsset(symbol)}
-          </span>
-        ) : undefined}
+        {children}
       </$TableCellContent>
     </TableCell>
   );
@@ -84,7 +83,14 @@ const $AssetIcon = styled(AssetIcon)<{ stacked?: boolean }>`
     font-size: ${({ stacked }) => (stacked ? '1.5rem' : '2.25rem')};
   }
 `;
-const $Asset = styled.span<{ stacked?: boolean }>`
+const $Asset = styled.span<{ stacked?: boolean; truncateAssetName?: boolean }>`
   color: var(--color-text-1);
-  font: ${({ stacked }) => (stacked ? 'var(--font-small-medium)' : 'var(--font-medium-medium)')};
+  font: ${({ stacked }) => (stacked ? 'var(--font-base-medium)' : 'var(--font-medium-medium)')};
+
+  ${({ truncateAssetName }) =>
+    truncateAssetName &&
+    css`
+      ${layoutMixins.textTruncate}
+      max-width: 4.5rem;
+    `}
 `;

--- a/src/components/Table/TablePaginationRow.tsx
+++ b/src/components/Table/TablePaginationRow.tsx
@@ -7,6 +7,7 @@ import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { type MenuItem } from '@/constants/menus';
 
+import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -37,6 +38,7 @@ export const TablePaginationRow = ({
   setPageSize,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
+  const { isNotMobile } = useBreakpoints();
 
   const pageNumberToDisplay = (pageNumber: number) => String(pageNumber + 1);
   const pageToggles = () => {
@@ -96,14 +98,15 @@ export const TablePaginationRow = ({
 
   return (
     <$PaginationRow>
-      {stringGetter({
-        key: STRING_KEYS.SHOWING_NUM_OUT_OF_TOTAL,
-        params: {
-          START: currentPage * pageSize + 1,
-          END: Math.min((currentPage + 1) * pageSize, totalRows),
-          TOTAL: totalRows,
-        },
-      })}
+      {isNotMobile &&
+        stringGetter({
+          key: STRING_KEYS.SHOWING_NUM_OUT_OF_TOTAL,
+          params: {
+            START: currentPage * pageSize + 1,
+            END: Math.min((currentPage + 1) * pageSize, totalRows),
+            TOTAL: totalRows,
+          },
+        })}
       {pageToggles()}
       {pageSizeSelector()}
     </$PaginationRow>
@@ -115,6 +118,8 @@ const $InlineRow = tw.div`inlineRow`;
 const $PaginationRow = styled.div`
   ${layoutMixins.spacedRow}
   padding: var(--tableCell-padding);
+  max-width: 100vw;
+  overflow-x: auto;
 `;
 
 const $ToggleGroup = styled(ToggleGroup)`

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -263,12 +263,11 @@ export const useMarketsData = ({
   }, [markets, searchFilter, filter]);
 
   const marketFilters = useMemo(
-    () =>
-      [
-        ...objectKeys(MARKET_FILTER_OPTIONS).filter((marketFilter) =>
-          markets.some((market) => filterFunctions[marketFilter](market))
-        ),
-      ].filter(isTruthy),
+    () => [
+      ...objectKeys(MARKET_FILTER_OPTIONS).filter((marketFilter) =>
+        markets.some((market) => filterFunctions[marketFilter](market))
+      ),
+    ],
     [markets]
   );
 

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 
 import { STRING_KEYS } from '@/constants/localization';
-import { MarketSorting } from '@/constants/markets';
+import { MarketFilters, MarketSorting } from '@/constants/markets';
 
+import { useMarketsData } from '@/hooks/useMarketsData';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import breakpoints from '@/styles/breakpoints';
@@ -26,21 +27,28 @@ export const MarketsStats = (props: MarketsStatsProps) => {
   const stringGetter = useStringGetter();
   const [sorting, setSorting] = useState(MarketSorting.GAINERS);
 
+  const { hasResults: hasNewMarkets } = useMarketsData({
+    filter: MarketFilters.NEW,
+    hideUnlaunchedMarkets: true,
+  });
+
   return (
     <section
       className={className}
-      tw="grid grid-cols-3 gap-1 tablet:column desktopSmall:pl-1 desktopSmall:pr-1"
+      tw="grid auto-cols-fr grid-flow-col gap-1 tablet:column desktopSmall:pl-1 desktopSmall:pr-1"
     >
       <ExchangeBillboards />
-      <$Section>
-        <$SectionHeader>
-          <h4 tw="flex items-center gap-0.375">
-            {stringGetter({ key: STRING_KEYS.RECENTLY_LISTED })}
-            <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
-          </h4>
-        </$SectionHeader>
-        <MarketsCompactTable sorting={MarketSorting.RECENTLY_LISTED} />
-      </$Section>
+      {hasNewMarkets && (
+        <$Section>
+          <$SectionHeader>
+            <h4 tw="flex items-center gap-0.375">
+              {stringGetter({ key: STRING_KEYS.RECENTLY_LISTED })}
+              <NewTag>{stringGetter({ key: STRING_KEYS.NEW })}</NewTag>
+            </h4>
+          </$SectionHeader>
+          <MarketsCompactTable sorting={MarketSorting.RECENTLY_LISTED} />
+        </$Section>
+      )}
       <$Section>
         <$SectionHeader>
           <h4>{stringGetter({ key: STRING_KEYS.BIGGEST_MOVERS })}</h4>

--- a/src/views/tables/MarketsCompactTable.tsx
+++ b/src/views/tables/MarketsCompactTable.tsx
@@ -7,7 +7,6 @@ import { STRING_KEYS } from '@/constants/localization';
 import { MarketFilters, MarketSorting, type MarketData } from '@/constants/markets';
 import { AppRoute } from '@/constants/routes';
 
-import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useMarketsData } from '@/hooks/useMarketsData';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -37,11 +36,10 @@ export const MarketsCompactTable = ({
   sorting,
 }: PropsWithChildren<MarketsCompactTableProps>) => {
   const stringGetter = useStringGetter();
-  const { isTablet } = useBreakpoints();
   const navigate = useNavigate();
 
   const { filteredMarkets } = useMarketsData({
-    filter: MarketFilters.ALL,
+    filter: sorting === MarketSorting.RECENTLY_LISTED ? MarketFilters.NEW : MarketFilters.ALL,
     hideUnlaunchedMarkets: true,
   });
 
@@ -60,11 +58,15 @@ export const MarketsCompactTable = ({
             name,
           }) => (
             <AssetTableCell
-              stacked
               configs={{ imageUrl, effectiveInitialMarginFraction, initialMarginFraction }}
               name={name}
               symbol={assetId}
-            />
+              truncateAssetName
+            >
+              <span tw="text-color-text-0 font-mini-medium">
+                {getDisplayableAssetFromBaseAsset(assetId)}
+              </span>
+            </AssetTableCell>
           ),
         },
         {
@@ -142,7 +144,7 @@ export const MarketsCompactTable = ({
               ),
             },
       ] satisfies ColumnDef<MarketData>[],
-    [stringGetter, isTablet]
+    [stringGetter, sorting]
   );
 
   const sortedMarkets = useMemo(() => {
@@ -179,7 +181,7 @@ export const MarketsCompactTable = ({
     <$Table
       withInnerBorders
       data={sortedMarkets.slice(0, 3)}
-      getRowKey={(row) => row.id ?? ''}
+      getRowKey={(row) => row.id}
       label="Markets"
       onRowAction={(market: Key) =>
         navigate(`${AppRoute.Trade}/${market}`, { state: { from: AppRoute.Markets } })

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -57,8 +57,8 @@ export const MarketsTable = ({ className }: { className?: string }) => {
       isTablet
         ? ([
             {
-              columnKey: 'market',
-              getCellValue: (row) => row.id,
+              columnKey: 'marketAndVolume',
+              getCellValue: (row) => row.volume24H,
               label: stringGetter({ key: STRING_KEYS.MARKET }),
               renderCell: ({
                 assetId,
@@ -67,6 +67,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 initialMarginFraction,
                 name,
                 isUnlaunched,
+                volume24H,
               }) => (
                 <AssetTableCell
                   configs={{
@@ -77,7 +78,13 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                   }}
                   name={name}
                   symbol={assetId}
-                />
+                >
+                  <Output
+                    type={OutputType.CompactFiat}
+                    value={volume24H ?? undefined}
+                    tw="text-color-text-0 font-mini-medium"
+                  />
+                </AssetTableCell>
               ),
             },
             {
@@ -96,6 +103,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                     value={oraclePrice}
                     fractionDigits={tickSizeDecimals}
                     withBaseFont
+                    withSubscript
                   />
                   <$InlineRow tw="font-small-book">
                     {!priceChange24H ? (
@@ -263,7 +271,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
           navigate(`${AppRoute.Trade}/${market}`, { state: { from: AppRoute.Markets } })
         }
         defaultSortDescriptor={{
-          column: 'volume24H',
+          column: isTablet ? 'marketAndVolume' : 'volume24H',
           direction: 'descending',
         }}
         columns={columns}
@@ -345,7 +353,7 @@ const $Table = styled(Table)`
   }
 ` as typeof Table;
 
-const $TabletOutput = tw(Output)`font-medium-book text-color-text-2`;
+const $TabletOutput = tw(Output)`font-base-book text-color-text-2`;
 
 const $InlineRow = tw.div`inlineRow`;
 const $NumberOutput = tw(Output)`font-base-medium text-color-text-2`;


### PR DESCRIPTION
markets table polish and fixes, especially on mobile: show volume (and sorted by that), truncate asset name in compact table + shorten pagination row so they don't overflow weridly
hide recently listed table when no markets are new (currently defined by having less than 7d sparklines historical data)

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/26c72bd5-2e3c-4c69-9f6a-367c78e601c9">
<img width="498" alt="image" src="https://github.com/user-attachments/assets/69759050-9b86-44b7-9a57-52cec93ba428">
