### PR TITLE
fix: reasonable sizing for mobile wallet info

### DIFF
--- a/src/pages/trade/MobileTopPanel.tsx
+++ b/src/pages/trade/MobileTopPanel.tsx
@@ -22,6 +22,7 @@ import { LiveTrades } from '@/views/tables/LiveTrades';
 import { useAppSelector } from '@/state/appTypes';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
+import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 import { isTruthy } from '@/lib/isTruthy';
 
 enum Tab {
@@ -106,6 +107,7 @@ export const MobileTopPanel = ({
   return (
     <$Tabs
       value={value}
+      $shortMode={value === Tab.Account}
       onValueChange={setValue}
       items={items.map((item) => ({
         ...item,
@@ -117,8 +119,12 @@ export const MobileTopPanel = ({
     />
   );
 };
-const $Tabs = styled(Tabs)`
-  --scrollArea-height: 38rem;
+
+type TabsStyleProps = { $shortMode?: boolean };
+const TabsTypeTemp = getSimpleStyledOutputType(Tabs, {} as TabsStyleProps);
+
+const $Tabs = styled(Tabs)<TabsStyleProps>`
+  --scrollArea-height: ${({ $shortMode }) => ($shortMode ? '19rem' : '38rem')};
   --stickyArea0-background: var(--color-layer-2);
   --tabContent-height: calc(var(--scrollArea-height) - 2rem - var(--tabs-currentHeight));
 
@@ -135,7 +141,7 @@ const $Tabs = styled(Tabs)`
       gap: 0.5rem;
     }
   }
-` as typeof Tabs;
+` as typeof TabsTypeTemp;
 
 const $TabButton = styled(ToggleButton)`
   padding: 0 0.5rem;


### PR DESCRIPTION
https://linear.app/dydx/issue/CT-1303/[wallet]-consider-aligning-better-using-the-space

![image](https://github.com/user-attachments/assets/39c30e08-2f71-4a8c-a177-9d9bdd98f1ed)

Before:
![image](https://github.com/user-attachments/assets/b6c84868-ca3e-4b16-aede-5dc2f7e4f9b4)
