### PR TITLE
fix: change tvWidget into react state instead of ref

### DIFF
--- a/src/hooks/tradingView/useBuySellMarks.ts
+++ b/src/hooks/tradingView/useBuySellMarks.ts
@@ -19,7 +19,7 @@ export function useBuySellMarks({
 }: {
   buySellMarksToggle: HTMLElement | null;
   buySellMarksToggleOn: boolean;
-  tvWidget: TvWidget | null;
+  tvWidget?: TvWidget;
 }) {
   const marketId = useAppSelector(getCurrentMarketId);
   const fills = useAppSelector(getMarketFills);

--- a/src/hooks/tradingView/useChartLines.tsx
+++ b/src/hooks/tradingView/useChartLines.tsx
@@ -58,7 +58,7 @@ export const useChartLines = ({
   orderLineToggle,
   orderLinesToggleOn,
 }: {
-  tvWidget: TvWidget | null;
+  tvWidget?: TvWidget;
   orderLineToggle: HTMLElement | null;
   orderLinesToggleOn: boolean;
 }) => {

--- a/src/hooks/tradingView/useChartMarketAndResolution.ts
+++ b/src/hooks/tradingView/useChartMarketAndResolution.ts
@@ -25,7 +25,7 @@ export const useChartMarketAndResolution = ({
 }: {
   currentMarketId: string;
   isViewingUnlaunchedMarket?: boolean;
-  tvWidget: TvWidget | null;
+  tvWidget?: TvWidget;
   savedResolution?: ResolutionString;
 }) => {
   const dispatch = useAppDispatch();

--- a/src/hooks/tradingView/useOrderbookCandles.ts
+++ b/src/hooks/tradingView/useOrderbookCandles.ts
@@ -15,7 +15,7 @@ export const useOrderbookCandles = ({
 }: {
   orderbookCandlesToggle: HTMLElement | null;
   orderbookCandlesToggleOn: boolean;
-  tvWidget: TvWidget | null;
+  tvWidget?: TvWidget;
 }) => {
   useEffect(
     // Update orderbookCandles button on toggle

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -3,6 +3,7 @@ import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useSt
 import BigNumber from 'bignumber.js';
 import isEmpty from 'lodash/isEmpty';
 import {
+  IChartingLibraryWidget,
   LanguageCode,
   ResolutionString,
   TradingTerminalWidgetOptions,
@@ -40,7 +41,8 @@ import { useTradingViewLimitOrder } from './useTradingViewLimitOrder';
  * @description Hook to initialize TradingView Chart
  */
 export const useTradingView = ({
-  tvWidgetRef,
+  tvWidget,
+  setTvWidget,
   orderLineToggleRef,
   orderLinesToggleOn,
   setOrderLinesToggleOn,
@@ -51,7 +53,8 @@ export const useTradingView = ({
   buySellMarksToggleOn,
   setBuySellMarksToggleOn,
 }: {
-  tvWidgetRef: React.MutableRefObject<TvWidget | null>;
+  tvWidget?: TvWidget;
+  setTvWidget: Dispatch<SetStateAction<TvWidget | undefined>>;
   orderLineToggleRef: React.MutableRefObject<HTMLElement | null>;
   orderLinesToggleOn: boolean;
   setOrderLinesToggleOn: Dispatch<SetStateAction<boolean>>;
@@ -100,20 +103,20 @@ export const useTradingView = ({
   const initializeToggle = useCallback(
     ({
       toggleRef,
-      tvWidget,
+      widget,
       isOn,
       setToggleOn,
       label,
       tooltip,
     }: {
       toggleRef: React.MutableRefObject<HTMLElement | null>;
-      tvWidget: TvWidget;
+      widget: IChartingLibraryWidget;
       isOn: boolean;
       setToggleOn: Dispatch<SetStateAction<boolean>>;
       label: string;
       tooltip: string;
     }) => {
-      toggleRef.current = tvWidget.createButton();
+      toggleRef.current = widget.createButton();
       toggleRef.current.innerHTML = `<span>${label}</span> <div class="toggle"></div>`;
       toggleRef.current.setAttribute('title', tooltip);
       if (isOn) {
@@ -141,7 +144,7 @@ export const useTradingView = ({
   const tradingViewLimitOrder = useTradingViewLimitOrder(marketId, tickSizeDecimals);
 
   useEffect(() => {
-    if (marketId && tickSizeDecimals !== undefined) {
+    if (marketId && tickSizeDecimals !== undefined && !tvWidget) {
       const widgetOptions = getWidgetOptions();
       const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
 
@@ -166,62 +169,60 @@ export const useTradingView = ({
       };
 
       const tvChartWidget = new Widget(options);
-      tvWidgetRef.current = tvChartWidget;
+      setTvWidget(tvChartWidget);
 
       tvChartWidget.onChartReady(() => {
         // Initialize additional right-click-menu options
         tvChartWidget.onContextMenu(tradingViewLimitOrder);
 
         tvChartWidget.headerReady().then(() => {
-          if (tvWidgetRef.current) {
-            // Order Lines
-            initializeToggle({
-              toggleRef: orderLineToggleRef,
-              tvWidget: tvWidgetRef.current,
-              isOn: orderLinesToggleOn,
-              setToggleOn: setOrderLinesToggleOn,
-              label: stringGetter({
-                key: STRING_KEYS.ORDER_LINES,
-              }),
-              tooltip: stringGetter({
-                key: STRING_KEYS.ORDER_LINES_TOOLTIP,
-              }),
+          // Order Lines
+          initializeToggle({
+            toggleRef: orderLineToggleRef,
+            widget: tvChartWidget,
+            isOn: orderLinesToggleOn,
+            setToggleOn: setOrderLinesToggleOn,
+            label: stringGetter({
+              key: STRING_KEYS.ORDER_LINES,
+            }),
+            tooltip: stringGetter({
+              key: STRING_KEYS.ORDER_LINES_TOOLTIP,
+            }),
+          });
+
+          if (ffEnableOrderbookCandles) {
+            // Orderbook Candles (OHLC)
+            const getOhlcTooltipString = tooltipStrings.ohlc;
+            const { title: ohlcTitle, body: ohlcBody } = getOhlcTooltipString({
+              stringGetter,
+              stringParams: {},
+              urlConfigs,
+              featureFlags,
             });
 
-            if (ffEnableOrderbookCandles) {
-              // Orderbook Candles (OHLC)
-              const getOhlcTooltipString = tooltipStrings.ohlc;
-              const { title: ohlcTitle, body: ohlcBody } = getOhlcTooltipString({
-                stringGetter,
-                stringParams: {},
-                urlConfigs,
-                featureFlags,
-              });
-
-              initializeToggle({
-                toggleRef: orderbookCandlesToggleRef,
-                tvWidget: tvWidgetRef.current,
-                isOn: orderbookCandlesToggleOn,
-                setToggleOn: setOrderbookCandlesToggleOn,
-                label: `${ohlcTitle}*`,
-                tooltip: ohlcBody as string,
-              });
-            }
-
-            // Buy/Sell Marks
             initializeToggle({
-              toggleRef: buySellMarksToggleRef,
-              tvWidget: tvWidgetRef.current,
-              isOn: buySellMarksToggleOn,
-              setToggleOn: setBuySellMarksToggleOn,
-              label: stringGetter({
-                key: STRING_KEYS.BUYS_SELLS_TOGGLE,
-              }),
-              tooltip: stringGetter({
-                key: STRING_KEYS.BUYS_SELLS_TOGGLE_TOOLTIP,
-              }),
+              toggleRef: orderbookCandlesToggleRef,
+              widget: tvChartWidget,
+              isOn: orderbookCandlesToggleOn,
+              setToggleOn: setOrderbookCandlesToggleOn,
+              label: `${ohlcTitle}*`,
+              tooltip: ohlcBody as string,
             });
           }
+
+          // Buy/Sell Marks
+          initializeToggle({
+            toggleRef: buySellMarksToggleRef,
+            widget: tvChartWidget,
+            isOn: buySellMarksToggleOn,
+            setToggleOn: setBuySellMarksToggleOn,
+            label: stringGetter({
+              key: STRING_KEYS.BUYS_SELLS_TOGGLE,
+            }),
+            tooltip: stringGetter({
+              key: STRING_KEYS.BUYS_SELLS_TOGGLE_TOOLTIP,
+            }),
+          });
         });
 
         tvChartWidget.subscribe('onAutoSaveNeeded', () =>
@@ -239,8 +240,7 @@ export const useTradingView = ({
       orderbookCandlesToggleRef.current = null;
       buySellMarksToggleRef.current?.remove();
       buySellMarksToggleRef.current = null;
-      tvWidgetRef.current?.remove();
-      tvWidgetRef.current = null;
+      tvWidget?.remove();
     };
   }, [
     selectedLocale,
@@ -254,6 +254,8 @@ export const useTradingView = ({
     setOrderLinesToggleOn,
     setOrderbookCandlesToggleOn,
     orderbookCandlesToggleOn,
+    tvWidget,
+    setTvWidget,
   ]);
 
   return { savedResolution };

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -3,7 +3,6 @@ import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useSt
 import BigNumber from 'bignumber.js';
 import isEmpty from 'lodash/isEmpty';
 import {
-  IChartingLibraryWidget,
   LanguageCode,
   ResolutionString,
   TradingTerminalWidgetOptions,
@@ -110,7 +109,7 @@ export const useTradingView = ({
       tooltip,
     }: {
       toggleRef: React.MutableRefObject<HTMLElement | null>;
-      widget: IChartingLibraryWidget;
+      widget: TvWidget;
       isOn: boolean;
       setToggleOn: Dispatch<SetStateAction<boolean>>;
       label: string;

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 import {
@@ -28,10 +28,12 @@ import { useMetadataService } from '../useLaunchableMarkets';
  * @description Hook to initialize TradingView Chart
  */
 export const useTradingViewLaunchable = ({
-  tvWidgetRef,
+  tvWidget,
+  setTvWidget,
   marketId,
 }: {
-  tvWidgetRef: React.MutableRefObject<TvWidget | null>;
+  tvWidget?: TvWidget;
+  setTvWidget: Dispatch<SetStateAction<TvWidget | undefined>>;
   marketId: string;
 }) => {
   const dispatch = useDispatch();
@@ -47,7 +49,7 @@ export const useTradingViewLaunchable = ({
   const { data: metadataServiceData, isLoading: isDataLoading } = useMetadataService();
 
   useEffect(() => {
-    if (marketId && !isDataLoading) {
+    if (marketId && !isDataLoading && !tvWidget) {
       const widgetOptions = getWidgetOptions(true);
       const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
 
@@ -64,11 +66,11 @@ export const useTradingViewLaunchable = ({
       };
 
       const tvChartWidget = new Widget(options);
-      tvWidgetRef.current = tvChartWidget;
+      setTvWidget(tvChartWidget);
 
       tvChartWidget.onChartReady(() => {
-        tvWidgetRef.current?.subscribe('onAutoSaveNeeded', () =>
-          tvWidgetRef.current?.save((chartConfig: object) => {
+        tvChartWidget.subscribe('onAutoSaveNeeded', () =>
+          tvChartWidget.save((chartConfig: object) => {
             dispatch(updateLaunchableMarketsChartConfig(chartConfig));
           })
         );
@@ -76,10 +78,10 @@ export const useTradingViewLaunchable = ({
     }
 
     return () => {
-      tvWidgetRef.current?.remove();
-      tvWidgetRef.current = null;
+      tvWidget?.remove();
+      setTvWidget(undefined);
     };
-  }, [dispatch, !!marketId, selectedLocale, tvWidgetRef, isDataLoading]);
+  }, [dispatch, !!marketId, selectedLocale, isDataLoading, tvWidget, setTvWidget]);
 
   return { savedResolution };
 };

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -79,7 +79,6 @@ export const useTradingViewLaunchable = ({
 
     return () => {
       tvWidget?.remove();
-      setTvWidget(undefined);
     };
   }, [dispatch, !!marketId, selectedLocale, isDataLoading, tvWidget, setTvWidget]);
 

--- a/src/hooks/tradingView/useTradingViewTheme.ts
+++ b/src/hooks/tradingView/useTradingViewTheme.ts
@@ -28,7 +28,7 @@ export const useTradingViewTheme = ({
   tvWidget,
 }: {
   chartLines?: Record<string, ChartLine>;
-  tvWidget: TvWidget | null;
+  tvWidget?: TvWidget;
 }) => {
   const appTheme: AppTheme = useAppSelector(getAppTheme);
   const appColorMode: AppColorMode = useAppSelector(getAppColorMode);

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -13,9 +13,7 @@ export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
 
   useEffect(() => {
     setIsChartReady(false);
-    tvWidget?.onChartReady(() => {
-      setIsChartReady(true);
-    });
+    tvWidget?.onChartReady(() => setIsChartReady(true));
   }, [tvWidget]);
 
   return (

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -13,7 +13,9 @@ export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
 
   useEffect(() => {
     setIsChartReady(false);
-    tvWidget?.onChartReady(() => setIsChartReady(true));
+    tvWidget?.onChartReady(() => {
+      setIsChartReady(true);
+    });
   }, [tvWidget]);
 
   return (

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import type { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -21,8 +21,7 @@ import { BaseTvChart } from './BaseTvChart';
 export const TvChart = () => {
   const currentMarketId: string = useAppSelector(getCurrentMarketId) ?? DEFAULT_MARKETID;
 
-  const tvWidgetRef = useRef<TvWidget | null>(null);
-  const tvWidget = tvWidgetRef.current;
+  const [tvWidget, setTvWidget] = useState<TvWidget>();
 
   const orderLineToggleRef = useRef<HTMLElement | null>(null);
   const orderLineToggle = orderLineToggleRef.current;
@@ -41,7 +40,8 @@ export const TvChart = () => {
     buySellMarksToggleOn,
   } = useTradingViewToggles();
   const { savedResolution } = useTradingView({
-    tvWidgetRef,
+    tvWidget,
+    setTvWidget,
     orderLineToggleRef,
     orderLinesToggleOn,
     setOrderLinesToggleOn,

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -15,6 +15,7 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
 
   const { savedResolution } = useTradingViewLaunchable({
     marketId,
+    tvWidget,
     setTvWidget,
   });
 

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 
 import { ResolutionString } from 'public/tradingview/charting_library';
 
@@ -11,12 +11,11 @@ import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
-  const tvWidgetRef = useRef<TvWidget | null>(null);
-  const tvWidget = tvWidgetRef.current;
+  const [tvWidget, setTvWidget] = useState<TvWidget>();
 
   const { savedResolution } = useTradingViewLaunchable({
     marketId,
-    tvWidgetRef,
+    setTvWidget,
   });
 
   useChartMarketAndResolution({


### PR DESCRIPTION
fixes an issue where loading states for launchable markets weren't updating when tvWidget was ready
