### PR TITLE
fix: do not surface referralDialog when using own code

### DIFF
--- a/src/views/dialogs/ReferralDialog.tsx
+++ b/src/views/dialogs/ReferralDialog.tsx
@@ -37,20 +37,30 @@ const CONTENT_SECTIONS = [
 export const ReferralDialog = ({ setIsOpen, refCode }: DialogProps<ReferralDialogProps>) => {
   const stringGetter = useStringGetter();
   const { dydxAddress } = useAccounts();
+
   const {
     data: referralAddress,
     isPending: isReferralAddressPending,
     isFetched: isReferralAddressFetched,
   } = useReferralAddress(refCode);
+
   const {
     affiliateMetadataQuery: { data: affiliatesInfo, isSuccess: isAffiliatesInfoSuccess },
   } = useAffiliatesInfo(referralAddress);
+
   const { data: referredBy, isPending: isReferredByPending } = useReferredBy();
 
   const isNotEligible = isAffiliatesInfoSuccess && !affiliatesInfo.isEligible;
+  const isOwnReferralCode = isReferralAddressFetched && referralAddress === dydxAddress;
+
   const invalidReferralCode = isReferralAddressFetched && !referralAddress;
 
-  if (isReferralAddressPending || isReferredByPending || !!referredBy?.affiliateAddress)
+  if (
+    isReferralAddressPending ||
+    isReferredByPending ||
+    !!referredBy?.affiliateAddress ||
+    isOwnReferralCode
+  )
     return null;
 
   return (


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Re-organize useAffiliateInfo hooks by moving queries to their own hooks.
Check for matching referralCode or referalAddresses.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<ReferralDialog>`
  - if matching addresses, return null.

## Hooks

- `hooks/useAffiliatesInfo`
  - Separate queries

- `hooks/useReferralCode`
  -  check for matching referralCode and remove latestReferrer if that is the case.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
