### PR TITLE
feat: use faq link instead of fuul link

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -94,6 +94,7 @@
          "deployerTermsAndConditions": "",
          "dydxLearnMore": "https://www.mintscan.io/dydx",
          "affiliateProgram": "",
+         "affiliateProgramFaq": "https://help.dydx.trade/en/articles/240149-affiliate-program-faq",
          "launchMarketTos": null,
          "launchMarketLearnMore": null
       },
@@ -138,6 +139,7 @@
          "deployerTermsAndConditions": "",
          "dydxLearnMore": "https://www.mintscan.io/dydx",
          "affiliateProgram": "https://dydx-affiliates.fuul.xyz/",
+         "affiliateProgramFaq": "https://help.dydx.trade/en/articles/240149-affiliate-program-faq",
          "affiliateProgramSupportEmail": "dydx@fuul.xyz",
          "launchMarketTos": null,
          "launchMarketLearnMore": null
@@ -184,6 +186,7 @@
          "deployerTermsAndConditions": "",
          "dydxLearnMore": "https://www.mintscan.io/dydx",
          "affiliateProgram": "https://dydx-affiliates.fuul.xyz/",
+         "affiliateProgramFaq": "https://help.dydx.trade/en/articles/240149-affiliate-program-faq",
          "affiliateProgramSupportEmail": "dydx@fuul.xyz",
          "launchMarketTos": null,
          "launchMarketLearnMore": null
@@ -230,6 +233,7 @@
          "deployerTermsAndConditions": "[HTTP link to terms and conditions, can be null]",
          "dydxLearnMore": "[HTTP link to information about the dYdX blockchain]",
          "affiliateProgram": "[HTTP link to information about the affiliate program]",
+         "affiliateProgramFaq": "[HTTP link to FAQ site about the affiliate program]",
          "affiliateProgramSupportEmail": "[Email address for affiliate program customer support]",
          "launchMarketTos": "[HTTP link to launch market ToS]",
          "launchMarketLearnMore": "[HTTP link to launch market learn more]"

