### PR TITLE
fix: always refetch affiliates metadata query on mount

### DIFF
--- a/src/hooks/useAffiliatesInfo.ts
+++ b/src/hooks/useAffiliatesInfo.ts
@@ -66,6 +66,7 @@ export const useAffiliateMetadata = (dydxAddress?: string) => {
     queryFn: fetchAffiliateMetadata,
     enabled: Boolean(compositeClient && dydxAddress),
     staleTime: 5 * timeUnits.minute,
+    refetchOnMount: 'always',
   });
 
   return affiliateMetadataQuery;


### PR DESCRIPTION
this is so that every time the user goes to the referrals tab, we should update their metadata query, even if the staleTime hasn't been reached yet. we should still keep the staleTime because that prevents re-requests on rerenders
