### PR TITLE
chore(pml-mobile): update mobile LaunchMarket page

### DIFF
--- a/src/pages/LaunchMarket.tsx
+++ b/src/pages/LaunchMarket.tsx
@@ -42,10 +42,10 @@ const $Page = styled.div`
 
   @media ${breakpoints.tablet} {
     --stickyArea-topHeight: var(--page-header-height-mobile);
-    padding: 0 1rem 1rem;
+    padding: 0;
 
     > * {
-      max-width: calc(100vw - 2rem);
+      max-width: 100vw;
       width: 100%;
     }
   }
@@ -61,7 +61,7 @@ const $Content = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin: 0 auto;
+    margin: 0;
   }
 `;
 
@@ -75,6 +75,7 @@ const $FormContainer = styled.div`
   @media ${breakpoints.tablet} {
     width: 100%;
     min-width: unset;
+    border-radius: 0;
   }
 `;
 

--- a/src/pages/trade/TradeHeaderMobile.tsx
+++ b/src/pages/trade/TradeHeaderMobile.tsx
@@ -38,7 +38,7 @@ export const TradeHeaderMobile = ({ launchableMarketId }: { launchableMarketId?:
       <img
         src={launchableAsset.logo}
         alt={launchableAsset.name}
-        tw="h-[2.5rem] w-[2.5rem] border-r-[50%]"
+        tw="h-[2.5rem] w-[2.5rem] rounded-[50%]"
       />
       <$Name>
         <h3>{launchableAsset.name}</h3>

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -21,6 +21,7 @@ import {
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { LinkOutIcon } from '@/icons';
+import breakpoints from '@/styles/breakpoints';
 
 import { Details } from '@/components/Details';
 import { Icon, IconName } from '@/components/Icon';
@@ -265,7 +266,14 @@ export const LaunchableMarketChart = ({
   );
 };
 
-const $LaunchableMarketChartContainer = tw.div`flex h-fit w-[25rem] flex-col gap-1 rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]`;
+const $LaunchableMarketChartContainer = styled.div`
+  ${tw`flex h-fit w-[25rem] flex-col gap-1 rounded-[1rem] border-[length:--border-width] border-color-border p-1.5 [border-style:solid]`}
+
+  @media ${breakpoints.tablet} {
+    ${tw`w-full`}
+    border: none;
+  }
+`;
 
 const $ChartContainerHeader = tw.div`flex flex-row items-center justify-between`;
 


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
| Before | After |
| --- | --- |
| <img width="602" alt="Screen Shot 2024-10-30 at 12 47 28 PM" src="https://github.com/user-attachments/assets/04612b35-eec3-43e9-aa15-af3ae7c4742c"> | <img width="611" alt="Screen Shot 2024-10-30 at 12 47 50 PM" src="https://github.com/user-attachments/assets/e3eb65d1-6683-4438-acd6-76c09cfeaa4d"> |



<!-- Overall purpose of the PR -->
Update LaunchMarket page for mobile view

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<TradeMobileHeader>`
  - `border-r` is border-right and not border-radius

- `<LaunchMarket>`, `<LaunchableMarketChart>`
  - Update padding and widths of components

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
