### PR TITLE
style(with-subscript): Add withSubscript prop to rendered prices

### DIFF
--- a/src/views/LaunchableMarketStatsDetails.tsx
+++ b/src/views/LaunchableMarketStatsDetails.tsx
@@ -89,7 +89,12 @@ export const LaunchableMarketStatsDetails = ({
     <$MarketDetailsItems>
       {showMidMarketPrice && (
         <$MidMarketPrice>
-          <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+          <Output
+            withSubscript
+            type={OutputType.Fiat}
+            value={price}
+            fractionDigits={tickSizeDecimals}
+          />
           <VerticalSeparator />
         </$MidMarketPrice>
       )}

--- a/src/views/MarketStatsDetails.tsx
+++ b/src/views/MarketStatsDetails.tsx
@@ -240,7 +240,14 @@ const DetailsItem = ({
 
   switch (stat) {
     case MarketStats.OraclePrice: {
-      return <$Output type={OutputType.Fiat} value={value} fractionDigits={tickSizeDecimals} />;
+      return (
+        <$Output
+          withSubscript
+          type={OutputType.Fiat}
+          value={value}
+          fractionDigits={tickSizeDecimals}
+        />
+      );
     }
     case MarketStats.OpenInterest: {
       return (
@@ -271,7 +278,12 @@ const DetailsItem = ({
       return (
         <$RowSpan color={!isLoading ? color : undefined}>
           {!isLoading && <TriangleIndicator value={valueBN} />}
-          <$Output type={OutputType.Fiat} value={valueBN.abs()} fractionDigits={tickSizeDecimals} />
+          <$Output
+            withSubscript
+            type={OutputType.Fiat}
+            value={valueBN.abs()}
+            fractionDigits={tickSizeDecimals}
+          />
           {!isLoading && (
             <$Output
               type={OutputType.Percent}

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -106,7 +106,12 @@ const MarketsDropdownContent = ({
           getCellValue: (row: MarketData) => row.oraclePrice,
           label: stringGetter({ key: STRING_KEYS.PRICE }),
           renderCell: ({ oraclePrice, tickSizeDecimals }: MarketData) => (
-            <$Output type={OutputType.Fiat} value={oraclePrice} fractionDigits={tickSizeDecimals} />
+            <$Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={oraclePrice}
+              fractionDigits={tickSizeDecimals}
+            />
           ),
         },
         {

--- a/src/views/MidMarketPrice.tsx
+++ b/src/views/MidMarketPrice.tsx
@@ -51,6 +51,7 @@ export const MidMarketPrice = () => {
 
   return midMarketPrice !== undefined ? (
     <$Output
+      withSubscript
       type={OutputType.Fiat}
       value={midMarketPrice}
       color={midMarketColor}

--- a/src/views/PositionInfo.tsx
+++ b/src/views/PositionInfo.tsx
@@ -52,6 +52,7 @@ type PositionInfoItems = {
   showSign?: ShowSign;
   useDiffOutput?: boolean;
   withBaseFont?: boolean;
+  withSubscript?: boolean;
 
   // Values
   value: Nullable<number> | string;
@@ -98,6 +99,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
       label: STRING_KEYS.AVERAGE_OPEN,
       fractionDigits: tickSizeDecimals,
       value: entryPrice?.current,
+      withSubscript: true,
     },
     {
       key: 'average-close',
@@ -245,6 +247,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
     newValue,
     percentValue,
     withBaseFont,
+    withSubscript,
   }: PositionInfoItems) => ({
     key,
     label: stringGetter({ key: label }),
@@ -261,6 +264,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
         sign={sign}
         showSign={showSign}
         withBaseFont={withBaseFont}
+        withSubscript={withSubscript}
         withDiff={isNumber(newValue) && value !== newValue}
       />
     ) : (
@@ -284,6 +288,7 @@ export const PositionInfo = ({ showNarrowVariation }: { showNarrowVariation?: bo
           )
         }
         withBaseFont={withBaseFont}
+        withSubscript={withSubscript}
       />
     ),
   });

--- a/src/views/PositionTile.tsx
+++ b/src/views/PositionTile.tsx
@@ -107,6 +107,7 @@ export const PositionTile = ({
             </div>
           ) : (
             <$Output
+              withSubscript
               type={OutputType.Fiat}
               value={notionalTotal}
               fractionDigits={tickSizeDecimals}

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -136,6 +136,7 @@ export const LaunchableMarketChart = ({
         <span>
           {stringGetter({ key: STRING_KEYS.PRICE })}:{' '}
           <Output
+            withSubscript
             tw="inline"
             value={datum.close}
             type={OutputType.Fiat}
@@ -192,6 +193,7 @@ export const LaunchableMarketChart = ({
               tooltip: 'reference-price',
               value: (
                 <Output
+                  withSubscript
                   type={OutputType.Fiat}
                   tw="text-color-text-1"
                   value={price}

--- a/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/FillDetailsDialog.tsx
@@ -63,7 +63,14 @@ export const FillDetailsDialog = ({ fillId, setIsOpen }: DialogProps<FillDetails
       {
         key: 'price',
         label: stringGetter({ key: STRING_KEYS.PRICE }),
-        value: <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />,
+        value: (
+          <Output
+            withSubscript
+            type={OutputType.Fiat}
+            value={price}
+            fractionDigits={tickSizeDecimals}
+          />
+        ),
       },
       {
         key: 'total',

--- a/src/views/forms/AdjustIsolatedMarginForm.tsx
+++ b/src/views/forms/AdjustIsolatedMarginForm.tsx
@@ -379,6 +379,7 @@ export const AdjustIsolatedMarginForm = ({
       </div>
       <div>
         <DiffOutput
+          withSubscript
           withDiff={
             !!liquidationPriceUpdated &&
             liquidationPrice !== liquidationPriceUpdated &&

--- a/src/views/notifications/TradeNotification/FillDetails.tsx
+++ b/src/views/notifications/TradeNotification/FillDetails.tsx
@@ -57,6 +57,7 @@ export const FillDetails = ({
               <span>{stringGetter({ key: STRING_KEYS.MARKET_ORDER_SHORT })}</span>
             ) : (
               <Output
+                withSubscript
                 type={OutputType.Fiat}
                 value={averagePrice}
                 fractionDigits={tickSizeDecimals}

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -134,7 +134,12 @@ const getFillsTableColumnDef = ({
                 {resources.sideStringKey ? stringGetter({ key: resources.sideStringKey }) : null}
               </$Side>
               <span tw="text-color-text-0">@</span>
-              <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+              <Output
+                withSubscript
+                type={OutputType.Fiat}
+                value={price}
+                fractionDigits={tickSizeDecimals}
+              />
             </$InlineRow>
             <$InlineRow>
               <span tw="text-color-text-1">
@@ -243,7 +248,12 @@ const getFillsTableColumnDef = ({
         getCellValue: (row) => row.price,
         label: stringGetter({ key: STRING_KEYS.PRICE }),
         renderCell: ({ price, tickSizeDecimals }) => (
-          <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+          <Output
+            withSubscript
+            type={OutputType.Fiat}
+            value={price}
+            fractionDigits={tickSizeDecimals}
+          />
         ),
       },
       [FillsTableColumnKey.AmountTag]: {
@@ -290,7 +300,12 @@ const getFillsTableColumnDef = ({
         renderCell: ({ size, stepSizeDecimals, price, tickSizeDecimals }) => (
           <TableCell stacked>
             <Output type={OutputType.Asset} value={size} fractionDigits={stepSizeDecimals} />
-            <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={price}
+              fractionDigits={tickSizeDecimals}
+            />
           </TableCell>
         ),
       },

--- a/src/views/tables/FundingPaymentsTable.tsx
+++ b/src/views/tables/FundingPaymentsTable.tsx
@@ -145,7 +145,12 @@ export const FundingPaymentsTable = ({
             getCellValue: (row) => row.price,
             label: stringGetter({ key: STRING_KEYS.ORACLE_PRICE }),
             renderCell: ({ price, tickSizeDecimals }) => (
-              <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+              <Output
+                withSubscript
+                type={OutputType.Fiat}
+                value={price}
+                fractionDigits={tickSizeDecimals}
+              />
             ),
           },
         ] satisfies Array<false | ColumnDef<FundingPaymentTableRow>>

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -99,11 +99,11 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               }) => (
                 <TableCell stacked>
                   <$TabletOutput
+                    withSubscript
                     type={OutputType.Fiat}
                     value={oraclePrice}
                     fractionDigits={tickSizeDecimals}
                     withBaseFont
-                    withSubscript
                   />
                   <$InlineRow tw="font-small-book">
                     {!priceChange24H ? (
@@ -157,6 +157,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
               label: stringGetter({ key: STRING_KEYS.ORACLE_PRICE }),
               renderCell: ({ oraclePrice, tickSizeDecimals }) => (
                 <$TabletOutput
+                  withSubscript
                   type={OutputType.Fiat}
                   value={oraclePrice}
                   fractionDigits={tickSizeDecimals}

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -230,7 +230,12 @@ const getOrdersTableColumnDef = ({
           isMarketOrderType(type) ? (
             stringGetter({ key: STRING_KEYS.MARKET_PRICE_SHORT })
           ) : (
-            <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={price}
+              fractionDigits={tickSizeDecimals}
+            />
           ),
       },
       [OrdersTableColumnKey.Trigger]: {
@@ -239,7 +244,12 @@ const getOrdersTableColumnDef = ({
         label: stringGetter({ key: STRING_KEYS.TRIGGER_PRICE_SHORT }),
         renderCell: ({ triggerPrice, trailingPercent, tickSizeDecimals }) => (
           <TableCell stacked>
-            <Output type={OutputType.Fiat} value={triggerPrice} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={triggerPrice}
+              fractionDigits={tickSizeDecimals}
+            />
             {trailingPercent && (
               <span>
                 <Output
@@ -353,7 +363,12 @@ const getOrdersTableColumnDef = ({
                 {resources.sideStringKey ? stringGetter({ key: resources.sideStringKey }) : null}
               </$Side>
               <span tw="text-color-text-0">@</span>
-              <Output type={OutputType.Fiat} value={price} fractionDigits={tickSizeDecimals} />
+              <Output
+                withSubscript
+                type={OutputType.Fiat}
+                value={price}
+                fractionDigits={tickSizeDecimals}
+              />
             </$InlineRow>
             <span>
               {resources.typeStringKey ? stringGetter({ key: resources.typeStringKey }) : null}

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -166,8 +166,14 @@ const getPositionsTableColumnDef = ({
         hideOnBreakpoint: MediaQueryKeys.isNotTablet,
         renderCell: ({ entryPrice, oraclePrice, tickSizeDecimals }) => (
           <TableCell stacked>
-            <Output type={OutputType.Fiat} value={oraclePrice} fractionDigits={tickSizeDecimals} />
             <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={oraclePrice}
+              fractionDigits={tickSizeDecimals}
+            />
+            <Output
+              withSubscript
               type={OutputType.Fiat}
               value={entryPrice.current}
               fractionDigits={tickSizeDecimals}
@@ -316,6 +322,7 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ entryPrice, tickSizeDecimals }) => (
           <TableCell>
             <Output
+              withSubscript
               type={OutputType.Fiat}
               value={entryPrice.current}
               fractionDigits={tickSizeDecimals}
@@ -331,12 +338,18 @@ const getPositionsTableColumnDef = ({
           <TableCell stacked={!uiRefresh}>
             {!uiRefresh && (
               <Output
+                withSubscript
                 type={OutputType.Fiat}
                 value={liquidationPrice.current}
                 fractionDigits={tickSizeDecimals}
               />
             )}
-            <Output type={OutputType.Fiat} value={oraclePrice} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={oraclePrice}
+              fractionDigits={tickSizeDecimals}
+            />
           </TableCell>
         ),
       },
@@ -347,12 +360,14 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ liquidationPrice, oraclePrice, tickSizeDecimals }) => (
           <TableCell stacked={!uiRefresh}>
             <Output
+              withSubscript
               type={OutputType.Fiat}
               value={liquidationPrice.current}
               fractionDigits={tickSizeDecimals}
             />
             {!uiRefresh && (
               <Output
+                withSubscript
                 type={OutputType.Fiat}
                 value={oraclePrice}
                 fractionDigits={tickSizeDecimals}
@@ -407,11 +422,17 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ liquidationPrice, oraclePrice, tickSizeDecimals }) => (
           <TableCell stacked>
             <Output
+              withSubscript
               type={OutputType.Fiat}
               value={liquidationPrice.current}
               fractionDigits={tickSizeDecimals}
             />
-            <Output type={OutputType.Fiat} value={oraclePrice} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={oraclePrice}
+              fractionDigits={tickSizeDecimals}
+            />
           </TableCell>
         ),
       },
@@ -461,11 +482,17 @@ const getPositionsTableColumnDef = ({
         renderCell: ({ entryPrice, exitPrice, tickSizeDecimals }) => (
           <TableCell stacked>
             <Output
+              withSubscript
               type={OutputType.Fiat}
               value={entryPrice.current}
               fractionDigits={tickSizeDecimals}
             />
-            <Output type={OutputType.Fiat} value={exitPrice} fractionDigits={tickSizeDecimals} />
+            <Output
+              withSubscript
+              type={OutputType.Fiat}
+              value={exitPrice}
+              fractionDigits={tickSizeDecimals}
+            />
           </TableCell>
         ),
       },

--- a/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCell.tsx
@@ -146,6 +146,7 @@ export const PositionsTriggersCell = ({
 
       const output = (
         <$Output
+          withSubscript
           type={OutputType.Fiat}
           value={triggerPrice ?? null}
           fractionDigits={tickSizeDecimals}

--- a/src/views/tables/PositionsTable/PositionsTriggersCellDeprecated.tsx
+++ b/src/views/tables/PositionsTable/PositionsTriggersCellDeprecated.tsx
@@ -183,6 +183,7 @@ export const PositionsTriggersCellDeprecated = ({
         <>
           {triggerLabel({ liquidationWarningSide })}
           <$Output
+            withSubscript
             type={OutputType.Fiat}
             value={triggerPrice ?? null}
             fractionDigits={tickSizeDecimals}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1105" alt="Screen Shot 2024-10-31 at 7 46 15 AM" src="https://github.com/user-attachments/assets/b4848306-07b4-4acb-b046-81f29aa1fe73">


<!-- Overall purpose of the PR -->
Use `withSubscript` prop for most `<Output>` components that use `tickSizeDecimals` as it's `fractionDigits`.
This should cutdown on the width of rendered prices in multiple places.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