--- a/src/hooks/useURLConfigs.ts
+++ b/src/hooks/useURLConfigs.ts
@@ -47,6 +47,7 @@ export interface LinksConfigs {
   deployerTermsAndConditions?: string;
   dydxLearnMore?: string;
   affiliateProgram?: string;
+  affiliateProgramFaq?: string;
   affiliateProgramSupportEmail?: string;
   launchMarketTos?: string;
   launchMarketLearnMore?: string;
@@ -99,6 +100,7 @@ export const useURLConfigs = (): LinksConfigs => {
     deployerTermsAndConditions: linksConfigs.deployerTermsAndConditions,
     dydxLearnMore: linksConfigs.dydxLearnMore ?? FALLBACK_URL,
     affiliateProgram: linksConfigs.affiliateProgram,
+    affiliateProgramFaq: linksConfigs.affiliateProgramFaq,
     affiliateProgramSupportEmail: linksConfigs.affiliateProgramSupportEmail,
     launchMarketTos: linksConfigs.launchMarketTos ?? FALLBACK_URL,
     launchMarketLearnMore: linksConfigs.launchMarketLearnMore ?? FALLBACK_URL,

--- a/src/pages/portfolio/Overview.tsx
+++ b/src/pages/portfolio/Overview.tsx
@@ -42,7 +42,7 @@ export const Overview = () => {
   const feedbackRequestWalletAddresses = dynamicConfigs[StatsigDynamicConfigs.dcHighestVolumeUsers];
   const shouldShowTelegramInvite =
     dydxAddress && feedbackRequestWalletAddresses?.includes(dydxAddress);
-  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
+  const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates) || true;
   const dismissedAffiliateBanner = useAppSelector(getDismissedAffiliateBanner);
 
   const handleViewUnopenedIsolatedOrders = useCallback(() => {

--- a/src/views/dialogs/ShareAffiliateDialog.tsx
+++ b/src/views/dialogs/ShareAffiliateDialog.tsx
@@ -5,7 +5,6 @@ import {
   AFFILIATES_FEE_DISCOUNT_USD,
   AFFILIATES_REQUIRED_VOLUME_USD,
   DEFAULT_AFFILIATES_EARN_PER_MONTH_USD,
-  DEFAULT_AFFILIATES_VIP_EARN_PER_MONTH_USD,
 } from '@/constants/affiliates';
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { DialogProps, ShareAffiliateDialogProps } from '@/constants/dialogs';
@@ -39,7 +38,7 @@ const copyBlobToClipboard = async (blob: Blob | null) => {
 
 export const ShareAffiliateDialog = ({ setIsOpen }: DialogProps<ShareAffiliateDialogProps>) => {
   const stringGetter = useStringGetter();
-  const { affiliateProgram } = useURLConfigs();
+  const { affiliateProgramFaq, affiliateProgram } = useURLConfigs();
   const { dydxAddress } = useAccounts();
   const {
     affiliateMetadataQuery: { data },
@@ -47,7 +46,6 @@ export const ShareAffiliateDialog = ({ setIsOpen }: DialogProps<ShareAffiliateDi
   } = useAffiliatesInfo(dydxAddress);
 
   const maxEarning = maxEarningData?.maxEarning;
-  const maxVipEarning = maxEarningData?.maxVipEarning;
 
   const [{ isLoading: isCopying }, , ref] = useToBlob<HTMLDivElement>({
     quality: 1.0,
@@ -74,27 +72,28 @@ export const ShareAffiliateDialog = ({ setIsOpen }: DialogProps<ShareAffiliateDi
   const affiliatesUrl =
     data?.metadata?.referralCode && `${window.location.host}?ref=${data.metadata.referralCode}`;
 
+  const dialogDescription = (
+    <span>
+      {stringGetter({
+        key: STRING_KEYS.EARN_FOR_EACH_TRADER,
+        params: {
+          AMOUNT_USD:
+            maxEarning?.toLocaleString() ?? DEFAULT_AFFILIATES_EARN_PER_MONTH_USD.toLocaleString(),
+        },
+      })}
+      .{' '}
+      <Link href={affiliateProgramFaq} isInline>
+        {stringGetter({ key: STRING_KEYS.LEARN_MORE })} →
+      </Link>
+    </span>
+  );
+
   return (
     <Dialog
       isOpen
       setIsOpen={setIsOpen}
       title={stringGetter({ key: STRING_KEYS.INVITE_FRIENDS })}
-      description={stringGetter({
-        key: STRING_KEYS.EARN_FOR_EACH_TRADER_REFER_FOR_DISCOUNTS,
-        params: {
-          AMOUNT_DISCOUNT: AFFILIATES_FEE_DISCOUNT_USD.toLocaleString(),
-          VIP_AMOUNT_USD:
-            maxVipEarning?.toLocaleString() ??
-            DEFAULT_AFFILIATES_VIP_EARN_PER_MONTH_USD.toLocaleString(),
-          AMOUNT_PER_MONTH:
-            maxEarning?.toLocaleString() ?? DEFAULT_AFFILIATES_EARN_PER_MONTH_USD.toLocaleString(),
-          LEARN_MORE_LINK: (
-            <Link href={affiliateProgram} isInline>
-              {stringGetter({ key: STRING_KEYS.LEARN_MORE })} →
-            </Link>
-          ),
-        },
-      })}
+      description={dialogDescription}
     >
       {!dydxAddress && (
         <OnboardingTriggerButton
@@ -142,7 +141,7 @@ export const ShareAffiliateDialog = ({ setIsOpen }: DialogProps<ShareAffiliateDi
               </CopyButton>
             )}
           </div>
-          {affiliatesUrl && (
+          {data?.isEligible && affiliatesUrl && (
             <div
               ref={(domNode) => {
                 if (domNode) {


### PR DESCRIPTION
Updates the affiliate share dialog to (1) update copy text to be simpler and (2) Learn more link should go to an FAQ page about the general affiliates program and not just the VIP affiliates program

<img width="641" alt="image" src="https://github.com/user-attachments/assets/599eb484-bd73-4021-83da-378d0a404fac">

POV Not eligible:

<img width="582" alt="image" src="https://github.com/user-attachments/assets/5d4cc490-d503-42a5-ac7d-2c2f93678595">
