### PR TITLE
fix(pml): Remove remaining LaunchMarket entrypoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,14 +137,7 @@ const Content = () => {
               </Route>
 
               <Route path={AppRoute.Markets}>
-                {testFlags.pml ? (
-                  <Route
-                    path={MarketsRoute.New}
-                    element={<Navigate to={AppRoute.LaunchMarket} replace />}
-                  />
-                ) : (
-                  <Route path={MarketsRoute.New} element={<NewMarket />} />
-                )}
+                {testFlags.pml ? null : <Route path={MarketsRoute.New} element={<NewMarket />} />}
                 <Route path={AppRoute.Markets} element={<MarketsPage />} />
               </Route>
 

--- a/src/constants/launchableMarkets.ts
+++ b/src/constants/launchableMarkets.ts
@@ -6,4 +6,4 @@ export enum LaunchMarketStatus {
   SUCCESS,
 }
 
-export const ESTIMATED_LAUNCH_TIMEOUT = timeUnits.second * 30;
+export const ESTIMATED_LAUNCH_TIMEOUT = timeUnits.minute;

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -201,16 +201,6 @@ export const NewMarketForm = ({
         <NewMarketSuccessStep2
           transactionUrl={mintscanTxUrl.replace('{tx_hash}', proposalTxHash)}
           tickerToAdd={tickerToAdd}
-          onLaunchAnotherMarket={() => {
-            setTickerToAdd(undefined);
-            setStep(NewMarketFormStep.SELECTION);
-
-            trackLaunchMarketFormStepChange({
-              currentStep: NewMarketFormStep.SUCCESS,
-              updatedStep: NewMarketFormStep.SELECTION,
-              ticker: undefined,
-            });
-          }}
         />
       );
     }

--- a/src/views/forms/NewMarketForm/v7/NewMarketSuccessStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketSuccessStep.tsx
@@ -15,13 +15,11 @@ import { Icon, IconName } from '@/components/Icon';
 import { getDisplayableTickerFromMarket } from '@/lib/assetUtils';
 
 type NewMarketSuccessStepProps = {
-  onLaunchAnotherMarket: () => void;
   tickerToAdd: string;
   transactionUrl: string;
 };
 
 export const NewMarketSuccessStep = ({
-  onLaunchAnotherMarket,
   tickerToAdd,
   transactionUrl,
 }: NewMarketSuccessStepProps) => {
@@ -80,17 +78,6 @@ export const NewMarketSuccessStep = ({
           {stringGetter({ key: STRING_KEYS.VIEW_TRANSACTION })}
           <LinkOutIcon />
         </Button>
-
-        {!isOnMarketTradePage && (
-          <Button
-            type={ButtonType.Button}
-            buttonStyle={ButtonStyle.WithoutBackground}
-            tw="h-fit text-color-text-0"
-            onClick={onLaunchAnotherMarket}
-          >
-            {stringGetter({ key: STRING_KEYS.LAUNCH_ANOTHER_MARKET })}
-          </Button>
-        )}
       </div>
     </$Container>
   );

--- a/src/views/notifications/PermissionlessMarketsLiveNotification.tsx
+++ b/src/views/notifications/PermissionlessMarketsLiveNotification.tsx
@@ -1,8 +1,6 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
-import { AppRoute } from '@/constants/routes';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -34,12 +32,6 @@ export const PermissionlessMarketsLiveNotification = ({
         <div tw="relative flex flex-row">
           <div tw="flex flex-col">
             <span>{stringGetter({ key: STRING_KEYS.INSTANTLY_LAUNCH_BY_DEPOSITING })}</span>
-            <Link
-              tw="mt-0.75 text-color-accent visited:text-color-accent hover:underline"
-              to={AppRoute.LaunchMarket}
-            >
-              {stringGetter({ key: STRING_KEYS.READY_FOR_LAUNCH })} →
-            </Link>
           </div>
           <$SpaceshipImg src="/hedgie-spaceship.png" alt="hedgie-spaceship" />
         </div>


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Remove LaunchMarket entry points entirely.
Update wait time from 30s -> 1m

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<App>`, `<NewMarketSuccessStep>`, `<PermissionlessMarketsLiveNotification>`
  - remove entry point to `AppRoute.LaunchMarket`

## Constants/Types

- `constants/launchableMarkets`
  - 30s delay -> 60s

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
