### PR TITLE
chore: fix usage of isChartReady in trading view charts

### DIFF
--- a/src/hooks/tradingView/useBuySellMarks.ts
+++ b/src/hooks/tradingView/useBuySellMarks.ts
@@ -16,12 +16,10 @@ export function useBuySellMarks({
   buySellMarksToggle,
   buySellMarksToggleOn,
   tvWidget,
-  isChartReady,
 }: {
   buySellMarksToggle: HTMLElement | null;
   buySellMarksToggleOn: boolean;
   tvWidget: TvWidget | null;
-  isChartReady: boolean;
 }) {
   const marketId = useAppSelector(getCurrentMarketId);
   const fills = useAppSelector(getMarketFills);
@@ -33,7 +31,7 @@ export function useBuySellMarks({
   useEffect(
     // Update marks on toggle and on new fills and on display preference changes
     () => {
-      if (!isChartReady || !tvWidget) return;
+      if (!tvWidget) return;
 
       tvWidget.onChartReady(() => {
         tvWidget.headerReady().then(() => {
@@ -56,7 +54,6 @@ export function useBuySellMarks({
       isAccountConnected,
       buySellMarksToggle,
       tvWidget,
-      isChartReady,
       currentMarketFills,
       theme,
     ]

--- a/src/hooks/tradingView/useChartMarketAndResolution.ts
+++ b/src/hooks/tradingView/useChartMarketAndResolution.ts
@@ -21,13 +21,11 @@ export const useChartMarketAndResolution = ({
   currentMarketId,
   isViewingUnlaunchedMarket,
   tvWidget,
-  isWidgetReady,
   savedResolution,
 }: {
   currentMarketId: string;
   isViewingUnlaunchedMarket?: boolean;
   tvWidget: TvWidget | null;
-  isWidgetReady?: boolean;
   savedResolution?: ResolutionString;
 }) => {
   const dispatch = useAppDispatch();
@@ -35,18 +33,22 @@ export const useChartMarketAndResolution = ({
   const selectedResolution: string =
     useAppSelector((s) => getSelectedResolutionForMarket(s, currentMarketId)) ?? DEFAULT_RESOLUTION;
 
-  const chart = isWidgetReady ? tvWidget?.chart() : undefined;
+  const chart = tvWidget?._ready ? tvWidget.chart() : undefined;
   const chartResolution = chart?.resolution();
 
   /**
    * @description Hook to handle changing markets - intentionally should avoid triggering on change of resolutions.
    */
   useEffect(() => {
-    if (isWidgetReady && currentMarketId !== tvWidget?.activeChart().symbol()) {
-      const resolution = savedResolution ?? selectedResolution;
-      tvWidget?.setSymbol(currentMarketId, resolution as ResolutionString, () => {});
-    }
-  }, [currentMarketId, isWidgetReady]);
+    if (!tvWidget) return;
+
+    tvWidget.onChartReady(() => {
+      if (currentMarketId !== tvWidget.activeChart().symbol()) {
+        const resolution = savedResolution ?? selectedResolution;
+        tvWidget.setSymbol(currentMarketId, resolution as ResolutionString, () => {});
+      }
+    });
+  }, [currentMarketId, tvWidget]);
 
   /**
    * @description Hook to handle changing chart resolution

--- a/src/hooks/tradingView/useOrderbookCandles.ts
+++ b/src/hooks/tradingView/useOrderbookCandles.ts
@@ -10,19 +10,17 @@ import abacusStateManager from '@/lib/abacus';
  */
 export const useOrderbookCandles = ({
   orderbookCandlesToggle,
-  isChartReady,
   orderbookCandlesToggleOn,
   tvWidget,
 }: {
   orderbookCandlesToggle: HTMLElement | null;
-  isChartReady: boolean;
   orderbookCandlesToggleOn: boolean;
   tvWidget: TvWidget | null;
 }) => {
   useEffect(
     // Update orderbookCandles button on toggle
     () => {
-      if (!isChartReady || !tvWidget) return;
+      if (!tvWidget) return;
 
       tvWidget.onChartReady(() => {
         tvWidget.headerReady().then(() => {
@@ -35,7 +33,7 @@ export const useOrderbookCandles = ({
         });
       });
     },
-    [orderbookCandlesToggleOn, orderbookCandlesToggle, tvWidget, isChartReady]
+    [orderbookCandlesToggleOn, orderbookCandlesToggle, tvWidget]
   );
 
   return { orderbookCandlesToggleOn };

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -50,7 +50,6 @@ export const useTradingView = ({
   buySellMarksToggleRef,
   buySellMarksToggleOn,
   setBuySellMarksToggleOn,
-  setIsChartReady,
 }: {
   tvWidgetRef: React.MutableRefObject<TvWidget | null>;
   orderLineToggleRef: React.MutableRefObject<HTMLElement | null>;
@@ -62,7 +61,6 @@ export const useTradingView = ({
   buySellMarksToggleRef: React.MutableRefObject<HTMLElement | null>;
   buySellMarksToggleOn: boolean;
   setBuySellMarksToggleOn: Dispatch<SetStateAction<boolean>>;
-  setIsChartReady: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const stringGetter = useStringGetter();
   const urlConfigs = useURLConfigs();
@@ -172,9 +170,9 @@ export const useTradingView = ({
 
       tvChartWidget.onChartReady(() => {
         // Initialize additional right-click-menu options
-        tvWidgetRef.current?.onContextMenu(tradingViewLimitOrder);
+        tvChartWidget.onContextMenu(tradingViewLimitOrder);
 
-        tvWidgetRef.current?.headerReady().then(() => {
+        tvChartWidget.headerReady().then(() => {
           if (tvWidgetRef.current) {
             // Order Lines
             initializeToggle({
@@ -226,13 +224,11 @@ export const useTradingView = ({
           }
         });
 
-        tvWidgetRef.current?.subscribe('onAutoSaveNeeded', () =>
-          tvWidgetRef.current?.save((chartConfig: object) => {
+        tvChartWidget.subscribe('onAutoSaveNeeded', () =>
+          tvChartWidget.save((chartConfig: object) => {
             dispatch(updateChartConfig(chartConfig));
           })
         );
-
-        setIsChartReady(true);
       });
     }
 
@@ -245,7 +241,6 @@ export const useTradingView = ({
       buySellMarksToggleRef.current = null;
       tvWidgetRef.current?.remove();
       tvWidgetRef.current = null;
-      setIsChartReady(false);
     };
   }, [
     selectedLocale,
@@ -259,7 +254,6 @@ export const useTradingView = ({
     setOrderLinesToggleOn,
     setOrderbookCandlesToggleOn,
     orderbookCandlesToggleOn,
-    tvWidgetRef,
   ]);
 
   return { savedResolution };

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -29,11 +29,9 @@ import { useMetadataService } from '../useLaunchableMarkets';
  */
 export const useTradingViewLaunchable = ({
   tvWidgetRef,
-  setIsChartReady,
   marketId,
 }: {
   tvWidgetRef: React.MutableRefObject<TvWidget | null>;
-  setIsChartReady: React.Dispatch<React.SetStateAction<boolean>>;
   marketId: string;
 }) => {
   const dispatch = useDispatch();
@@ -74,17 +72,14 @@ export const useTradingViewLaunchable = ({
             dispatch(updateLaunchableMarketsChartConfig(chartConfig));
           })
         );
-
-        setIsChartReady(true);
       });
     }
 
     return () => {
       tvWidgetRef.current?.remove();
       tvWidgetRef.current = null;
-      setIsChartReady(false);
     };
-  }, [dispatch, !!marketId, selectedLocale, setIsChartReady, tvWidgetRef, isDataLoading]);
+  }, [dispatch, !!marketId, selectedLocale, tvWidgetRef, isDataLoading]);
 
   return { savedResolution };
 };

--- a/src/hooks/tradingView/useTradingViewTheme.ts
+++ b/src/hooks/tradingView/useTradingViewTheme.ts
@@ -26,17 +26,17 @@ const isIFrame = (element: HTMLElement | null): element is HTMLIFrameElement =>
 export const useTradingViewTheme = ({
   chartLines,
   tvWidget,
-  isWidgetReady,
 }: {
   chartLines?: Record<string, ChartLine>;
   tvWidget: TvWidget | null;
-  isWidgetReady?: boolean;
 }) => {
   const appTheme: AppTheme = useAppSelector(getAppTheme);
   const appColorMode: AppColorMode = useAppSelector(getAppColorMode);
 
   useEffect(() => {
-    if (tvWidget && isWidgetReady) {
+    if (!tvWidget) return;
+
+    tvWidget.onChartReady(() => {
       tvWidget.changeTheme(THEME_NAMES[appTheme]).then(() => {
         const tvChartId = tvWidget._id;
 
@@ -102,6 +102,6 @@ export const useTradingViewTheme = ({
           });
         }
       });
-    }
-  }, [appTheme, appColorMode, isWidgetReady]);
+    });
+  }, [appTheme, appColorMode, tvWidget]);
 };

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -1,10 +1,21 @@
+import { useEffect, useState } from 'react';
+
 import styled, { css } from 'styled-components';
+
+import { TvWidget } from '@/constants/tvchart';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 
-export const BaseTvChart = ({ isChartReady }: { isChartReady?: boolean }) => {
+export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
+  const [isChartReady, setIsChartReady] = useState(false);
+
+  useEffect(() => {
+    setIsChartReady(false);
+    tvWidget?.onChartReady(() => setIsChartReady(true));
+  }, [tvWidget]);
+
   return (
     <$PriceChart isChartReady={isChartReady}>
       {!isChartReady && <LoadingSpace id="tv-chart-loading" />}

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -23,7 +23,6 @@ export const TvChart = () => {
 
   const tvWidgetRef = useRef<TvWidget | null>(null);
   const tvWidget = tvWidgetRef.current;
-  const isWidgetReady = tvWidget?._ready;
 
   const orderLineToggleRef = useRef<HTMLElement | null>(null);
   const orderLineToggle = orderLineToggleRef.current;
@@ -56,7 +55,6 @@ export const TvChart = () => {
   useChartMarketAndResolution({
     currentMarketId,
     tvWidget,
-    isWidgetReady,
     savedResolution: savedResolution as ResolutionString | undefined,
   });
   const { chartLines } = useChartLines({
@@ -74,7 +72,7 @@ export const TvChart = () => {
     buySellMarksToggleOn,
     tvWidget,
   });
-  useTradingViewTheme({ tvWidget, isWidgetReady, chartLines });
+  useTradingViewTheme({ tvWidget, chartLines });
 
   const [isChartReady, setIsChartReady] = useState(false);
   useEffect(() => {

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -19,7 +19,6 @@ import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChart = () => {
-  const [isChartReady, setIsChartReady] = useState(false);
   const currentMarketId: string = useAppSelector(getCurrentMarketId) ?? DEFAULT_MARKETID;
 
   const tvWidgetRef = useRef<TvWidget | null>(null);
@@ -53,7 +52,6 @@ export const TvChart = () => {
     buySellMarksToggleRef,
     buySellMarksToggleOn,
     setBuySellMarksToggleOn,
-    setIsChartReady,
   });
   useChartMarketAndResolution({
     currentMarketId,
@@ -64,12 +62,10 @@ export const TvChart = () => {
   const { chartLines } = useChartLines({
     tvWidget,
     orderLineToggle,
-    isChartReady,
     orderLinesToggleOn,
   });
   useOrderbookCandles({
     orderbookCandlesToggle,
-    isChartReady,
     orderbookCandlesToggleOn,
     tvWidget,
   });
@@ -77,9 +73,14 @@ export const TvChart = () => {
     buySellMarksToggle,
     buySellMarksToggleOn,
     tvWidget,
-    isChartReady,
   });
   useTradingViewTheme({ tvWidget, isWidgetReady, chartLines });
+
+  const [isChartReady, setIsChartReady] = useState(false);
+  useEffect(() => {
+    setIsChartReady(false);
+    tvWidget?.onChartReady(() => setIsChartReady(true));
+  }, [tvWidget]);
 
   return <BaseTvChart isChartReady={isChartReady} />;
 };

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import type { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -74,11 +74,5 @@ export const TvChart = () => {
   });
   useTradingViewTheme({ tvWidget, chartLines });
 
-  const [isChartReady, setIsChartReady] = useState(false);
-  useEffect(() => {
-    setIsChartReady(false);
-    tvWidget?.onChartReady(() => setIsChartReady(true));
-  }, [tvWidget]);
-
-  return <BaseTvChart isChartReady={isChartReady} />;
+  return <BaseTvChart tvWidget={tvWidget} />;
 };

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -11,7 +11,7 @@ import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
-  const [isWidgetReady, setIsWidgetReady] = useState(false);
+  const [isChartReady, setIsChartReady] = useState(false);
 
   const tvWidgetRef = useRef<TvWidget | null>(null);
   const tvWidget = tvWidgetRef.current;
@@ -25,19 +25,17 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
     currentMarketId: marketId,
     isViewingUnlaunchedMarket: true,
     tvWidget,
-    isWidgetReady,
     savedResolution: savedResolution as ResolutionString,
   });
 
   useTradingViewTheme({
     tvWidget,
-    isWidgetReady,
   });
 
   useEffect(() => {
-    setIsWidgetReady(false);
-    tvWidget?.onChartReady(() => setIsWidgetReady(true));
+    setIsChartReady(false);
+    tvWidget?.onChartReady(() => setIsChartReady(true));
   }, [tvWidget]);
 
-  return <BaseTvChart isChartReady={isWidgetReady} />;
+  return <BaseTvChart isChartReady={isChartReady} />;
 };

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -11,16 +11,14 @@ import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
-  const [isChartReady, setIsChartReady] = useState(false);
+  const [isWidgetReady, setIsWidgetReady] = useState(false);
 
   const tvWidgetRef = useRef<TvWidget | null>(null);
   const tvWidget = tvWidgetRef.current;
-  const isWidgetReady = tvWidget?._ready;
 
   const { savedResolution } = useTradingViewLaunchable({
     marketId,
     tvWidgetRef,
-    setIsChartReady,
   });
 
   useChartMarketAndResolution({
@@ -36,5 +34,10 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
     isWidgetReady,
   });
 
-  return <BaseTvChart isChartReady={isChartReady} />;
+  useEffect(() => {
+    setIsWidgetReady(false);
+    tvWidget?.onChartReady(() => setIsWidgetReady(true));
+  }, [tvWidget]);
+
+  return <BaseTvChart isChartReady={isWidgetReady} />;
 };

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -11,8 +11,6 @@ import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
-  const [isChartReady, setIsChartReady] = useState(false);
-
   const tvWidgetRef = useRef<TvWidget | null>(null);
   const tvWidget = tvWidgetRef.current;
 
@@ -32,10 +30,5 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
     tvWidget,
   });
 
-  useEffect(() => {
-    setIsChartReady(false);
-    tvWidget?.onChartReady(() => setIsChartReady(true));
-  }, [tvWidget]);
-
-  return <BaseTvChart isChartReady={isChartReady} />;
+  return <BaseTvChart tvWidget={tvWidget} />;
 };


### PR DESCRIPTION
- refactors instances of isChartReady usage to just run in tvWidget.onChartReady() callbacks to keep the widget and callbacks more atomic to the actual instance of the widget being used
- removes one check for clearing chart lines bcuz we have no idea why its being done this way: https://github.com/dydxprotocol/v4-web/blob/main/src/hooks/tradingView/useChartLines.tsx#L493