### PR TITLE
chore(pml-analytics): Add analytics events to PML flow

### DIFF
--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -371,6 +371,16 @@ export const AnalyticsEvents = unionize(
 
     // Affiliate
     AffiliateRegistration: ofType<{ affiliateAddress: string }>(),
+
+    // Launching Markets
+    LaunchMarketFormSelectedAsset: ofType<{ asset: string }>(),
+    LaunchMarketFormStepChange: ofType<{
+      currentStep: number;
+      updatedStep: number;
+      ticker?: string;
+    }>(),
+    LaunchMarketPageChangePriceChartTimeframe: ofType<{ timeframe: string; asset: string }>(),
+    LaunchMarketViewFromTradePage: ofType<{ marketId: string }>(),
   },
   { tag: 'type' as const, value: 'payload' as const }
 );
@@ -386,6 +396,8 @@ export enum TransactionMemo {
 
   placeOrder = `${DEFAULT_TRANSACTION_MEMO} | Place Order`,
   cancelOrderTransfer = `${DEFAULT_TRANSACTION_MEMO} | Cancel Order`,
+
+  launchMarket = `${DEFAULT_TRANSACTION_MEMO} | Launch Market`,
 }
 
 export const lastSuccessfulRestRequestByOrigin: Record<URL['origin'], number> = {};

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -378,8 +378,10 @@ export const AnalyticsEvents = unionize(
       currentStep: number;
       updatedStep: number;
       ticker?: string;
+      userFreeCollateral?: number;
     }>(),
     LaunchMarketPageChangePriceChartTimeframe: ofType<{ timeframe: string; asset: string }>(),
+    LaunchMarketTransaction: ofType<{ marketId: string }>(),
     LaunchMarketViewFromTradePage: ofType<{ marketId: string }>(),
   },
   { tag: 'type' as const, value: 'payload' as const }

--- a/src/hooks/usePotentialMarkets.tsx
+++ b/src/hooks/usePotentialMarkets.tsx
@@ -5,6 +5,7 @@ import { LIQUIDITY_TIERS } from '@/constants/markets';
 import type { NewMarketProposal } from '@/constants/potentialMarkets';
 
 import { log } from '@/lib/telemetry';
+import { testFlags } from '@/lib/testFlags';
 
 import { useStringGetter } from './useStringGetter';
 
@@ -95,7 +96,7 @@ const usePotentialMarketsContext = () => {
 
   return {
     potentialMarkets,
-    hasPotentialMarketsData: Boolean(potentialMarkets),
+    hasPotentialMarketsData: Boolean(potentialMarkets) && !testFlags.pml,
     liquidityTiers,
   };
 };

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -746,7 +746,13 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         throw new Error('wallet not initialized');
       }
 
-      const response = await compositeClient.createMarketPermissionless(subaccountClient, ticker);
+      const response = await compositeClient.createMarketPermissionless(
+        subaccountClient,
+        ticker,
+        undefined,
+        undefined,
+        TransactionMemo.launchMarket
+      );
 
       return response;
     },

