### PR TITLE
fix(notifs): Block historic Abacus generated notifs

### DIFF
--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -97,8 +97,6 @@ const parseStringParamsForNotification = ({
   return value as string;
 };
 
-const NOTIFICATIONS_INIT_TIME = Date.now();
-
 export const notificationTypes: NotificationTypeConfig[] = [
   {
     type: NotificationType.AbacusGenerated,
@@ -114,11 +112,6 @@ export const notificationTypes: NotificationTypeConfig[] = [
         for (const abacusNotif of abacusNotifications) {
           const [abacusNotificationType = '', id = ''] = abacusNotif.id.split(':');
           const parsedData = abacusNotif.data ? JSON.parse(abacusNotif.data) : {};
-
-          // skip notifications that were generated before the app was initialized
-          if (abacusNotif.updateTimeInMilliseconds < NOTIFICATIONS_INIT_TIME) {
-            return;
-          }
 
           const params = Object.fromEntries(
             Object.entries(parsedData).map(([key, value]) => {

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -97,6 +97,8 @@ const parseStringParamsForNotification = ({
   return value as string;
 };
 
+const NOTIFICATIONS_INIT_TIME = Date.now();
+
 export const notificationTypes: NotificationTypeConfig[] = [
   {
     type: NotificationType.AbacusGenerated,
@@ -112,6 +114,11 @@ export const notificationTypes: NotificationTypeConfig[] = [
         for (const abacusNotif of abacusNotifications) {
           const [abacusNotificationType = '', id = ''] = abacusNotif.id.split(':');
           const parsedData = abacusNotif.data ? JSON.parse(abacusNotif.data) : {};
+
+          // skip notifications that were generated before the app was initialized
+          if (abacusNotif.updateTimeInMilliseconds < NOTIFICATIONS_INIT_TIME) {
+            return;
+          }
 
           const params = Object.fromEntries(
             Object.entries(parsedData).map(([key, value]) => {

--- a/src/layout/NotificationsToastArea/NotifcationStack.tsx
+++ b/src/layout/NotificationsToastArea/NotifcationStack.tsx
@@ -32,6 +32,8 @@ type StyleProps = {
   className?: string;
 };
 
+const NOTIFICATIONS_INIT_TIME = Date.now();
+
 export const NotificationStack = ({ notifications, className }: ElementProps & StyleProps) => {
   const [shouldStackNotifications, setshouldStackNotifications] = useState(true);
 
@@ -60,7 +62,10 @@ export const NotificationStack = ({ notifications, className }: ElementProps & S
         <StyledToast
           key={key}
           isStacked={idx > 0 && shouldStackNotifications}
-          isOpen={notification.status < NotificationStatus.Unseen}
+          isOpen={
+            notification.status < NotificationStatus.Unseen &&
+            (notification.timestamps[NotificationStatus.Unseen] ?? 0) > NOTIFICATIONS_INIT_TIME
+          }
           layer={idx}
           notification={notification}
           slotIcon={displayData?.icon}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
To prevent outdated `fills` notifications. Block all historic notifications that occurred before App initialization.

---

## Views

- `<NotificationStack>`
  - Add const var `NOTIFICATIONS_INIT_TIME` at `useNotificationTypes` initialization
  - Block toast notifs that occur before app init.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
