### PR TITLE
fix: re-introduce governance variables

### DIFF
--- a/public/configs/v1/env.json
+++ b/public/configs/v1/env.json
@@ -295,6 +295,29 @@
          "signTypedDataDomainName": "dYdX Chain"
       }
    },
+   "governance": {
+      "dydxprotocol-testnet": {
+         "newMarketProposal": {
+            "initialDepositAmount": 10000000,
+            "delayBlocks": 60,
+            "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
+         }
+      },
+      "dydx-testnet-4": {
+         "newMarketProposal": {
+            "initialDepositAmount": 10000000,
+            "delayBlocks": 60,
+            "newMarketsMethodology": "https://docs.google.com/spreadsheets/d/1zjkV9R7R_7KMItuzqzvKGwefSBRfE-ZNAx1LH55OcqY/edit?usp=sharing"
+         }
+      },
+      "[mainnet chain id]": {
+         "newMarketProposal": {
+            "initialDepositAmount": 0,
+            "delayBlocks": 0,
+            "newMarketsMethodology": "[URL to spreadsheet or document that explains methodology]"
+         }
+      }
+   },
    "deployments": {
       "MAINNET": {
          "environments": [

--- a/src/views/tables/FillsTable.tsx
+++ b/src/views/tables/FillsTable.tsx
@@ -347,15 +347,18 @@ type StyleProps = {
 };
 
 export const FillsTable = forwardRef(
-  ({
-    columnKeys,
-    columnWidths,
-    currentMarket,
-    initialPageSize,
-    withGradientCardRows,
-    withOuterBorder,
-    withInnerBorders = true,
-  }: ElementProps & StyleProps) => {
+  (
+    {
+      columnKeys,
+      columnWidths,
+      currentMarket,
+      initialPageSize,
+      withGradientCardRows,
+      withOuterBorder,
+      withInnerBorders = true,
+    }: ElementProps & StyleProps,
+    _ref
+  ) => {
     const stringGetter = useStringGetter();
     const dispatch = useAppDispatch();
     const { isMobile } = useBreakpoints();

--- a/src/views/tables/OrdersTable.tsx
+++ b/src/views/tables/OrdersTable.tsx
@@ -405,14 +405,17 @@ type StyleProps = {
 };
 
 export const OrdersTable = forwardRef(
-  ({
-    columnKeys = [],
-    columnWidths,
-    currentMarket,
-    marketTypeFilter,
-    initialPageSize,
-    withOuterBorder,
-  }: ElementProps & StyleProps) => {
+  (
+    {
+      columnKeys = [],
+      columnWidths,
+      currentMarket,
+      marketTypeFilter,
+      initialPageSize,
+      withOuterBorder,
+    }: ElementProps & StyleProps,
+    _ref
+  ) => {
     const stringGetter = useStringGetter();
     const dispatch = useAppDispatch();
     const { isTablet } = useBreakpoints();

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -533,19 +533,22 @@ type StyleProps = {
 };
 
 export const PositionsTable = forwardRef(
-  ({
-    columnKeys,
-    columnWidths,
-    currentRoute,
-    currentMarket,
-    marketTypeFilter,
-    showClosePositionAction,
-    initialPageSize,
-    onNavigate,
-    navigateToOrders,
-    withGradientCardRows,
-    withOuterBorder,
-  }: ElementProps & StyleProps) => {
+  (
+    {
+      columnKeys,
+      columnWidths,
+      currentRoute,
+      currentMarket,
+      marketTypeFilter,
+      showClosePositionAction,
+      initialPageSize,
+      onNavigate,
+      navigateToOrders,
+      withGradientCardRows,
+      withOuterBorder,
+    }: ElementProps & StyleProps,
+    _ref
+  ) => {
     const stringGetter = useStringGetter();
     const navigate = useNavigate();
     const { isSlTpLimitOrdersEnabled } = useEnvFeatures();


### PR DESCRIPTION
Quiet ref errors in Table components and re-introduce Governance variables.

- Due to Abacus w/ StaticTyping
  - Any removal of fields within env.json will also need a prerequisite Abacus change so there are no serialization errors
  - Need to figure out why Abacus swallows these errors