### PR TITLE
fix: default resolution logic + remove data for saving resolution per market

### DIFF
--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -256,6 +256,4 @@ export const useTradingView = ({
     tvWidget,
     setTvWidget,
   ]);
-
-  return { savedResolution };
 };

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -81,6 +81,4 @@ export const useTradingViewLaunchable = ({
       tvWidget?.remove();
     };
   }, [dispatch, !!marketId, selectedLocale, isDataLoading, tvWidget, setTvWidget]);
-
-  return { savedResolution };
 };

--- a/src/state/perpetuals.ts
+++ b/src/state/perpetuals.ts
@@ -13,7 +13,6 @@ import { LocalStorageKey } from '@/constants/localStorage';
 import { DEFAULT_MARKETID, MarketFilters } from '@/constants/markets';
 
 import { getLocalStorage } from '@/lib/localStorage';
-import { objectKeys } from '@/lib/objectHelpers';
 import { processOrderbookToCreateMap } from '@/lib/orderbookHelpers';
 
 interface CandleDataByMarket {
@@ -133,24 +132,6 @@ export const perpetualsSlice = createSlice({
         },
       };
     },
-    setTvChartResolution: (
-      state: PerpetualsState,
-      action: PayloadAction<{ marketId: string; resolution: string }>
-    ) => {
-      const { marketId, resolution } = action.payload;
-
-      const candleState =
-        state.candles[marketId] != null
-          ? { ...state.candles[marketId]!, selectedResolution: resolution }
-          : {
-              data: Object.fromEntries(
-                objectKeys(RESOLUTION_MAP).map((resolutionString) => [resolutionString, []])
-              ),
-              selectedResolution: resolution,
-            };
-
-      state.candles[marketId] = candleState;
-    },
     setHistoricalFundings: (
       state: PerpetualsState,
       action: PayloadAction<{ historicalFundings: MarketHistoricalFunding[]; marketId: string }>
@@ -172,7 +153,6 @@ export const {
   setLiveTrades,
   setMarkets,
   setOrderbook,
-  setTvChartResolution,
   setHistoricalFundings,
   resetPerpetualsState,
   setMarketFilter,

--- a/src/state/perpetualsSelectors.ts
+++ b/src/state/perpetualsSelectors.ts
@@ -196,14 +196,6 @@ export const getPerpetualBarsForPriceChart = (orderbookCandlesToggleOn: boolean)
   );
 
 /**
- *
- * @param marketId
- * @returns TvChart resolution for specified marketId
- */
-export const getSelectedResolutionForMarket = (state: RootState, marketId: string) =>
-  state.perpetuals.candles[marketId]?.selectedResolution;
-
-/**
  * @returns Current market's next funding rate
  */
 export const getCurrentMarketNextFundingRate = createAppSelector(

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -1,7 +1,5 @@
 import { useRef, useState } from 'react';
 
-import type { ResolutionString } from 'public/tradingview/charting_library';
-
 import { DEFAULT_MARKETID } from '@/constants/markets';
 import type { TvWidget } from '@/constants/tvchart';
 
@@ -39,7 +37,8 @@ export const TvChart = () => {
     setBuySellMarksToggleOn,
     buySellMarksToggleOn,
   } = useTradingViewToggles();
-  const { savedResolution } = useTradingView({
+
+  useTradingView({
     tvWidget,
     setTvWidget,
     orderLineToggleRef,
@@ -55,7 +54,6 @@ export const TvChart = () => {
   useChartMarketAndResolution({
     currentMarketId,
     tvWidget,
-    savedResolution: savedResolution as ResolutionString | undefined,
   });
   const { chartLines } = useChartLines({
     tvWidget,

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-import { ResolutionString } from 'public/tradingview/charting_library';
-
 import type { TvWidget } from '@/constants/tvchart';
 
 import { useChartMarketAndResolution } from '@/hooks/tradingView/useChartMarketAndResolution';
@@ -13,7 +11,7 @@ import { BaseTvChart } from './BaseTvChart';
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
   const [tvWidget, setTvWidget] = useState<TvWidget>();
 
-  const { savedResolution } = useTradingViewLaunchable({
+  useTradingViewLaunchable({
     marketId,
     tvWidget,
     setTvWidget,
@@ -23,7 +21,6 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
     currentMarketId: marketId,
     isViewingUnlaunchedMarket: true,
     tvWidget,
-    savedResolution: savedResolution as ResolutionString,
   });
 
   useTradingViewTheme({


### PR DESCRIPTION
- this PR removes struct from perpetual slice that saves resolutions per market, because they arent really being used
- this fixes logic with initial resolutions when changing markets 
