### PR TITLE
fix(affiliates): banner links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -15,6 +15,7 @@ type ElementProps = {
   href?: string;
   onClick?: (e: React.MouseEvent) => void;
   withIcon?: boolean;
+  isNewPage?: boolean;
 };
 
 type StyleProps = {
@@ -33,6 +34,7 @@ export const Link = forwardRef<HTMLAnchorElement, ElementProps & StyleProps>(
       withIcon = false,
       isInline = false,
       isAccent = false,
+      isNewPage = true,
       className,
       ...props
     }: ElementProps & StyleProps,
@@ -54,7 +56,7 @@ export const Link = forwardRef<HTMLAnchorElement, ElementProps & StyleProps>(
         onClick?.(e);
       }}
       rel="noopener noreferrer"
-      target="_blank"
+      target={isNewPage ? '_blank' : undefined}
       {...props}
     >
       {children}

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -21,7 +21,7 @@ import { TelegramInviteBanner } from '@/views/TelegramInviteBanner';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
 import { calculateShouldRenderActionsInPositionsTable } from '@/state/accountCalculators';
-import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { useAppSelector } from '@/state/appTypes';
 import { getDismissedAffiliateBanner } from '@/state/dismissableSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
@@ -33,7 +33,6 @@ import { AccountOverviewSection } from './AccountOverviewSection';
 export const Overview = () => {
   const stringGetter = useStringGetter();
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
 
   const { isTablet } = useBreakpoints();
   const { dydxAddress } = useAccounts();
@@ -42,7 +41,7 @@ export const Overview = () => {
   const feedbackRequestWalletAddresses = dynamicConfigs[StatsigDynamicConfigs.dcHighestVolumeUsers];
   const shouldShowTelegramInvite =
     dydxAddress && feedbackRequestWalletAddresses?.includes(dydxAddress);
-  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates) || true;
+  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
   const dismissedAffiliateBanner = useAppSelector(getDismissedAffiliateBanner);
 
   const handleViewUnopenedIsolatedOrders = useCallback(() => {

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -21,7 +21,7 @@ import { TelegramInviteBanner } from '@/views/TelegramInviteBanner';
 import { PositionsTable, PositionsTableColumnKey } from '@/views/tables/PositionsTable';
 
 import { calculateShouldRenderActionsInPositionsTable } from '@/state/accountCalculators';
-import { useAppSelector } from '@/state/appTypes';
+import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getDismissedAffiliateBanner } from '@/state/dismissableSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
@@ -33,6 +33,7 @@ import { AccountOverviewSection } from './AccountOverviewSection';
 export const Overview = () => {
   const stringGetter = useStringGetter();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   const { isTablet } = useBreakpoints();
   const { dydxAddress } = useAccounts();
@@ -41,7 +42,7 @@ export const Overview = () => {
   const feedbackRequestWalletAddresses = dynamicConfigs[StatsigDynamicConfigs.dcHighestVolumeUsers];
   const shouldShowTelegramInvite =
     dydxAddress && feedbackRequestWalletAddresses?.includes(dydxAddress);
-  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
+  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates) || true;
   const dismissedAffiliateBanner = useAppSelector(getDismissedAffiliateBanner);
 
   const handleViewUnopenedIsolatedOrders = useCallback(() => {
@@ -59,7 +60,7 @@ export const Overview = () => {
     <div>
       {affiliatesEnabled && !dismissedAffiliateBanner && !isTablet && (
         <DetachedSection>
-          <AffiliatesBanner withClose />
+          <AffiliatesBanner withClose showLink />
         </DetachedSection>
       )}
 
@@ -79,7 +80,7 @@ export const Overview = () => {
 
       {affiliatesEnabled && isTablet && (
         <DetachedSection>
-          <AffiliatesBanner />
+          <AffiliatesBanner showLink />
         </DetachedSection>
       )}
 

--- a/src/views/Affiliates/cards/AffiliateStatsCard.tsx
+++ b/src/views/Affiliates/cards/AffiliateStatsCard.tsx
@@ -41,7 +41,15 @@ const MobileView = ({
           outputType={OutputType.Text}
           value={isVip ? stringGetter({ key: STRING_KEYS.VIP }) : currentAffiliateTier}
         >
-          <Link isInline href="#" onClick={toggleCriteria}>
+          <Link
+            isInline
+            href="#"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleCriteria();
+            }}
+          >
             <p tw="text-base text-color-accent">
               {stringGetter({ key: STRING_KEYS.AFFILIATE_TIERS_CRITERIA })}
             </p>

--- a/src/views/Affiliates/community-chart/ProgramChartContainer.tsx
+++ b/src/views/Affiliates/community-chart/ProgramChartContainer.tsx
@@ -26,7 +26,7 @@ export const CommunityChartContainer = () => {
   const { programStats } = useOutletContext<{ programStats: IProgramStats }>();
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col px-1">
       <Tabs
         value={chartMetric}
         onValueChange={setChartMetric}
@@ -49,7 +49,7 @@ export const CommunityChartContainer = () => {
           },
         ]}
       />
-      <$ChartContainer className="bg-color-layer-3 p-2">
+      <$ChartContainer className="bg-color-layer-3 p-1">
         <ProgramHistoricalChart
           {...{ programStats }}
           selectedChartMetric={chartMetric}

--- a/src/views/AffiliatesBanner.tsx
+++ b/src/views/AffiliatesBanner.tsx
@@ -12,7 +12,6 @@ import { STRING_KEYS } from '@/constants/localization';
 import { useAffiliatesInfo } from '@/hooks/useAffiliatesInfo';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useStringGetter } from '@/hooks/useStringGetter';
-import { useURLConfigs } from '@/hooks/useURLConfigs';
 
 import breakpoints from '@/styles/breakpoints';
 import { layoutMixins } from '@/styles/layoutMixins';
@@ -27,11 +26,16 @@ import { getGridBackground } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
 import { setDismissedAffiliateBanner } from '@/state/dismissable';
 
-export const AffiliatesBanner = ({ withClose = false }: { withClose?: boolean }) => {
+export const AffiliatesBanner = ({
+  withClose = false,
+  showLink = false,
+}: {
+  withClose?: boolean;
+  showLink?: boolean;
+}) => {
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
   const { isTablet } = useBreakpoints();
-  const { affiliateProgram } = useURLConfigs();
   const {
     affiliateMaxEarningQuery: { data: maxEarningData },
   } = useAffiliatesInfo();
@@ -48,25 +52,30 @@ export const AffiliatesBanner = ({ withClose = false }: { withClose?: boolean })
   });
 
   const description = (
-    <>
-      {stringGetter({
-        key: STRING_KEYS.REFER_FOR_DISCOUNTS_FIRST_ORDER,
-        params: {
-          AMOUNT_USD: `$${AFFILIATES_FEE_DISCOUNT_USD.toLocaleString()}`,
-        },
-      })}{' '}
-      <br />
-      {stringGetter({
-        key: STRING_KEYS.WANT_TO_VIEW_EARNINGS,
-        params: {
-          LINK: (
-            <Link href={affiliateProgram} isInline isAccent>
-              {stringGetter({ key: STRING_KEYS.AFFILIATES_PROGRAM })} →
-            </Link>
-          ),
-        },
-      })}
-    </>
+    <div tw="flex flex-col">
+      <div>
+        {stringGetter({
+          key: STRING_KEYS.REFER_FOR_DISCOUNTS,
+          params: {
+            AMOUNT_USD: `${AFFILIATES_FEE_DISCOUNT_USD.toLocaleString()}`,
+          },
+        })}
+      </div>
+      {showLink && (
+        <div>
+          {stringGetter({
+            key: STRING_KEYS.WANT_TO_VIEW_EARNINGS,
+            params: {
+              LINK: (
+                <Link isNewPage={false} href="/affiliates" isInline isAccent>
+                  {stringGetter({ key: STRING_KEYS.AFFILIATES_PROGRAM })} →
+                </Link>
+              ),
+            },
+          })}
+        </div>
+      )}
+    </div>
   );
 
   if (isTablet) {
@@ -111,7 +120,7 @@ export const AffiliatesBanner = ({ withClose = false }: { withClose?: boolean })
               {titleString}
             </div>
           </div>
-          <div tw="ml-0.5">{description}</div>
+          <div tw="ml-0.5 text-small text-color-text-0">{description}</div>
         </div>
       </div>
       <div>

--- a/src/views/AffiliatesBanner.tsx
+++ b/src/views/AffiliatesBanner.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { css } from 'styled-components';
 import { styled } from 'twin.macro';
 
@@ -8,6 +9,7 @@ import {
 import { ButtonAction, ButtonShape, ButtonSize } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
+import { AppRoute } from '@/constants/routes';
 
 import { useAffiliatesInfo } from '@/hooks/useAffiliatesInfo';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
@@ -19,7 +21,6 @@ import { layoutMixins } from '@/styles/layoutMixins';
 import { Button } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
-import { Link } from '@/components/Link';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getGridBackground } from '@/state/appUiConfigsSelectors';
@@ -67,7 +68,10 @@ export const AffiliatesBanner = ({
             key: STRING_KEYS.WANT_TO_VIEW_EARNINGS,
             params: {
               LINK: (
-                <Link isNewPage={false} href="/affiliates" isInline isAccent>
+                <Link
+                  to={AppRoute.Affiliates}
+                  tw="inline-flex text-color-accent visited:text-color-accent hover:underline"
+                >
                   {stringGetter({ key: STRING_KEYS.AFFILIATES_PROGRAM })} →
                 </Link>
               ),


### PR DESCRIPTION
The links should redirect to /affiliates instead of to the Fuul page

Portfolio page:
|Desktop|Mobile|
|---------|------|
|<img width="1055" alt="image" src="https://github.com/user-attachments/assets/11bff170-19ca-48de-ae3f-fcb68b113ba1">|<img width="822" alt="image" src="https://github.com/user-attachments/assets/e02a8396-9782-4db6-afef-9a72eef85057">|

Affiliates page:
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/c3ab41d0-2aba-49b2-bd52-440a7c44eb08">


