### PR TITLE
fix: compliance banner hides table pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,6 @@ import { parseLocationHash } from '@/lib/urlUtils';
 import { config, privyConfig } from '@/lib/wagmi';
 
 import { RestrictionWarning } from './components/RestrictionWarning';
-import { ComplianceStates } from './constants/compliance';
 import { DialogTypes } from './constants/dialogs';
 import { funkitConfig, funkitTheme } from './constants/funkit';
 import { LocalStorageKey } from './constants/localStorage';
@@ -96,8 +95,7 @@ const Content = () => {
   const isShowingHeader = isNotTablet;
   const isShowingFooter = useShouldShowFooter();
 
-  const { complianceState } = useComplianceState();
-  const showRestrictionWarning = complianceState === ComplianceStates.READ_ONLY;
+  const { showRestrictionWarning } = useComplianceState();
 
   const pathFromHash = useMemo(() => {
     if (location.hash === '') {
@@ -268,6 +266,7 @@ const $Content = styled.div<{
   /* Computed */
   --page-currentHeaderHeight: 0px;
   --page-currentFooterHeight: 0px;
+  --restriction-warning-currentHeight: 0px;
 
   ${({ isShowingHeader }) =>
     isShowingHeader &&
@@ -289,6 +288,16 @@ const $Content = styled.div<{
       }
     `}
 
+  ${({ showRestrictionWarning }) =>
+    showRestrictionWarning &&
+    css`
+      --restriction-warning-currentHeight: var(--restriction-warning-height);
+
+      @media ${breakpoints.tablet} {
+        --restriction-warning-currentHeight: var(--restriction-warning-height-mobile);
+      }
+    `}
+
     /* Rules */
     ${layoutMixins.contentContainer}
 
@@ -307,10 +316,13 @@ const $Content = styled.div<{
 
   ${layoutMixins.withOuterAndInnerBorders}
   display: grid;
+
   ${({ showRestrictionWarning, isShowingHeader }) => css`
     grid-template:
       ${isShowingHeader ? css`'Header' var(--page-currentHeaderHeight)` : ''}
-      ${showRestrictionWarning ? css`'RestrictionWarning' min-content` : ''}
+      ${showRestrictionWarning
+        ? css`'RestrictionWarning' var(--restriction-warning-currentHeight)`
+        : ''}
       'Main' minmax(min-content, 1fr)
       'Footer' var(--page-currentFooterHeight)
       / 100%;

--- a/src/components/RestrictionWarning.tsx
+++ b/src/components/RestrictionWarning.tsx
@@ -16,17 +16,19 @@ export const RestrictionWarning = () => {
 
   return (
     <$RestrictedWarning>
-      {stringGetter({
-        key: STRING_KEYS.BLOCKED_BANNER_MESSAGE,
-        params: {
-          TERMS_OF_USE_LINK: <TermsOfUseLink isInline />,
-          HELP_LINK: (
-            <Link href={help} isInline>
-              {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
-            </Link>
-          ),
-        },
-      })}
+      <span>
+        {stringGetter({
+          key: STRING_KEYS.BLOCKED_BANNER_MESSAGE,
+          params: {
+            TERMS_OF_USE_LINK: <TermsOfUseLink isInline />,
+            HELP_LINK: (
+              <Link href={help} isInline>
+                {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
+              </Link>
+            ),
+          },
+        })}
+      </span>
     </$RestrictedWarning>
   );
 };
@@ -34,6 +36,9 @@ export const RestrictionWarning = () => {
 const $RestrictedWarning = styled.div`
   ${layoutMixins.sticky}
   --stickyArea-totalInsetTop: var(--page-currentHeaderHeight);
+  height: var(--restriction-warning-currentHeight);
+  display: flex;
+  align-items: center;
 
   grid-area: RestrictionWarning;
   z-index: 1;

--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -112,6 +112,6 @@ export const useComplianceState = () => {
     complianceState,
     complianceMessage,
     disableConnectButton,
-    showRestrictionWarning: true, // complianceState === ComplianceStates.READ_ONLY,
+    showRestrictionWarning: complianceState === ComplianceStates.READ_ONLY,
   };
 };

--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -112,5 +112,6 @@ export const useComplianceState = () => {
     complianceState,
     complianceMessage,
     disableConnectButton,
+    showRestrictionWarning: true, // complianceState === ComplianceStates.READ_ONLY,
   };
 };

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -10,7 +10,7 @@
 
   /* Restriction Warning */
   --restriction-warning-height: 3.25rem;
-  --restriction-warning-height-mobile: 5rem;
+  --restriction-warning-height-mobile: min-content;
 
   /* Sidebar constants */
   --sidebar-width: 20.25rem;

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -8,6 +8,10 @@
   --page-footer-height: 2rem;
   --page-footer-height-mobile: 4.5rem;
 
+  /* Restriction Warning */
+  --restriction-warning-height: 3.25rem;
+  --restriction-warning-height-mobile: 5rem;
+
   /* Sidebar constants */
   --sidebar-width: 20.25rem;
   --collapsed-sidebar-width: 3.5rem;

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -390,7 +390,9 @@ const $Popover = styled(Popover)`
   flex-direction: column;
 
   height: calc(
-    100vh - var(--page-header-height) - var(--market-info-row-height) - var(--page-footer-height)
+    100vh - var(--page-header-height) - var(--market-info-row-height) - var(--page-footer-height) - var(
+        --restriction-warning-height
+      )
   );
 
   width: var(--marketsDropdown-openWidth);


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="936" alt="Screen Shot 2024-11-26 at 4 16 21 PM" src="https://github.com/user-attachments/assets/da71701c-1ff3-4e77-b0f6-b622fbd86859">

<!-- Overall purpose of the PR -->
Add restriction warning height to css vars in order to be used in css calcs.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<App>`
  - set the restriction warning current height css var

- `<MarketDropdown>`
  - include restriction warning height in sticky positioning calc

## Components

- `<RestrictionWarning>`
  - wrap contents in span in order to vertically center after giving a fixed height

## Styles/Mixins

- `styles/constants.css`
  - add restriction warning heights

## Hooks

- `hooks/useComplianceState`
  - return boolean on whether to display compliance warning

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
