### PR TITLE
fix: get rid of pending checks in affiliate flow

### DIFF
--- a/src/hooks/useReferralCode.ts
+++ b/src/hooks/useReferralCode.ts
@@ -23,9 +23,7 @@ export function useReferralCode() {
   const { data: affiliateMetadata, isPending: isAffiliateMetadataPending } =
     useAffiliateMetadata(dydxAddress);
 
-  const { data: referralAddress, isSuccess: isReferralAddressSuccess } = useReferralAddress(
-    testFlags.referralCode
-  );
+  const { data: referralAddress } = useReferralAddress(testFlags.referralCode);
 
   const { data: referredBy, isPending: isReferredByPending } = useReferredBy();
 
@@ -40,22 +38,12 @@ export function useReferralCode() {
   }, [dispatch]);
 
   useEffect(() => {
-    // wait for relevant data to load
-    if (!isReferralAddressSuccess || isReferredByPending || isAffiliateMetadataPending) return;
-
-    // current user already has a referrer registered
-    if (referredBy?.affiliateAddress) return;
-
-    // current user is using their own code
-    if (isOwnReferralCode) return;
-
     if (referralAddress) {
       track(AnalyticsEvents.AffiliateSaveReferralAddress({ affiliateAddress: referralAddress }));
       dispatch(updateLatestReferrer(referralAddress));
     }
   }, [
     referralAddress,
-    isReferralAddressSuccess,
     dispatch,
     isReferredByPending,
     referredBy?.affiliateAddress,

--- a/src/views/dialogs/ReferralDialog.tsx
+++ b/src/views/dialogs/ReferralDialog.tsx
@@ -17,8 +17,6 @@ import { Button } from '@/components/Button';
 import { Dialog } from '@/components/Dialog';
 import { Link } from '@/components/Link';
 
-import { truncateAddress } from '@/lib/wallet';
-
 import { OnboardingTriggerButton } from './OnboardingTriggerButton';
 
 const CONTENT_SECTIONS = [
@@ -64,7 +62,7 @@ export const ReferralDialog = ({ setIsOpen, refCode }: DialogProps<ReferralDialo
 
   if (
     isReferralAddressPending ||
-    isReferredByPending ||
+    !!(dydxAddress && isReferredByPending) ||
     !!referredBy?.affiliateAddress ||
     isOwnReferralCode
   ) {
@@ -84,9 +82,7 @@ export const ReferralDialog = ({ setIsOpen, refCode }: DialogProps<ReferralDialo
                 ? STRING_KEYS.YOUR_FRIEND
                 : STRING_KEYS.WELCOME_DYDX,
           })}
-          {!isNotEligible && !invalidReferralCode && (
-            <span tw="text-color-text-1">{refCode ?? truncateAddress(referralAddress)}</span>
-          )}
+          {!isNotEligible && !invalidReferralCode && <span tw="text-color-text-1">{refCode}</span>}
         </span>
       }
       description={stringGetter({


### PR DESCRIPTION
isPending will be false if theres no current `dydxAddress`, as some of these queries are paused until `dydxAddress` is defined, so dont rely on that as a loading indicator if theres no connected wallet yet
