### PR TITLE
fix: Fix Google Tag Manager parameter injection

### DIFF
--- a/scripts/inject-google-tag-manager.js
+++ b/scripts/inject-google-tag-manager.js
@@ -28,7 +28,7 @@ async function inject(fileName) {
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-ABCDEFGH');</script>
+        })(window,document,'script','dataLayer','${GOOGLE_TAG_MANAGER_CONTAINER_ID}');</script>
         <!-- End Google Tag Manager -->
   `;
   const injectedHtml = html.replace('</head>', `${googleTagManagerHeadScript}\n</head>`);


### PR DESCRIPTION
The existing version always used a dummy container ID: `GTM-ABCDEFGH`. This PR fixes the issue by inserting the value from the `GOOGLE_TAG_MANAGER_CONTAINER_ID` environment variable.