### PR TITLE
feat: more sane loading states for affiliate page

### DIFF
--- a/src/hooks/useAffiliatesInfo.ts
+++ b/src/hooks/useAffiliatesInfo.ts
@@ -7,6 +7,7 @@ import {
   MAX_AFFILIATE_VIP_SHARE,
   REF_SHARE_VOLUME_CAP_USD,
 } from '@/constants/affiliates';
+import { timeUnits } from '@/constants/time';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getFeeTiers } from '@/state/configsSelectors';
@@ -32,6 +33,7 @@ export const useAffiliatesInfo = (dydxAddress?: string) => {
     if (!compositeClient || !dydxAddress) {
       return {};
     }
+
     const metadataEndpoint = `${compositeClient.indexerClient.config.restEndpoint}/v4/affiliates/metadata`;
     const totalVolumeEndpoint = `${compositeClient.indexerClient.config.restEndpoint}/v4/affiliates/total_volume`;
 
@@ -89,12 +91,14 @@ export const useAffiliatesInfo = (dydxAddress?: string) => {
     queryKey: ['affiliateMetadata', dydxAddress],
     queryFn: fetchAffiliateMetadata,
     enabled: Boolean(compositeClient && dydxAddress && affiliatesBaseUrl),
+    staleTime: 5 * timeUnits.minute,
   });
 
   const affiliateStatsQuery = useQuery({
     queryKey: ['accountStats', dydxAddress],
     queryFn: fetchAccountStats,
     enabled: Boolean(compositeClient && dydxAddress),
+    staleTime: 5 * timeUnits.minute,
   });
 
   const fetchAffiliateMaxEarning = async () => {
@@ -114,6 +118,7 @@ export const useAffiliatesInfo = (dydxAddress?: string) => {
     queryKey: ['affiliateMaxEarning', feeTiers],
     queryFn: fetchAffiliateMaxEarning,
     enabled: Boolean(compositeClient && feeTiers && affiliatesBaseUrl),
+    staleTime: Infinity,
   });
 
   return {

--- a/src/hooks/useAffiliatesLeaderboard.ts
+++ b/src/hooks/useAffiliatesLeaderboard.ts
@@ -1,8 +1,6 @@
-import { useMemo } from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 
-import { IAffiliateLeaderboardStats, IAffiliateStats } from '@/constants/affiliates';
+import { IAffiliateStats } from '@/constants/affiliates';
 
 import { log } from '@/lib/telemetry';
 
@@ -27,29 +25,22 @@ export const useAffiliatesLeaderboard = () => {
       });
 
       const data = await response.json();
-      return data?.affiliateList;
+      return data?.affiliateList?.map((stat: IAffiliateStats, i: number) => ({
+        ...stat,
+        rank: i + 1,
+      }));
     } catch (error) {
       log('useAffiliateLeaderboard', error, { endpoint });
       throw error;
     }
   };
 
-  const affiliatesLeaderboardQuery = useQuery({
+  return useQuery({
     queryKey: ['affiliatesLeaderboard'],
     queryFn: fetchAffiliateStats,
     enabled: Boolean(compositeClient),
     refetchOnMount: false,
+    staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
-
-  const affiliates: IAffiliateLeaderboardStats[] | undefined = useMemo(
-    () =>
-      affiliatesLeaderboardQuery.data?.map((stat: IAffiliateStats, i: number) => ({
-        ...stat,
-        rank: i + 1,
-      })),
-    [affiliatesLeaderboardQuery.data]
-  );
-
-  return { affiliates };
 };

--- a/src/pages/affiliates/AffiliatesPage.tsx
+++ b/src/pages/affiliates/AffiliatesPage.tsx
@@ -67,7 +67,7 @@ export const AffiliatesPage = () => {
                 />
               )}
 
-              <ProgramStatusCard tw="w-full notTablet:w-4/12" isVip={!!userStatus.isVip} />
+              <ProgramStatusCard isVip={!!userStatus.isVip} />
             </section>
           </>
         )}

