### PR TITLE
fix: nicer tables in a few ways

### DIFF
--- a/src/components/SortIcon.tsx
+++ b/src/components/SortIcon.tsx
@@ -43,6 +43,7 @@ const $SortIcon = styled.div<{ hidden: boolean }>`
     hidden
       ? css`
           opacity: 0;
+          width: 0;
         `
       : css`
           opacity: 1;

--- a/src/pages/portfolio/Fees.tsx
+++ b/src/pages/portfolio/Fees.tsx
@@ -138,16 +138,21 @@ export const Fees = () => {
                 label: stringGetter({ key: STRING_KEYS.VOLUME_30D }),
                 allowsSorting: false,
                 renderCell: ({ symbol, volume: vol, makerShare, totalShare }) => (
-                  <>
-                    <span>{`${
-                      symbol in EQUALITY_SYMBOL_MAP
-                        ? EQUALITY_SYMBOL_MAP[symbol as keyof typeof EQUALITY_SYMBOL_MAP]
-                        : symbol
-                    } `}</span>
-                    <$HighlightOutput type={OutputType.CompactFiat} value={vol} />
-                    {isTablet &&
-                      AdditionalConditions({ totalShare, makerShare, isAdditional: true })}
-                  </>
+                  <div tw="flex flex-col">
+                    <div tw="flex flex-row justify-end gap-0.25">
+                      <span>{`${
+                        symbol in EQUALITY_SYMBOL_MAP
+                          ? EQUALITY_SYMBOL_MAP[symbol as keyof typeof EQUALITY_SYMBOL_MAP]
+                          : symbol
+                      } `}</span>
+                      <$HighlightOutput type={OutputType.CompactFiat} value={vol} />
+                    </div>
+                    {isTablet && (
+                      <div tw="flex justify-end">
+                        {AdditionalConditions({ totalShare, makerShare, isAdditional: true })}
+                      </div>
+                    )}
+                  </div>
                 ),
               },
               isNotTablet && {
@@ -199,20 +204,28 @@ const $AdditionalConditions = styled.div`
   > :nth-child(2) {
     font: var(--font-small-book);
   }
+
+  @media ${breakpoints.mobile} {
+    max-width: 6rem;
+  }
 `;
 
 const $AdditionalConditionsText = styled.span`
   display: flex;
   gap: 0.5ch;
   justify-content: end;
+  align-items: flex-end;
 
   @media ${breakpoints.mobile} {
     display: inline;
-    max-width: 8rem;
     min-width: 0;
 
     output {
       display: inline;
+    }
+
+    :after {
+      content: ' ';
     }
   }
 `;

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -1,10 +1,10 @@
 import { BREAKPOINT_REM } from '@/constants/page';
 
 export default {
-  mobile: `(max-width: ${BREAKPOINT_REM.mobile})`,
-  notMobile: `(min-width: ${BREAKPOINT_REM.mobile})`,
-  tablet: `(max-width: ${BREAKPOINT_REM.tablet})`,
-  notTablet: `(min-width: ${BREAKPOINT_REM.tablet})`,
+  mobile: `(width <= ${BREAKPOINT_REM.mobile})`,
+  notMobile: `(width > ${BREAKPOINT_REM.mobile})`,
+  tablet: `(width <= ${BREAKPOINT_REM.tablet})`,
+  notTablet: `(width > ${BREAKPOINT_REM.tablet})`,
   desktopSmall: `(max-width: ${BREAKPOINT_REM.desktopSmall})`,
   desktopMedium: `(min-width: ${BREAKPOINT_REM.desktopMedium})`,
   desktopLarge: `(min-width: ${BREAKPOINT_REM.desktopLarge})`,


### PR DESCRIPTION
- invisible sort icons dont take up space
- make exclusive breakpoints non-overlapping
- make fees look nicer

![image](https://github.com/user-attachments/assets/8c629697-abc3-44d2-afce-9f6f13d6bd9c)
Before:
![image](https://github.com/user-attachments/assets/1fdf07a3-1a5c-432f-a728-9f18fa08de66)
