### PR TITLE
chore(newmarket-preview-step): hide alertInfo if loading

### DIFF
--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -51,14 +51,12 @@ export enum NewMarketFormStep {
 type NewMarketFormProps = {
   defaultLaunchableMarketId?: string;
   setFormStep?: Dispatch<SetStateAction<NewMarketFormStep | undefined>>;
-  setIsParentLoading?: Dispatch<SetStateAction<boolean>>;
   updateTickerToAdd?: Dispatch<SetStateAction<string | undefined>>;
 };
 
 export const NewMarketForm = ({
   defaultLaunchableMarketId,
   setFormStep,
-  setIsParentLoading,
   updateTickerToAdd,
 }: NewMarketFormProps) => {
   const [step, setStep] = useState(NewMarketFormStep.SELECTION);
@@ -231,7 +229,6 @@ export const NewMarketForm = ({
             });
           }}
           receiptItems={receiptItems}
-          setIsParentLoading={setIsParentLoading}
           shouldHideTitleAndDescription={shouldHideTitleAndDescription}
           ticker={tickerToAdd}
         />


### PR DESCRIPTION
Clean up NewMarketForm and v7/NewMarketPreviewStep
- Remove `setParentIsLoading` prop since we no longer have a Dialog View
- Block alertMessage if form is in `loading` state