### PR TITLE
feat(spot-volume): show spot-volume and market cap

### DIFF
--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -30,6 +30,8 @@ export type MarketData = {
   tickSizeDecimals?: Nullable<number>;
   trades24H?: Nullable<number>;
   volume24H?: Nullable<number>;
+  spotVolume24H?: Nullable<number>;
+  marketCap?: Nullable<number>;
   tags?: Nullable<string[]>;
   isFavorite: boolean;
 };

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -22,7 +22,7 @@ import { getTvChartConfig } from '@/state/tradingViewSelectors';
 import { getLaunchableMarketDatafeed } from '@/lib/tradingView/launchableMarketFeed';
 import { getSavedResolution, getWidgetOptions, getWidgetOverrides } from '@/lib/tradingView/utils';
 
-import { useMetadataService } from '../useLaunchableMarkets';
+import { useMetadataService } from '../useMetadataService';
 
 /**
  * @description Hook to initialize TradingView Chart

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -19,6 +19,16 @@ import { useDydxClient } from './useDydxClient';
 
 const ASSETS_TO_REMOVE = ['USDC', 'USDT'];
 
+export const useMarketMapPriceData = () => {
+  return useQuery({
+    queryKey: ['marketMapPrice'],
+    queryFn: async (): Promise<MetadataServicePricesResponse> => {
+      return metadataClient.getAssetPrices();
+    },
+    refetchInterval: timeUnits.minute * 5,
+  });
+};
+
 export const useMetadataService = () => {
   const metadataQuery = useQueries({
     queries: [

--- a/src/hooks/useLaunchableMarkets.ts
+++ b/src/hooks/useLaunchableMarkets.ts
@@ -1,127 +1,10 @@
 import { useMemo } from 'react';
 
-import { useQueries, useQuery } from '@tanstack/react-query';
-
-import {
-  MetadataServiceAsset,
-  MetadataServiceCandlesTimeframes,
-  MetadataServiceInfoResponse,
-  MetadataServicePricesResponse,
-} from '@/constants/assetMetadata';
-import { timeUnits } from '@/constants/time';
-
-import metadataClient from '@/clients/metadataService';
-import { getAssetFromMarketId } from '@/lib/assetUtils';
-import { getTickSizeDecimalsFromPrice } from '@/lib/numbers';
-import { mapMetadataServiceCandles } from '@/lib/tradingView/utils';
-
-import { useDydxClient } from './useDydxClient';
-
-const ASSETS_TO_REMOVE = ['USDC', 'USDT'];
-
-export const useMarketMapPriceData = () => {
-  return useQuery({
-    queryKey: ['marketMapPrice'],
-    queryFn: async (): Promise<MetadataServicePricesResponse> => {
-      return metadataClient.getAssetPrices();
-    },
-    refetchInterval: timeUnits.minute * 5,
-  });
-};
-
-export const useMetadataService = () => {
-  const metadataQuery = useQueries({
-    queries: [
-      {
-        queryKey: ['marketMapInfo'],
-        queryFn: async (): Promise<MetadataServiceInfoResponse> => {
-          return metadataClient.getAssetInfo();
-        },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-      },
-      {
-        queryKey: ['marketMapPrice'],
-        queryFn: async (): Promise<MetadataServicePricesResponse> => {
-          return metadataClient.getAssetPrices();
-        },
-        refetchInterval: timeUnits.minute * 5,
-      },
-    ],
-    combine: (results) => {
-      const info = results[0].data;
-      const prices = results[1].data;
-      const data: Record<string, MetadataServiceAsset> = {};
-
-      Object.keys(info ?? {}).forEach((key) => {
-        const infoKey = info?.[key];
-        const pricesKey = prices?.[key];
-
-        if (infoKey && pricesKey && !ASSETS_TO_REMOVE.includes(key)) {
-          const tickSizeDecimals = getTickSizeDecimalsFromPrice(pricesKey.price);
-
-          data[key] = {
-            id: key,
-            name: infoKey.name,
-            logo: infoKey.logo,
-            urls: {
-              website: infoKey.urls.website,
-              technicalDoc: infoKey.urls.technical_doc,
-              cmc: infoKey.urls.cmc,
-            },
-            sectorTags: infoKey.sector_tags,
-            exchanges: infoKey.exchanges,
-            price: pricesKey.price,
-            percentChange24h: pricesKey.percent_change_24h,
-            marketCap: pricesKey.market_cap,
-            volume24h: pricesKey.volume_24h,
-            reportedMarketCap: pricesKey.self_reported_market_cap,
-            tickSizeDecimals,
-          };
-        }
-      });
-
-      return {
-        data,
-        isLoading: results.some((result) => result.isLoading),
-        isError: results.some((result) => result.isError),
-        isSuccess: results.every((result) => result.isSuccess),
-      };
-    },
-  });
-
-  return metadataQuery;
-};
-
-export const useMetadataServiceAssetFromId = (marketId?: string) => {
-  const metadataServiceData = useMetadataService();
-
-  const launchableAsset = useMemo(() => {
-    if (!metadataServiceData.data || !marketId) {
-      return null;
-    }
-
-    const assetId = getAssetFromMarketId(marketId);
-    return metadataServiceData.data[assetId];
-  }, [metadataServiceData.data, marketId]);
-
-  return launchableAsset;
-};
+import { useMetadataService } from './useMetadataService';
+import { usePerpetualMarkets } from './userPerpetualMarkets';
 
 export const useLaunchableMarkets = () => {
-  const { requestAllPerpetualMarkets } = useDydxClient();
-
-  const perpetualMarketsFetch = useQuery({
-    queryKey: ['requestAllPerpetualMarkets'],
-    queryFn: requestAllPerpetualMarkets,
-    refetchInterval: timeUnits.minute,
-    staleTime: timeUnits.minute,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-  });
-
+  const perpetualMarketsFetch = usePerpetualMarkets();
   const metadataServiceData = useMetadataService();
 
   const filteredPotentialMarkets: { id: string; asset: string }[] = useMemo(() => {
@@ -140,26 +23,5 @@ export const useLaunchableMarkets = () => {
   return {
     ...metadataServiceData,
     data: filteredPotentialMarkets,
-  };
-};
-
-export const useMetadataServiceCandles = (
-  asset?: string,
-  timeframe?: MetadataServiceCandlesTimeframes
-) => {
-  const candlesQuery = useQuery({
-    enabled: !!asset && !!timeframe,
-    queryKey: ['candles', asset, timeframe],
-    queryFn: async () => {
-      return metadataClient.getCandles({ asset: asset!, timeframe: timeframe! });
-    },
-    refetchInterval: timeUnits.minute * 5,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-  });
-
-  return {
-    ...candlesQuery,
-    data: candlesQuery.data?.[asset ?? '']?.map(mapMetadataServiceCandles),
   };
 };

--- a/src/hooks/useMarketsData.ts
+++ b/src/hooks/useMarketsData.ts
@@ -30,7 +30,7 @@ import { matchesSearchFilter } from '@/lib/search';
 import { testFlags } from '@/lib/testFlags';
 import { orEmptyObj, orEmptyRecord } from '@/lib/typeUtils';
 
-import { useMarketMapPriceData, useMetadataService } from './useLaunchableMarkets';
+import { useMetadataService } from './useMetadataService';
 import { useAllStatsigGateValues } from './useStatsig';
 
 const filterFunctions = {
@@ -136,12 +136,11 @@ export const useMarketsData = ({
   const allAssets = orEmptyRecord(useAppSelector(getAssets, shallowEqual));
   const sevenDaysSparklineData = usePerpetualMarketSparklines();
   const featureFlags = useAllStatsigGateValues();
-  const unlaunchedMarkets = useMetadataService();
+  const metadataServiceInfo = useMetadataService();
   const shouldHideLaunchableMarkets =
     useAppSelector(getShouldHideLaunchableMarkets) || hideUnlaunchedMarkets;
   const favoritedMarkets = useAppSelector(getFavoritedMarkets, shallowEqual);
   const hasMarketIds = Object.keys(allPerpetualMarkets).length > 0;
-  const metadataPriceInfo = useMarketMapPriceData();
 
   const allPerpetualMarketIdsSet = new Set(
     Object.values(allPerpetualMarkets)
@@ -167,10 +166,10 @@ export const useMarketsData = ({
         );
         const clobPairId = allPerpetualClobIds[marketData.id] ?? 0;
         const {
-          volume_24h: spotVolume24H,
-          market_cap: marketCap,
-          self_reported_market_cap: reportedMarketCap,
-        } = orEmptyObj(metadataPriceInfo.data?.[marketData.assetId]);
+          volume24h: spotVolume24H,
+          marketCap,
+          reportedMarketCap,
+        } = orEmptyObj(metadataServiceInfo.data[marketData.assetId]);
 
         const {
           assetId,
@@ -220,7 +219,7 @@ export const useMarketsData = ({
       });
 
     if (!shouldHideLaunchableMarkets && testFlags.pml) {
-      const unlaunchedMarketsData = Object.values(unlaunchedMarkets.data)
+      const unlaunchedMarketsData = Object.values(metadataServiceInfo.data)
         .sort(sortByMarketCap)
         .map((market) => {
           const {
@@ -285,9 +284,8 @@ export const useMarketsData = ({
     sevenDaysSparklineData,
     allPerpetualClobIds,
     allAssets,
-    unlaunchedMarkets.data,
+    metadataServiceInfo.data,
     favoritedMarkets,
-    metadataPriceInfo.data,
   ]);
 
   const filteredMarkets = useMemo(() => {

--- a/src/hooks/useMetadataService.ts
+++ b/src/hooks/useMetadataService.ts
@@ -105,15 +105,13 @@ export const useMetadataServiceCandles = (
     enabled: !!asset && !!timeframe,
     queryKey: ['candles', asset, timeframe],
     queryFn: async () => {
-      return metadataClient.getCandles({ asset: asset!, timeframe: timeframe! });
+      const candles = await metadataClient.getCandles({ asset: asset!, timeframe: timeframe! });
+      return candles[asset ?? '']?.map(mapMetadataServiceCandles);
     },
     refetchInterval: timeUnits.minute * 5,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
 
-  return {
-    ...candlesQuery,
-    data: candlesQuery.data?.[asset ?? '']?.map(mapMetadataServiceCandles),
-  };
+  return candlesQuery;
 };

--- a/src/hooks/useMetadataService.ts
+++ b/src/hooks/useMetadataService.ts
@@ -1,0 +1,119 @@
+import { useMemo } from 'react';
+
+import { useQueries, useQuery } from '@tanstack/react-query';
+
+import {
+  MetadataServiceAsset,
+  MetadataServiceCandlesTimeframes,
+  MetadataServiceInfoResponse,
+  MetadataServicePricesResponse,
+} from '@/constants/assetMetadata';
+import { timeUnits } from '@/constants/time';
+
+import metadataClient from '@/clients/metadataService';
+import { getAssetFromMarketId } from '@/lib/assetUtils';
+import { getTickSizeDecimalsFromPrice } from '@/lib/numbers';
+import { mapMetadataServiceCandles } from '@/lib/tradingView/utils';
+
+const ASSETS_TO_REMOVE = ['USDC', 'USDT'];
+
+export const useMetadataService = () => {
+  const metadataQuery = useQueries({
+    queries: [
+      {
+        queryKey: ['marketMapInfo'],
+        queryFn: async (): Promise<MetadataServiceInfoResponse> => {
+          return metadataClient.getAssetInfo();
+        },
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      },
+      {
+        queryKey: ['marketMapPrice'],
+        queryFn: async (): Promise<MetadataServicePricesResponse> => {
+          return metadataClient.getAssetPrices();
+        },
+        refetchInterval: timeUnits.minute * 5,
+      },
+    ],
+    combine: (results) => {
+      const info = results[0].data;
+      const prices = results[1].data;
+      const data: Record<string, MetadataServiceAsset> = {};
+
+      Object.keys(info ?? {}).forEach((key) => {
+        const infoKey = info?.[key];
+        const pricesKey = prices?.[key];
+
+        if (infoKey && pricesKey && !ASSETS_TO_REMOVE.includes(key)) {
+          const tickSizeDecimals = getTickSizeDecimalsFromPrice(pricesKey.price);
+
+          data[key] = {
+            id: key,
+            name: infoKey.name,
+            logo: infoKey.logo,
+            urls: {
+              website: infoKey.urls.website,
+              technicalDoc: infoKey.urls.technical_doc,
+              cmc: infoKey.urls.cmc,
+            },
+            sectorTags: infoKey.sector_tags,
+            exchanges: infoKey.exchanges,
+            price: pricesKey.price,
+            percentChange24h: pricesKey.percent_change_24h,
+            marketCap: pricesKey.market_cap,
+            volume24h: pricesKey.volume_24h,
+            reportedMarketCap: pricesKey.self_reported_market_cap,
+            tickSizeDecimals,
+          };
+        }
+      });
+
+      return {
+        data,
+        isLoading: results.some((result) => result.isLoading),
+        isError: results.some((result) => result.isError),
+        isSuccess: results.every((result) => result.isSuccess),
+      };
+    },
+  });
+
+  return metadataQuery;
+};
+
+export const useMetadataServiceAssetFromId = (marketId?: string) => {
+  const metadataServiceData = useMetadataService();
+
+  const launchableAsset = useMemo(() => {
+    if (!metadataServiceData.data || !marketId) {
+      return null;
+    }
+
+    const assetId = getAssetFromMarketId(marketId);
+    return metadataServiceData.data[assetId];
+  }, [metadataServiceData.data, marketId]);
+
+  return launchableAsset;
+};
+
+export const useMetadataServiceCandles = (
+  asset?: string,
+  timeframe?: MetadataServiceCandlesTimeframes
+) => {
+  const candlesQuery = useQuery({
+    enabled: !!asset && !!timeframe,
+    queryKey: ['candles', asset, timeframe],
+    queryFn: async () => {
+      return metadataClient.getCandles({ asset: asset!, timeframe: timeframe! });
+    },
+    refetchInterval: timeUnits.minute * 5,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    ...candlesQuery,
+    data: candlesQuery.data?.[asset ?? '']?.map(mapMetadataServiceCandles),
+  };
+};

--- a/src/hooks/userPerpetualMarkets.ts
+++ b/src/hooks/userPerpetualMarkets.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { timeUnits } from '@/constants/time';
+
+import { useDydxClient } from './useDydxClient';
+
+export const usePerpetualMarkets = () => {
+  const { requestAllPerpetualMarkets } = useDydxClient();
+
+  const perpetualMarketsFetch = useQuery({
+    queryKey: ['requestAllPerpetualMarkets'],
+    queryFn: requestAllPerpetualMarkets,
+    refetchInterval: timeUnits.minute,
+    staleTime: timeUnits.minute,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return perpetualMarketsFetch;
+};

--- a/src/pages/trade/TradeHeaderMobile.tsx
+++ b/src/pages/trade/TradeHeaderMobile.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { AppRoute } from '@/constants/routes';
 
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -44,7 +44,7 @@
 
   /* Market Selector constants */
   --marketsDropdown-openWidth-deprecated: 45rem;
