### PR TITLE
chore(uiRefresh): remove transparency on tooltips, polish orderbook row

### DIFF
--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -70,9 +70,9 @@ const ClassicThemeBase: (uiRefreshEnabled: boolean) => ThemeColorBase = (
   profileRed: ColorToken.Red2,
 
   inputBackground: ColorToken.GrayBlue3,
-  popoverBackground: generateFadedColorVariant(ColorToken.GrayBlue4, OpacityToken.Opacity90),
+  popoverBackground: ColorToken.GrayBlue4,
   toggleBackground: ColorToken.GrayBlue3,
-  tooltipBackground: generateFadedColorVariant(ColorToken.GrayBlue3, OpacityToken.Opacity66),
+  tooltipBackground: ColorToken.GrayBlue3,
 
   hoverFilterBase: BrightnessFilterToken.Lighten10,
   hoverFilterVariant: BrightnessFilterToken.Lighten10,
@@ -138,9 +138,9 @@ const DarkThemeBase: (uiRefreshEnabled: boolean) => ThemeColorBase = (
   profileRed: ColorToken.Red2,
 
   inputBackground: ColorToken.DarkGray6,
-  popoverBackground: generateFadedColorVariant(ColorToken.DarkGray8, OpacityToken.Opacity90),
+  popoverBackground: ColorToken.DarkGray8,
   toggleBackground: ColorToken.DarkGray6,
-  tooltipBackground: generateFadedColorVariant(ColorToken.DarkGray6, OpacityToken.Opacity66),
+  tooltipBackground: ColorToken.DarkGray6,
 
   hoverFilterBase: BrightnessFilterToken.Lighten10,
   hoverFilterVariant: BrightnessFilterToken.Lighten10,
@@ -212,9 +212,9 @@ const LightThemeBase: (uiRefreshEnabled: boolean) => ThemeColorBase = (
   profileRed: ColorToken.Red2,
 
   inputBackground: ColorToken.White,
-  popoverBackground: generateFadedColorVariant(ColorToken.LightGray9, OpacityToken.Opacity90),
+  popoverBackground: ColorToken.LightGray9,
   toggleBackground: ColorToken.LightGray4,
-  tooltipBackground: generateFadedColorVariant(ColorToken.LightGray8, OpacityToken.Opacity66),
+  tooltipBackground: ColorToken.LightGray8,
 
   hoverFilterBase: BrightnessFilterToken.Darken5,
   hoverFilterVariant: BrightnessFilterToken.Lighten10,

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -205,7 +205,7 @@ export const CanvasOrderbook = forwardRef(
         <$OrderbookContent $isLoading={!hasOrderbook}>
           {!hideHeader && <OrderbookControls assetId={id} grouping={currentGrouping} />}
           {!hideHeader && (
-            <OrderbookRow tw="h-1.75 text-color-text-0">
+            <$OrderbookRow tw="h-1.75 text-color-text-0">
               <span>
                 {stringGetter({ key: STRING_KEYS.PRICE })} <Tag>USD</Tag>
               </span>
@@ -217,7 +217,7 @@ export const CanvasOrderbook = forwardRef(
                 {stringGetter({ key: STRING_KEYS.TOTAL })}{' '}
                 <DisplayUnitTag assetId={id} entryPoint="orderbookAssetTag" />
               </span>
-            </OrderbookRow>
+            </$OrderbookRow>
           )}
 
           {(displaySide === 'top' || layout === 'horizontal') && (
@@ -261,6 +261,7 @@ const $OrderbookContent = styled.div<{ $isLoading?: boolean }>`
   position: relative;
   ${({ $isLoading }) => $isLoading && 'flex: 1;'}
 `;
+
 const $OrderbookSideContainer = styled.div<{ $side: 'bids' | 'asks'; $rows: number }>`
   ${({ $rows }) => css`
     min-height: calc(${$rows} * ${ORDERBOOK_ROW_HEIGHT}px);
@@ -286,6 +287,11 @@ const $HoverRows = styled.div<{ $bottom?: boolean }>`
   width: 100%;
 
   ${({ $bottom }) => $bottom && 'bottom: 0;'}
+`;
+
+const $OrderbookRow = styled(OrderbookRow)`
+  border-top: var(--border);
+  border-bottom: var(--border);
 `;
 
 const $Row = styled(OrderbookRow)<{ onClick?: () => void }>`


### PR DESCRIPTION
1. Remove transparency on tooltips + popovers
2. Update orderbook row:
  - Unflagged - add borders on top and bottom just cuz I think it looks better, feel free to disagree if you don't, I sorta went rogue here
  - Flagged - updated buttons to more toggle style cuz I think it matches the overall UI vibe better
  
 | Unflagged | Flagged |
 | ---- | ---- |
 | <img width="334" alt="Screenshot 2024-10-28 at 6 14 41 PM" src="https://github.com/user-attachments/assets/926fb100-4677-4197-bb32-3c645abb3276"> | <img width="335" alt="Screenshot 2024-10-28 at 6 19 32 PM" src="https://github.com/user-attachments/assets/328ce4df-424f-4f83-aec3-0f6eaf01d909"> | 
 

