### PR TITLE
fix: tickSizeDecimal calc and mobile view of markets tables

### DIFF
--- a/src/lib/__test__/numbers.spec.ts
+++ b/src/lib/__test__/numbers.spec.ts
@@ -1,7 +1,12 @@
 import BigNumber from 'bignumber.js';
 import { describe, expect, it } from 'vitest';
 
-import { getFractionDigits, isNumber, roundToNearestFactor } from '../numbers';
+import {
+  getFractionDigits,
+  getTickSizeFromPrice,
+  isNumber,
+  roundToNearestFactor,
+} from '../numbers';
 
 describe('roundToNearestFactor', () => {
   it('should return NaN if given a tick of 0', () => {
@@ -122,5 +127,11 @@ describe('isNumber', () => {
   });
   it('handles number', () => {
     expect(isNumber(3.421)).toEqual(true);
+  });
+});
+
+describe('getTickSizeFromPrice', () => {
+  it('tickSize', () => {
+    expect(getTickSizeFromPrice(0.22)).toEqual(0.0001);
   });
 });

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -35,11 +35,19 @@ export const getFractionDigits = (unit?: BigNumberish | null) =>
   // n?.toString().match(/[.](\d*)/)?.[1].length ?? 0
   unit ? Math.max(Math.ceil(-Math.log10(Math.abs(+unit))), 0) : 0;
 
+export const getTickSizeFromPrice = (price: BigNumberish) => {
+  const priceNum = MustBigNumber(price).toNumber();
+  const p = Math.floor(Math.log10(priceNum));
+  const subticksPerTickLog10 = Math.log10(10 ** (9 - 3));
+  const quantumConversionExponent = -9;
+  const exponent = p + quantumConversionExponent + subticksPerTickLog10;
+  return exponent < 0 ? 1 / 10 ** Math.abs(exponent) : 10 ** exponent;
+};
+
 export const getTickSizeDecimalsFromPrice = (price?: BigNumberish | null) => {
   if (!price) return TOKEN_DECIMALS;
-  const priceNum = MustBigNumber(price).toNumber();
-  const p = Math.floor(Math.log(priceNum));
-  return Math.abs(p - 3);
+  const tickSize = getTickSizeFromPrice(price);
+  return getFractionDigits(tickSize);
 };
 
 export const isNumber = (value: any): value is number =>

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -39,7 +39,7 @@ export const MarketsBanners = () => {
 
   return shouldDisplayPmlBanner ? (
     <$PmlBanner>
-      <img src="/affiliates-hedgie.png" alt="affiliates hedgie" tw="h-8" />
+      <img src="/affiliates-hedgie.png" alt="affiliates hedgie" tw="h-8 mobile:hidden" />
 
       <div tw="mr-auto flex flex-col">
         <span tw="font-medium-medium">

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -72,9 +72,10 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 isUnlaunched,
                 volume24H,
               }) => (
-                <div tw="flex items-center gap-0.25">
+                <div tw="flex max-w-[50vw] items-center gap-0.25 overflow-hidden">
                   <FavoriteButton marketId={id} tw="ml-[-0.5rem]" />
                   <AssetTableCell
+                    tw="overflow-auto"
                     configs={{
                       effectiveInitialMarginFraction,
                       imageUrl,

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -72,7 +72,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 isUnlaunched,
                 volume24H,
               }) => (
-                <div tw="flex items-center gap-0.25 overflow-hidden mobile:max-w-[50vw]">
+                <div tw="flex items-center gap-0.25 mobile:max-w-[50vw] mobile:overflow-hidden">
                   <FavoriteButton marketId={id} tw="ml-[-0.5rem]" />
                   <AssetTableCell
                     tw="overflow-auto"

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -72,7 +72,7 @@ export const MarketsTable = ({ className }: { className?: string }) => {
                 isUnlaunched,
                 volume24H,
               }) => (
-                <div tw="flex max-w-[50vw] items-center gap-0.25 overflow-hidden">
+                <div tw="flex items-center gap-0.25 overflow-hidden mobile:max-w-[50vw]">
                   <FavoriteButton marketId={id} tw="ml-[-0.5rem]" />
                   <AssetTableCell
                     tw="overflow-auto"


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

https://github.com/user-attachments/assets/a7a92325-d8e3-4d49-8b41-ef5b2619ba31

<!-- Overall purpose of the PR -->
- Update tickSizeDecimal calculation when given a reference price
- Fix MarketsTable and MarketsCompactTable
https://linear.app/dydx/issue/BUG2-60/mobile-web-biggest-movers-table-markets-page-clipping
https://linear.app/dydx/issue/BUG2-62/mobile-web-market-list-with-meme-filter-table-overlap-not-viewable

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<MarketsCompactTable>`
  - Remove 3rd column at mobile breakpoint

- `<MarketsBanners>`
  - hide hedgie img at mobile breakpoint

- `<MarketsTable>`
  - overflow on asset name at mobile breakpoint 

## Functions/Clients

- `lib/numbers`, `lib/__test__/numbers.spec.ts`
  - add `getTickSizeFromPrice` helper and add test
  - use to retrieve tickSizeDecimals
 
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