-  --marketsDropdown-openWidth: 40rem;
+  --marketsDropdown-openWidth: 50rem;
 
   /* Form constants */
   --form-input-gap: 0.625rem;

--- a/src/views/LaunchableMarketStatsDetails.tsx
+++ b/src/views/LaunchableMarketStatsDetails.tsx
@@ -8,7 +8,7 @@ import { USD_DECIMALS } from '@/constants/numbers';
 import { TooltipStringKeys } from '@/constants/tooltips';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import breakpoints from '@/styles/breakpoints';

--- a/src/views/MarketDetails/LaunchableMarketDetails.tsx
+++ b/src/views/MarketDetails/LaunchableMarketDetails.tsx
@@ -2,7 +2,7 @@ import { STRING_KEYS } from '@/constants/localization';
 import { ISOLATED_LIQUIDITY_TIER_INFO } from '@/constants/markets';
 import { TooltipStringKeys } from '@/constants/tooltips';
 
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { DetailsItem } from '@/components/Details';

--- a/src/views/MarketLinks.tsx
+++ b/src/views/MarketLinks.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonType } from '@/constants/buttons';
 
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 
 import { IconName } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -150,6 +150,22 @@ const MarketsDropdownContent = ({
             <$Output type={OutputType.CompactFiat} value={row.volume24H} />
           ),
         },