--- a/src/views/Affiliates/AffiliatesLeaderboard.tsx
+++ b/src/views/Affiliates/AffiliatesLeaderboard.tsx
@@ -82,7 +82,7 @@ export const AffiliatesLeaderboard = ({ accountStats }: IAffiliatesLeaderboardPr
   const stringGetter = useStringGetter();
   const affiliatesFilters = Object.values(AffiliateEpochsFilter);
   const [epochFilter, setEpochFilter] = useState<AffiliateEpochsFilter>(AffiliateEpochsFilter.ALL);
-  const { affiliates } = useAffiliatesLeaderboard();
+  const { data: affiliates } = useAffiliatesLeaderboard();
 
   const columns: ColumnDef<IAffiliateLeaderboardStats>[] = isTablet
     ? [
@@ -217,7 +217,6 @@ export const AffiliatesLeaderboard = ({ accountStats }: IAffiliatesLeaderboardPr
           filters={affiliatesFilters}
           onChangeFilter={setFilter}
         />
-
         <$Table
           withInnerBorders
           data={affiliates ?? EMPTY_ARR}

--- a/src/views/Affiliates/ShareAffiliateBanner.tsx
+++ b/src/views/Affiliates/ShareAffiliateBanner.tsx
@@ -17,7 +17,7 @@ export const ShareAffiliateBanner = ({ totalVolume }: IShareAffiliateBannerProps
   const stringGetter = useStringGetter();
 
   return (
-    <$Container tw="column gap-1">
+    <$Container tw="column flex-1 gap-1">
       <div tw="text-medium text-color-text-1">
         {stringGetter({
           key: STRING_KEYS.SHARE_AFFILIATE_BANNER_TITLE,

--- a/src/views/Affiliates/ShareAffiliateBanner.tsx
+++ b/src/views/Affiliates/ShareAffiliateBanner.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import tw from 'twin.macro';
 
 import {
   AFFILIATES_REQUIRED_VOLUME_USD,
@@ -17,7 +16,7 @@ export const ShareAffiliateBanner = ({ totalVolume }: IShareAffiliateBannerProps
   const stringGetter = useStringGetter();
 
   return (
-    <$Container tw="column flex-1 gap-1">
+    <div tw="column flex-1 gap-1 rounded-0.625 bg-color-layer-3 p-1">
       <div tw="text-medium text-color-text-1">
         {stringGetter({
           key: STRING_KEYS.SHARE_AFFILIATE_BANNER_TITLE,
@@ -64,11 +63,10 @@ export const ShareAffiliateBanner = ({ totalVolume }: IShareAffiliateBannerProps
           </div>
         </div>
       </$Requirements>
-    </$Container>
+    </div>
   );
 };
 
-const $Container = tw.div`rounded-0.625 bg-color-layer-3 p-1`;
 const $Requirements = styled.div`
   border: var(--border-width) solid var(--border-color);
 `;

--- a/src/views/Affiliates/cards/AffiliateStatsCard.tsx
+++ b/src/views/Affiliates/cards/AffiliateStatsCard.tsx
@@ -1,7 +1,6 @@
 import { useRef } from 'react';
 
 import styled from 'styled-components';
-import tw from 'twin.macro';
 
 import { IAffiliateStats } from '@/constants/affiliates';
 import { DialogTypes } from '@/constants/dialogs';
@@ -176,7 +175,6 @@ const DesktopView = ({
 };
 
 interface IAffiliateStatsProps {
-  className?: string;
   accountStats?: IAffiliateStats;
   isVip: boolean;
   currentAffiliateTier?: number;
@@ -184,7 +182,6 @@ interface IAffiliateStatsProps {
 }
 
 export const AffiliateStatsCard = ({
-  className,
   accountStats,
   isVip,
   stakedDydx,
@@ -206,7 +203,7 @@ export const AffiliateStatsCard = ({
   };
 
   return (
-    <$Container className={className}>
+    <div tw="flex-1 rounded-0.625 bg-color-layer-3">
       {isNotTablet ? (
         <DesktopView
           accountStats={accountStats}
@@ -222,12 +219,10 @@ export const AffiliateStatsCard = ({
           toggleCriteria={toggleCriteria}
         />
       )}
-    </$Container>
+    </div>
   );
 };
 
 const MobileStatsHeader = styled.div`
   border-bottom: 1px solid var(--color-border);
 `;
-
-const $Container = tw.div`rounded-0.625 bg-color-layer-3`;

--- a/src/views/Affiliates/cards/ProgramStatusCard.tsx
+++ b/src/views/Affiliates/cards/ProgramStatusCard.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 import styled from 'styled-components';
-import tw from 'twin.macro';
 
 import { DEFAULT_AFFILIATES_VIP_EARN_PER_MONTH_USD } from '@/constants/affiliates';
 import { ButtonAction, ButtonType } from '@/constants/buttons';
@@ -16,11 +15,10 @@ import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
 
 interface IProgramCardProps {
-  className?: string;
   isVip: boolean;
 }
 
-export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProps) => {
+export const ProgramStatusCard = ({ isVip = false }: IProgramCardProps) => {
   const stringGetter = useStringGetter();
   const { dydxAddress } = useAccounts();
   const { affiliateProgram, vipsChannel, affiliateProgramSupportEmail } = useURLConfigs();
@@ -63,7 +61,7 @@ export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProp
     : stringGetter({ key: STRING_KEYS.APPLY_NOW });
 
   return (
-    <$Container className={className}>
+    <div tw="w-full rounded-0.625 bg-color-layer-3 notTablet:w-4/12">
       {dydxAddress && (
         <div tw="flex flex-col gap-y-1 p-1">
           <$Header tw="flex items-center">
@@ -106,11 +104,9 @@ export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProp
           )}
         </div>
       )}
-    </$Container>
+    </div>
   );
 };
-
-const $Container = tw.div`rounded-0.625 bg-color-layer-3`;
 
 const $Header = styled.div`
   font-size: 18px;

--- a/src/views/Affiliates/cards/ProgramStatusCard.tsx
+++ b/src/views/Affiliates/cards/ProgramStatusCard.tsx
@@ -14,23 +14,11 @@ import { useURLConfigs } from '@/hooks/useURLConfigs';
 import { Button } from '@/components/Button';
 import { Icon, IconName } from '@/components/Icon';
 import { Output, OutputType } from '@/components/Output';
-import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton';
 
 interface IProgramCardProps {
   className?: string;
   isVip: boolean;
 }
-
-const ConnectWallet = () => {
-  const stringGetter = useStringGetter();
-
-  return (
-    <div tw="flex flex-col items-center justify-center gap-y-1 px-4 py-2 text-center">
-      <p>{stringGetter({ key: STRING_KEYS.AFFILIATE_CONNECT_WALLET })}</p>
-      <OnboardingTriggerButton />
-    </div>
-  );
-};
 
 export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProps) => {
   const stringGetter = useStringGetter();
@@ -76,8 +64,6 @@ export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProp
 
   return (
     <$Container className={className}>
-      {!dydxAddress && <ConnectWallet />}
-
       {dydxAddress && (
         <div tw="flex flex-col gap-y-1 p-1">
           <$Header tw="flex items-center">
@@ -124,7 +110,7 @@ export const ProgramStatusCard = ({ className, isVip = false }: IProgramCardProp
   );
 };
 
-const $Container = tw.div`h-full rounded-0.625 bg-color-layer-3`;
+const $Container = tw.div`rounded-0.625 bg-color-layer-3`;
 
 const $Header = styled.div`
   font-size: 18px;


### PR DESCRIPTION
This PR fixes a bunch of things on the affiliates page
- Changes the loading display to be more granular instead of making the whole page load
- Adds `staleTime` to some react-query calls so that affiliates calls will not be re-requested on some component mounting
- Fixes some styling

Disconnected view:
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/61cc4043-4be3-4151-9616-bd92470a891e">

Not affiliate view:
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/a6207d78-b5bf-43a3-8878-ea3c13c8f934">

Affiliate view:
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/62d8f6f9-4657-4f98-84be-e64a543eab04">

Loading metadata:
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/b26e6542-d0bc-4f6e-94ba-e21ed2e28558">