--- a/src/hooks/useSubaccount.tsx
+++ b/src/hooks/useSubaccount.tsx
@@ -746,6 +746,8 @@ const useSubaccountContext = ({ localDydxWallet }: { localDydxWallet?: LocalWall
         throw new Error('wallet not initialized');
       }
 
+      track(AnalyticsEvents.LaunchMarketTransaction({ marketId: ticker }));
+
       const response = await compositeClient.createMarketPermissionless(
         subaccountClient,
         ticker,

--- a/src/pages/trade/LaunchableMarket.tsx
+++ b/src/pages/trade/LaunchableMarket.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useMatch } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
+import { AnalyticsEvents } from '@/constants/analytics';
 import { TradeLayouts } from '@/constants/layout';
 import { AppRoute } from '@/constants/routes';
 
@@ -18,6 +19,7 @@ import { LaunchMarketSidePanel } from '@/views/LaunchMarketSidePanel';
 import { useAppSelector } from '@/state/appTypes';
 import { getSelectedTradeLayout } from '@/state/layoutSelectors';
 
+import { track } from '@/lib/analytics/analytics';
 import { testFlags } from '@/lib/testFlags';
 
 import { HorizontalPanel } from './HorizontalPanel';
@@ -36,6 +38,16 @@ const LaunchableMarket = () => {
   const { uiRefresh } = testFlags;
 
   const [isHorizontalPanelOpen, setIsHorizontalPanelOpen] = useState(true);
+
+  useEffect(() => {
+    if (marketId) {
+      track(
+        AnalyticsEvents.LaunchMarketViewFromTradePage({
+          marketId,
+        })
+      );
+    }
+  }, [marketId]);
 
   return isTablet ? (
     <$TradeLayoutMobile>

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -146,12 +146,12 @@ export const LaunchableMarketChart = ({
   };
 
   const trackTimeframeChange = useCallback(
-    (_timeframe: string) => {
+    (selectedTimeframe: string) => {
       if (id) {
         track(
           AnalyticsEvents.LaunchMarketPageChangePriceChartTimeframe({
             asset: id,
-            timeframe: _timeframe,
+            timeframe: selectedTimeframe,
           })
         );
       }

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -5,6 +5,7 @@ import { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 
+import { AnalyticsEvents } from '@/constants/analytics';
 import { MetadataServiceCandlesTimeframes } from '@/constants/assetMetadata';
 import { ButtonSize } from '@/constants/buttons';
 import { TradingViewBar } from '@/constants/candles';
@@ -34,6 +35,7 @@ import { useAppSelector } from '@/state/appTypes';
 import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
+import { track } from '@/lib/analytics/analytics';
 import { getDisplayableAssetFromBaseAsset } from '@/lib/assetUtils';
 import { BIG_NUMBERS } from '@/lib/numbers';
 import { orEmptyObj } from '@/lib/typeUtils';
@@ -143,6 +145,20 @@ export const LaunchableMarketChart = ({
     );
   };
 
+  const trackTimeframeChange = useCallback(
+    (_timeframe: string) => {
+      if (id) {
+        track(
+          AnalyticsEvents.LaunchMarketPageChangePriceChartTimeframe({
+            asset: id,
+            timeframe: _timeframe,
+          })
+        );
+      }
+    },
+    [id]
+  );
+
   return (
     <$LaunchableMarketChartContainer className={className}>
       <$ChartContainerHeader tw="flex flex-row items-center justify-between">
@@ -190,14 +206,23 @@ export const LaunchableMarketChart = ({
             {
               value: '1d',
               label: `1${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+              onClick() {
+                trackTimeframeChange('1d');
+              },
             },
             {
               value: '7d',
               label: `7${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+              onClick() {
+                trackTimeframeChange('7d');
+              },
             },
             {
               value: '30d',
               label: `30${stringGetter({ key: STRING_KEYS.DAYS_ABBREVIATED })}`,
+              onClick() {
+                trackTimeframeChange('30d');
+              },
             },
           ]}
           value={timeframe}

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -75,6 +75,7 @@ export const NewMarketForm = ({
   const { hasPotentialMarketsData } = usePotentialMarkets();
   const subAccount = orEmptyObj(useAppSelector(getSubaccount, shallowEqual));
   const { freeCollateral, marginUsage } = subAccount;
+  const currentFreeCollateral = freeCollateral?.current ?? 0;
 
   const summaryData = useVaultCalculationForLaunchingMarket({
     amount: DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH,
@@ -95,6 +96,28 @@ export const NewMarketForm = ({
   }, [updateTickerToAdd, tickerToAdd]);
 
   const shouldHideTitleAndDescription = setFormStep !== undefined;
+
+  const trackLaunchMarketFormStepChange = useCallback(
+    ({
+      currentStep,
+      updatedStep,
+      ticker,
+    }: {
+      currentStep: NewMarketFormStep;
+      updatedStep: NewMarketFormStep;
+      ticker?: string;
+    }) => {
+      track(
+        AnalyticsEvents.LaunchMarketFormStepChange({
+          currentStep,
+          updatedStep,
+          ticker,
+          userFreeCollateral: currentFreeCollateral,
+        })
+      );
+    },
+    [currentFreeCollateral]
+  );
 
   const freeCollateralDetailItem = useMemo(() => {
     return {
@@ -158,15 +181,13 @@ export const NewMarketForm = ({
       setProposalTxHash(txHash);
       setStep(NewMarketFormStep.SUCCESS);
 
-      track(
-        AnalyticsEvents.LaunchMarketFormStepChange({
-          currentStep: NewMarketFormStep.PREVIEW,
-          updatedStep: NewMarketFormStep.SUCCESS,
-          ticker: tickerToAdd,
-        })
-      );
+      trackLaunchMarketFormStepChange({
+        currentStep: NewMarketFormStep.PREVIEW,
+        updatedStep: NewMarketFormStep.SUCCESS,
+        ticker: tickerToAdd,
+      });
     },
-    [tickerToAdd]
+    [tickerToAdd, trackLaunchMarketFormStepChange]
   );
 
   /**
@@ -183,13 +204,11 @@ export const NewMarketForm = ({
             setTickerToAdd(undefined);
             setStep(NewMarketFormStep.SELECTION);
 
-            track(
-              AnalyticsEvents.LaunchMarketFormStepChange({
-                currentStep: NewMarketFormStep.SUCCESS,
-                updatedStep: NewMarketFormStep.SELECTION,
-                ticker: undefined,
-              })
-            );
+            trackLaunchMarketFormStepChange({
+              currentStep: NewMarketFormStep.SUCCESS,
+              updatedStep: NewMarketFormStep.SELECTION,
+              ticker: undefined,
+            });
           }}
         />
       );
@@ -202,13 +221,11 @@ export const NewMarketForm = ({
           onBack={() => {
             setStep(NewMarketFormStep.SELECTION);
 
-            track(
-              AnalyticsEvents.LaunchMarketFormStepChange({
-                currentStep: NewMarketFormStep.PREVIEW,
-                updatedStep: NewMarketFormStep.SELECTION,
-                ticker: tickerToAdd,
-              })
-            );
+            trackLaunchMarketFormStepChange({
+              currentStep: NewMarketFormStep.PREVIEW,
+              updatedStep: NewMarketFormStep.SELECTION,
+              ticker: tickerToAdd,
+            });
           }}
           receiptItems={receiptItems}
           setIsParentLoading={setIsParentLoading}
@@ -223,13 +240,11 @@ export const NewMarketForm = ({
         onConfirmMarket={() => {
           setStep(NewMarketFormStep.PREVIEW);
 
-          track(
-            AnalyticsEvents.LaunchMarketFormStepChange({
-              currentStep: NewMarketFormStep.SELECTION,
-              updatedStep: NewMarketFormStep.PREVIEW,
-              ticker: tickerToAdd,
-            })
-          );
+          trackLaunchMarketFormStepChange({
+            currentStep: NewMarketFormStep.SELECTION,
+            updatedStep: NewMarketFormStep.PREVIEW,
+            ticker: tickerToAdd,
+          });
         }}
         freeCollateralDetailItem={freeCollateralDetailItem}
         receiptItems={receiptItems}

--- a/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSelectionStep.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import { OnboardingState } from '@/constants/account';
 import { AlertType } from '@/constants/alerts';
+import { AnalyticsEvents } from '@/constants/analytics';
 import { ButtonAction, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH } from '@/constants/numbers';
@@ -35,6 +36,7 @@ import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton
 import { getOnboardingState } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
+import { track } from '@/lib/analytics/analytics';
 import { getDisplayableAssetFromBaseAsset, getDisplayableTickerFromMarket } from '@/lib/assetUtils';
 
 type NewMarketSelectionStepProps = {
@@ -133,6 +135,11 @@ export const NewMarketSelectionStep = ({
                   tag: getDisplayableAssetFromBaseAsset(launchableMarket.asset),
                   onSelect: () => {
                     setTickerToAdd(launchableMarket.id);
+                    track(
+                      AnalyticsEvents.LaunchMarketFormSelectedAsset({
+                        asset: launchableMarket.asset,
+                      })
+                    );
                   },
                 })),
               },


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Add analytics for PML flow to study feature popularity/engagement.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<NewMarketForm>`
  - add `LaunchMarketFormStepChange` tracking as user progresses through flow

- `<NewMarketSelectionStep>`
  - add `LaunchMarketFormSelectedAsset` tracking when user selects an asset
 
- `<LaunchableMarket>`
  - add `LaunchMarketViewFromTradePage` tracking views

- `<LaunchableMarketChart>`
  - add `LaunchMarketPageChangePriceChartTimeframe` tracking timeframe changes

## Constants/Types

- `constants/analytics`
  - Add 5 new AnalyticsEvents around PML flow

## Hooks

- `hooks/usePotentialMarketsData`
  - update `hasPotentialMarketsData` to include testFlag for pml boolean

- `hooks/useSubaccount`
  - add  track for `LaunchMarketTransaction`
 
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