+        {
+          columnKey: 'spotVolume24H',
+          getCellValue: (row: MarketData) => row.spotVolume24H,
+          label: stringGetter({ key: STRING_KEYS.SPOT_VOLUME_24H }),
+          renderCell: (row: MarketData) => (
+            <$Output type={OutputType.CompactFiat} value={row.spotVolume24H} />
+          ),
+        },
+        {
+          columnKey: 'marketCap',
+          getCellValue: (row: MarketData) => row.marketCap,
+          label: stringGetter({ key: STRING_KEYS.MARKET_CAP }),
+          renderCell: (row: MarketData) => (
+            <$Output type={OutputType.CompactFiat} value={row.marketCap} />
+          ),
+        },
         !uiRefresh && {
           columnKey: 'openInterest',
           getCellValue: (row: MarketData) => row.openInterestUSDC,

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -11,9 +11,9 @@ import { MarketFilters, PREDICTION_MARKET, type MarketData } from '@/constants/m
 import { AppRoute, MarketsRoute } from '@/constants/routes';
 import { StatsigFlags } from '@/constants/statsig';
 
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useMarketsData } from '@/hooks/useMarketsData';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 import { useParameterizedSelector } from '@/hooks/useParameterizedSelector';
 import { usePotentialMarkets } from '@/hooks/usePotentialMarkets';
 import { useAllStatsigGateValues } from '@/hooks/useStatsig';

