### PR TITLE
fix(pml-banner): banner on click and filter settled markets

### DIFF
--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -145,6 +145,8 @@ export const useMarketsData = ({
   const markets = useMemo(() => {
     const listOfMarkets = Object.values(allPerpetualMarkets)
       .filter(isTruthy)
+      // filter out markets that cannot be traded
+      .filter((m) => Boolean(m.status?.canTrade))
       // temporarily filter out markets with empty/0 oracle price
       .filter((m) => isTruthy(m.oraclePrice))
       // temporary filterout TRUMPWIN until the backend is working

--- a/src/pages/markets/Markets.tsx
+++ b/src/pages/markets/Markets.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -21,10 +21,12 @@ const Markets = () => {
   const [showHighlights, setShowHighlights] = useState(true);
   useDocumentTitle(stringGetter({ key: STRING_KEYS.MARKETS }));
 
+  const marketsTableRef = useRef<HTMLDivElement>(null);
+
   return (
     <$Page>
       <$HeaderSection>
-        <MarketsBanners />
+        <MarketsBanners marketsTableRef={marketsTableRef} />
         <$Highlights htmlFor="highlights">
           {stringGetter({ key: STRING_KEYS.HIDE })}
 
@@ -34,7 +36,7 @@ const Markets = () => {
         <$MarketsStats showHighlights={showHighlights} />
       </$HeaderSection>
 
-      <$MarketsTable />
+      <$MarketsTable ref={marketsTableRef} />
     </$Page>
   );
 };

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -1,3 +1,5 @@
+import { RefObject } from 'react';
+
 import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
@@ -16,7 +18,6 @@ import { Details } from '@/components/Details';
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { Output, OutputType } from '@/components/Output';
-import { MARKETS_FILTER_ID } from '@/views/MarketFilter';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { setShouldHideLaunchableMarkets } from '@/state/appUiConfigs';
@@ -27,7 +28,11 @@ import { getMarketIds } from '@/state/perpetualsSelectors';
 
 import { testFlags } from '@/lib/testFlags';
 
-export const MarketsBanners = () => {
+export const MarketsBanners = ({
+  marketsTableRef,
+}: {
+  marketsTableRef?: RefObject<HTMLDivElement>;
+}) => {
   const stringGetter = useStringGetter();
   const { data: launchableMarkets } = useLaunchableMarkets();
   const marketIds = useAppSelector(getMarketIds, shallowEqual);
@@ -42,8 +47,8 @@ export const MarketsBanners = () => {
   const onClickPmlBanner = () => {
     dispatch(setShouldHideLaunchableMarkets(false));
     dispatch(setMarketFilter(MarketFilters.LAUNCHABLE));
-    const marketsTable = document.getElementById(MARKETS_FILTER_ID);
-    marketsTable?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    console.log(marketsTableRef?.current);
+    marketsTableRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   const shouldDisplayPmlBanner = testFlags.pml && !hasDismissedPmlBanner;

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
+import { MarketFilters } from '@/constants/markets';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useLaunchableMarkets } from '@/hooks/useLaunchableMarkets';
@@ -15,10 +16,13 @@ import { Details } from '@/components/Details';
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { Output, OutputType } from '@/components/Output';
+import { MARKETS_FILTER_ID } from '@/views/MarketFilter';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { setShouldHideLaunchableMarkets } from '@/state/appUiConfigs';
 import { setHasDismissedPmlBanner } from '@/state/dismissable';
 import { getHasDismissedPmlBanner } from '@/state/dismissableSelectors';
+import { setMarketFilter } from '@/state/perpetuals';
 import { getMarketIds } from '@/state/perpetualsSelectors';
 
 import { testFlags } from '@/lib/testFlags';
@@ -35,10 +39,17 @@ export const MarketsBanners = () => {
     dispatch(setHasDismissedPmlBanner(true));
   };
 
+  const onClickPmlBanner = () => {
+    dispatch(setShouldHideLaunchableMarkets(false));
+    dispatch(setMarketFilter(MarketFilters.LAUNCHABLE));
+    const marketsTable = document.getElementById(MARKETS_FILTER_ID);
+    marketsTable?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   const shouldDisplayPmlBanner = testFlags.pml && !hasDismissedPmlBanner;
 
   return shouldDisplayPmlBanner ? (
-    <$PmlBanner>
+    <$PmlBanner onClick={onClickPmlBanner} role="button" tabIndex={0}>
       <img src="/affiliates-hedgie.png" alt="affiliates hedgie" tw="h-8 mobile:hidden" />
 
       <div tw="mr-auto flex flex-col">

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -47,7 +47,6 @@ export const MarketsBanners = ({
   const onClickPmlBanner = () => {
     dispatch(setShouldHideLaunchableMarkets(false));
     dispatch(setMarketFilter(MarketFilters.LAUNCHABLE));
-    console.log(marketsTableRef?.current);
     marketsTableRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 

--- a/src/views/MarketFilter.tsx
+++ b/src/views/MarketFilter.tsx
@@ -30,6 +30,8 @@ import { setMarketFilter } from '@/state/perpetuals';
 
 import { testFlags } from '@/lib/testFlags';
 
+export const MARKETS_FILTER_ID = 'markets-filter';
+
 type MarketFilterProps = {
   selectedFilter: MarketFilters;
   filters: MarketFilters[];
@@ -131,7 +133,11 @@ export const MarketFilter = ({
   );
 
   return (
-    <$MarketFilter $compactLayout={compactLayout} $uiRefreshEnabled={uiRefresh}>
+    <$MarketFilter
+      id={MARKETS_FILTER_ID}
+      $compactLayout={compactLayout}
+      $uiRefreshEnabled={uiRefresh}
+    >
       <div tw="flex items-center gap-0.5">
         <$SearchInput
           placeholder={stringGetter({ key: searchPlaceholderKey })}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
- Add onClick back to PML banner
- Filter markets by Abacus MarketStatus

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<MarketsBanners>`
  -  Add on click to PmlBanner to set filter and scroll to table

- `<MarketsPage>`
  - Add ref to MarketsTable to help with scroll

- `<MarketFilter>`, `<MarketsTable>`
  - wrap component in forwardRef

## Hooks

- `hooks/useMarketsData`
  - filter out any market that does not have `canTrade`.
  - Markets that have `canReduce` and not `canTrade` will still be accessible through open positions

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