--- a/src/views/charts/LaunchableMarketChart.tsx
+++ b/src/views/charts/LaunchableMarketChart.tsx
@@ -17,7 +17,7 @@ import { TooltipStringKeys } from '@/constants/tooltips';
 import {
   useMetadataServiceAssetFromId,
   useMetadataServiceCandles,
-} from '@/hooks/useLaunchableMarkets';
+} from '@/hooks/useMetadataService';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { LinkOutIcon } from '@/icons';

--- a/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
+++ b/src/views/forms/NewMarketForm/v7/NewMarketPreviewStep.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH } from '@/constants/numbers';
 import { timeUnits } from '@/constants/time';
 
 import { useCustomNotification } from '@/hooks/useCustomNotification';
-import { useMetadataServiceAssetFromId } from '@/hooks/useLaunchableMarkets';
+import { useMetadataServiceAssetFromId } from '@/hooks/useMetadataService';
 import { useNow } from '@/hooks/useNow';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useSubaccount } from '@/hooks/useSubaccount';

--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -225,6 +225,22 @@ export const MarketsTable = forwardRef(
                 ),
               },
               {
+                columnKey: 'spotVolume24H',
+                getCellValue: (row) => row.spotVolume24H,
+                label: stringGetter({ key: STRING_KEYS.SPOT_VOLUME_24H }),
+                renderCell: (row) => (
+                  <$NumberOutput type={OutputType.CompactFiat} value={row.spotVolume24H} />
+                ),
+              },
+              {
+                columnKey: 'market-cap',
+                getCellValue: (row) => row.marketCap,
+                label: stringGetter({ key: STRING_KEYS.MARKET_CAP }),
+                renderCell: (row) => (
+                  <$NumberOutput type={OutputType.CompactFiat} value={row.marketCap} />
+                ),
+              },
+              {
                 columnKey: 'trades24H',
                 getCellValue: (row) => row.trades24H,
                 label: stringGetter({ key: STRING_KEYS.TRADES }),


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="1092" alt="Screen Shot 2024-11-21 at 10 21 16 AM" src="https://github.com/user-attachments/assets/78b4b203-7f36-42dc-9638-a88ce8806e1d">

<img width="800" alt="Screen Shot 2024-11-21 at 10 21 43 AM" src="https://github.com/user-attachments/assets/6d647e43-30fb-47fe-a257-a5e8b3ba6885">

<!-- Overall purpose of the PR -->

Display spot volume and market cap within markets table and market dropdown.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<MarketDropdown>`, `<MarketsTable>`
  - add new columns

## Styles/Mixins

- `styles/constants.css`
  - Give MarketDropdown additional horizontal space

## Constants/Types

- `constants/markets`
  - add `spotVolume24H` and `marketCap`

## Hooks

- new `hooks/useMetadataService`
  - move all metadataService queries to new file

- `hooks/useLaunchableMarkets`
  - import `metadataService` queries

- `hooks/useMarketsData`
  - add spotVolume24H and marketCap to Market object 

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
