### PR TITLE
style(nits): remove sticky transparency, fix ui nits

### DIFF
--- a/src/components/DetailsDialog.tsx
+++ b/src/components/DetailsDialog.tsx
@@ -36,8 +36,6 @@ export const DetailsDialog = ({ slotIcon, title, items, slotFooter, setIsOpen }:
 };
 const $Content = styled.div`
   ${layoutMixins.expandingColumnWithStickyFooter}
-  --stickyFooterBackdrop-outsetX: var(--dialog-paddingX);
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
   gap: 1rem;
 `;
 const $Footer = styled.footer`

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -412,6 +412,7 @@ const $Header = styled.header<{ $withBorder: boolean; $withBlur: boolean }>`
       --stickyArea-backdropFilter: none;
     `};
 `;
+
 const $StackedHeaderTopRow = styled.div<{ $withBorder: boolean; $withBlur: boolean }>`
   ${layoutMixins.flexColumn}
   align-items: center;
@@ -452,6 +453,7 @@ const $Content = styled.div`
 
   isolation: isolate;
 `;
+
 const $Close = styled(Close)<{ $absolute?: boolean }>`
   width: 0.7813rem;
   height: 0.7813rem;
@@ -509,8 +511,6 @@ const $Description = tw(Description)`mt-0.5 text-color-text-0 font-base-book`;
 const $Footer = styled.footer<{ $withBorder: boolean }>`
   display: grid;
   ${layoutMixins.stickyFooter}
-  ${layoutMixins.withStickyFooterBackdrop}
-  --stickyFooterBackdrop-outsetX: var(--dialog-paddingX);
 
   ${({ $withBorder }) =>
     $withBorder &&

--- a/src/components/DropdownHeaderMenu.tsx
+++ b/src/components/DropdownHeaderMenu.tsx
@@ -65,7 +65,6 @@ export const DropdownHeaderMenu = <MenuItemValue extends string>({
 };
 const $Trigger = styled(Trigger)`
   ${popoverMixins.trigger}
-  ${popoverMixins.backdropOverlay}
 
   --trigger-padding: 0.33rem 0.5rem;
   --trigger-textColor: var(--color-text-2);

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -124,7 +124,6 @@ const $Item = styled(Item)<{ $highlightColor?: 'accent' | 'create' | 'destroy' }
 
 const $Trigger = styled(Trigger)`
   ${popoverMixins.trigger}
-  ${popoverMixins.backdropOverlay}
 `;
 
 const $DropdownIcon = styled.span`

--- a/src/components/DropdownSelectMenu.tsx
+++ b/src/components/DropdownSelectMenu.tsx
@@ -126,7 +126,6 @@ const $Trigger = styled(Trigger)`
   gap: 1rem;
 
   ${popoverMixins.trigger}
-  ${popoverMixins.backdropOverlay}
 `;
 
 const $DropdownIcon = styled.span`

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -285,7 +285,6 @@ const $Viewport = styled(Viewport)`
 
   &[data-orientation='vertical'] {
     left: 100%;
-    /* top: 100%; */
   }
 `;
 
@@ -312,11 +311,6 @@ const $Content = styled(Content)`
     max-height: 100vh;
 
     ${$List}[data-orientation="horizontal"] & {
-      /* position: absolute;
-      top: calc(100% + var(--submenu-side-offset));
-      left: 50%;
-      right: 50%; */
-
       position: relative;
       width: 0;
       left: 50%;

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -82,7 +82,6 @@ export const Popover = ({
   );
 };
 const $Trigger = styled(Trigger)<{ $noBlur?: boolean; $triggerType: TriggerType }>`
-  ${popoverMixins.backdropOverlay}
   ${popoverMixins.trigger}
 
   ${({ $triggerType }) =>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -321,8 +321,6 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
     pointer-events: none;
   }
 
-  pointer-events: auto;
-
   ${({ $hide }) =>
     $hide &&
     css`

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -321,14 +321,13 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
     pointer-events: none;
   }
 
-  &[data-state='active'] {
-    z-index: var(--activeTab-zIndex);
-  }
+  pointer-events: auto;
 
   ${({ $hide }) =>
     $hide &&
     css`
       display: none;
+      opacity: 0;
     `}
 
   @media (prefers-reduced-motion: no-preference) {
@@ -340,7 +339,6 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
             from {
               translate: 0 -0.25rem -1.5rem;
               opacity: 0;
-              /* filter: blur(3px); */
             }
           `} 0.2s var(--ease-out-expo);
         }
@@ -352,7 +350,6 @@ const $Content = styled(Content)<{ $hide?: boolean; $withTransitions: boolean }>
             to {
               translate: 0 -0.25rem -1.5rem;
               opacity: 0;
-              /* filter: blur(3px); */
             }
           `} 0.2s var(--ease-out-expo);
         }
@@ -366,6 +363,7 @@ const $DropdownTabTrigger = styled(Trigger)<{
   ${tabMixins.tabTriggerStyle}
   height: 100%;
   width: 100%;
+  --trigger-hover-filter: none;
 
   ${({ $withUnderline }) =>
     $withUnderline &&

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -138,23 +138,17 @@ const $Root = styled(Root)`
       animation:
         ${keyframes`
           from {
-            /* scale: 0; */
             grid-template-rows: 0fr; // height transition
-            /* grid-template-rows: 0fr 0fr; // height transition */
-
             margin-top: calc(-1 * var(--toasts-gap));
           }
         `} var(--toast-transition-duration) var(--ease-out-expo),
         ${keyframes`
           from {
             opacity: 0;
-            /* filter: blur(1px); */
           }
         `} var(--toast-transition-duration) var(--ease-out-expo),
         ${keyframes`
           33% {
-            /* scale: 1.05; */
-            /* filter: brightness(120%); */
             filter: drop-shadow(0 0 var(--color-text-0));
           }
         `} calc(var(--toast-transition-duration) * 3) 0.1s;

--- a/src/layout/Footer/FooterDesktop.tsx
+++ b/src/layout/Footer/FooterDesktop.tsx
@@ -141,6 +141,7 @@ const $Footer = styled.footer`
   ${layoutMixins.stickyFooter}
   ${layoutMixins.spacedRow}
   grid-area: Footer;
+  background-color: var(--color-layer-2);
 `;
 
 const $Row = styled.div`

--- a/src/layout/Footer/FooterMobile.tsx
+++ b/src/layout/Footer/FooterMobile.tsx
@@ -107,6 +107,7 @@ export const FooterMobile = () => {
 };
 const $MobileNav = styled.footer`
   grid-area: Footer;
+  background-color: var(--color-layer-2);
 
   ${layoutMixins.stickyFooter}
 `;
@@ -161,8 +162,6 @@ const $NavigationMenu = styled(NavigationMenu)`
         top: 12.5%;
         bottom: 12.5%;
         right: 0;
-
-        background: linear-gradient(to bottom, transparent, var(--border-color), transparent);
       }
     }
   }

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -239,7 +239,7 @@ const $Header = styled.header`
   ${layoutMixins.stickyHeader}
   ${layoutMixins.scrollSnapItem}
   backdrop-filter: none;
-
+  background-color: var(--color-layer-2);
   height: var(--page-currentHeaderHeight);
 
   grid-area: Header;
@@ -263,12 +263,6 @@ const $Header = styled.header`
   }
 
   font-size: 0.9375rem;
-
-  &:before {
-    --backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: var(--backdrop-filter);
-    backdrop-filter: var(--backdrop-filter);
-  }
 `;
 
 const $NavigationScrollBar = styled.div`

--- a/src/pages/portfolio/EquityTiers.tsx
+++ b/src/pages/portfolio/EquityTiers.tsx
@@ -109,7 +109,7 @@ const $Table = styled(Table)`
   --tableCell-padding: 0.5rem 1.5rem;
   --bordered-content-border-radius: 0.625rem;
   --table-cell-align: end;
-
+  border-top: var(--border-width) solid var(--color-border);
   font: var(--font-base-book);
 
   @media ${breakpoints.mobile} {
@@ -118,7 +118,7 @@ const $Table = styled(Table)`
   }
 
   @media ${breakpoints.notTablet} {
-    --tableStickyRow-backgroundColor: var(--color-layer-1);
+    --tableStickyRow-backgroundColor: var(--color-layer-2);
   }
 ` as typeof Table;
 

--- a/src/pages/portfolio/EquityTiers.tsx
+++ b/src/pages/portfolio/EquityTiers.tsx
@@ -98,18 +98,18 @@ export const EquityTiers = () => {
           }
           selectionBehavior="replace"
           paginationBehavior="showAll"
-          withOuterBorder={isNotTablet}
+          withOuterBorder
           withInnerBorders
         />
       </div>
     </AttachedExpandingSection>
   );
 };
+
 const $Table = styled(Table)`
   --tableCell-padding: 0.5rem 1.5rem;
   --bordered-content-border-radius: 0.625rem;
   --table-cell-align: end;
-  border-top: var(--border-width) solid var(--color-border);
   font: var(--font-base-book);
 
   @media ${breakpoints.mobile} {
@@ -123,6 +123,7 @@ const $Table = styled(Table)`
 ` as typeof Table;
 
 const $HighlightOutput = tw(Output)`text-color-text-1`;
+
 const $Description = styled.div`
   color: var(--color-text-0);
   padding: 0 1rem;

--- a/src/pages/portfolio/Fees.tsx
+++ b/src/pages/portfolio/Fees.tsx
@@ -240,7 +240,7 @@ export const Fees = () => {
           ).filter(isTruthy)}
           selectionBehavior="replace"
           paginationBehavior="showAll"
-          withOuterBorder={isNotTablet}
+          withOuterBorder
           withInnerBorders
         />
       </div>
@@ -341,7 +341,6 @@ const $FeeTable = styled(Table)`
   --tableCell-padding: 0.5rem 1.5rem;
   --bordered-content-border-radius: 0.625rem;
   --table-cell-align: end;
-  border-top: var(--border-width) solid var(--color-border);
 
   font: var(--font-base-book);
 

--- a/src/pages/portfolio/Fees.tsx
+++ b/src/pages/portfolio/Fees.tsx
@@ -341,6 +341,7 @@ const $FeeTable = styled(Table)`
   --tableCell-padding: 0.5rem 1.5rem;
   --bordered-content-border-radius: 0.625rem;
   --table-cell-align: end;
+  border-top: var(--border-width) solid var(--color-border);
 
   font: var(--font-base-book);
 
@@ -360,7 +361,7 @@ const $FeeTable = styled(Table)`
   }
 
   @media ${breakpoints.notTablet} {
-    --tableStickyRow-backgroundColor: var(--color-layer-1);
+    --tableStickyRow-backgroundColor: var(--color-layer-2);
   }
 ` as typeof Table;
 const $Highlighted = tw.strong`text-color-text-1`;

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { shallowEqual } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
 import { AppRoute } from '@/constants/routes';
@@ -294,7 +295,7 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
     <MobileTabs defaultValue={InfoSection.Position} items={tabItems} />
   ) : (
     <>
-      <CollapsibleTabs
+      <$CollapsibleTabs
         defaultTab={InfoSection.Position}
         tab={tab}
         setTab={setTab}
@@ -316,3 +317,11 @@ export const HorizontalPanel = ({ isOpen = true, setIsOpen }: ElementProps) => {
     </>
   );
 };
+
+const $CollapsibleTabs = styled(CollapsibleTabs)`
+  header {
+    background-color: var(--color-layer-2);
+  }
+
+  --trigger-active-underline-backgroundColor: var(--color-layer-2);
+`;

--- a/src/pages/trade/HorizontalPanel.tsx
+++ b/src/pages/trade/HorizontalPanel.tsx
@@ -324,4 +324,4 @@ const $CollapsibleTabs = styled(CollapsibleTabs)`
   }
 
   --trigger-active-underline-backgroundColor: var(--color-layer-2);
-`;
+` as typeof CollapsibleTabs;

--- a/src/pages/trade/TradeDialogTrigger.tsx
+++ b/src/pages/trade/TradeDialogTrigger.tsx
@@ -68,6 +68,7 @@ export const TradeDialogTrigger = () => {
 };
 const $TradeDialogTrigger = styled.div<{ hasSummary?: boolean }>`
   ${layoutMixins.stickyFooter}
+  background-color: var(--color-layer-2);
 
   ${layoutMixins.spacedRow}
 

--- a/src/pages/trade/VerticalPanel.tsx
+++ b/src/pages/trade/VerticalPanel.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import styled from 'styled-components';
+
 import { TradeLayouts } from '@/constants/layout';
 import { STRING_KEYS } from '@/constants/localization';
 import { ORDERBOOK_HEADER_HEIGHT, ORDERBOOK_ROW_HEIGHT } from '@/constants/orderbook';
@@ -61,7 +63,7 @@ export const VerticalPanel = ({ tradeLayout }: { tradeLayout: TradeLayouts }) =>
   }, [calculateNumRows, canvasOrderbook]);
 
   return (
-    <Tabs
+    <$Tabs
       fullWidthTabs
       dividerStyle="underline"
       value={value}
@@ -92,3 +94,7 @@ export const VerticalPanel = ({ tradeLayout }: { tradeLayout: TradeLayouts }) =>
     />
   );
 };
+
+const $Tabs = styled(Tabs)`
+  --trigger-active-underline-backgroundColor: var(--color-layer-2);
+` as typeof Tabs;

--- a/src/styles/formMixins.ts
+++ b/src/styles/formMixins.ts
@@ -142,7 +142,6 @@ export const formMixins = {
   withStickyFooter: css`
     footer {
       ${layoutMixins.stickyFooter}
-      ${layoutMixins.withStickyFooterBackdrop}
     }
   `,
 

--- a/src/styles/layoutMixins.ts
+++ b/src/styles/layoutMixins.ts
@@ -149,7 +149,6 @@ const sticky = css`
   --stickyArea-totalInsetBottom: ;
   --stickyArea-totalInsetLeft: ;
   --stickyArea-totalInsetRight: ;
-  --stickyArea-backdropFilter: blur(10px);
 
   z-index: 1;
 
@@ -159,9 +158,6 @@ const sticky = css`
   bottom: var(--stickyArea-totalInsetBottom, 0px);
   left: var(--stickyArea-totalInsetLeft, 0px);
   right: var(--stickyArea-totalInsetRight, 0px);
-
-  -webkit-backdrop-filter: var(--stickyArea-backdropFilter);
-  backdrop-filter: var(--stickyArea-backdropFilter);
 `;
 
 /**
@@ -185,8 +181,6 @@ const stickyArea = css`
   --stickyArea-paddingRight: ;
   --stickyArea-rightGap: ;
   --stickyArea-rightWidth: ;
-
-  --stickyArea-background: ;
 
   /* Computed */
   --stickyArea-totalInsetTop: var(--stickyArea-paddingTop);
@@ -217,14 +211,6 @@ const stickyArea = css`
       )
   );
 
-  /* Rules */
-  /* scroll-padding-top: var(--stickyArea-topHeight);
-scroll-padding-bottom: var(--stickyArea-bottomHeight); */
-  /* scroll-padding-top: var(--stickyArea-totalInsetTop);
-scroll-padding-bottom: var(--stickyArea-totalInsetBottom); */
-  /* scroll-padding-block-end: 4rem; */
-
-  /* Firefox: opaque background required for backdrop-filter to work */
   background: var(--stickyArea-background, var(--color-layer-2));
 `;
 
@@ -235,29 +221,6 @@ const stickyFooter = css`
   flex-shrink: 0;
 
   ${() => scrollSnapItem}
-`;
-
-// Use with layoutMixins.stickyFooter
-const withStickyFooterBackdrop = css`
-  /* Params */
-  --stickyFooterBackdrop-outsetY: ;
-  --stickyFooterBackdrop-outsetX: ;
-
-  /* Rules */
-  backdrop-filter: none;
-
-  &:before {
-    content: '';
-
-    z-index: -1;
-    position: absolute;
-    inset: calc(-1 * var(--stickyFooterBackdrop-outsetY, 0px))
-      calc(-1 * var(--stickyFooterBackdrop-outsetX, 0px));
-
-    background: linear-gradient(transparent, var(--stickyArea-background));
-
-    pointer-events: none;
-  }
 `;
 
 export const layoutMixins = {
@@ -869,8 +832,6 @@ export const layoutMixins = {
 
   scrollSnapItem,
 
-  withStickyFooterBackdrop,
-
   withOuterBorder,
 
   // Show "borders" between and around grid/flex items using gap + box-shadow
@@ -1004,7 +965,6 @@ export const layoutMixins = {
 
     > :last-child {
       ${() => stickyFooter}
-      ${() => withStickyFooterBackdrop}
     }
   `,
 

--- a/src/views/AccountInfo/AccountInfoSection.tsx
+++ b/src/views/AccountInfo/AccountInfoSection.tsx
@@ -218,4 +218,8 @@ const $WithSeparators = styled(WithSeparators)`
 
 const $Button = styled(Button)`
   --button-padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;

--- a/src/views/CanvasOrderbook/CanvasOrderbook.tsx
+++ b/src/views/CanvasOrderbook/CanvasOrderbook.tsx
@@ -36,6 +36,7 @@ import { OrderbookControls } from './OrderbookControls';
 import { OrderbookMiddleRow, OrderbookRow } from './OrderbookRow';
 
 type ElementProps = {
+  className?: string;
   rowsPerSide?: number;
   layout?: 'vertical' | 'horizontal';
 };
@@ -48,6 +49,7 @@ type StyleProps = {
 export const CanvasOrderbook = forwardRef(
   (
     {
+      className,
       histogramSide = 'right',
       hideHeader = false,
       layout = 'vertical',
@@ -130,7 +132,7 @@ export const CanvasOrderbook = forwardRef(
           );
         }
       },
-      [currentInput, tickSizeDecimals]
+      [dispatch, currentInput, tickSizeDecimals]
     );
 
     const displayUnit = useAppSelector(getSelectedDisplayUnit);
@@ -201,7 +203,7 @@ export const CanvasOrderbook = forwardRef(
     );
 
     return (
-      <div ref={ref} tw="flex flex-1 flex-col overflow-hidden">
+      <div className={className} ref={ref} tw="flex flex-1 flex-col overflow-hidden">
         <$OrderbookContent $isLoading={!hasOrderbook}>
           {!hideHeader && <OrderbookControls assetId={id} grouping={currentGrouping} />}
           {!hideHeader && (

--- a/src/views/MarketsDropdown.tsx
+++ b/src/views/MarketsDropdown.tsx
@@ -1,7 +1,7 @@
 import { Key, memo, useEffect, useMemo, useState } from 'react';
 
 import { Link, useNavigate } from 'react-router-dom';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 
 import { Nullable } from '@/constants/abacus';
 import { ButtonStyle } from '@/constants/buttons';
@@ -391,7 +391,7 @@ const $Popover = styled(Popover)`
 
   height: calc(
     100vh - var(--page-header-height) - var(--market-info-row-height) - var(--page-footer-height) - var(
-        --restriction-warning-height
+        --restriction-warning-currentHeight
       )
   );
 
@@ -402,25 +402,6 @@ const $Popover = styled(Popover)`
   box-shadow: 0 0 0 1px var(--color-border);
   border-radius: 0;
 
-  &[data-state='open'] {
-    animation: ${keyframes`
-      from {
-        opacity: 0;
-        scale: 0.9;
-        max-height: 0;
-      }
-    `} 0.2s var(--ease-out-expo);
-  }
-
-  &[data-state='closed'] {
-    animation: ${keyframes`
-      to {
-        opacity: 0;
-        scale: 0.95;
-        max-height: 0;
-      }
-    `} 0.2s;
-  }
   &:focus-visible {
     outline: none;
   }
@@ -487,6 +468,8 @@ const $Table = styled(Table)`
   thead {
     --stickyArea-totalInsetTop: 0px;
     --stickyArea-totalInsetBottom: 0px;
+    background-color: var(--color-layer-2);
+
     tr {
       height: var(--stickyArea-topHeight);
     }
@@ -495,6 +478,7 @@ const $Table = styled(Table)`
   tfoot {
     --stickyArea-totalInsetTop: 0px;
     --stickyArea-totalInsetBottom: 3px;
+    background-color: var(--color-layer-2);
 
     tr {
       height: var(--stickyArea-bottomHeight);

--- a/src/views/charts/DepthChart/index.tsx
+++ b/src/views/charts/DepthChart/index.tsx
@@ -342,7 +342,7 @@ export const DepthChart = ({
               )}
               showHorizontalCrosshair
               horizontalCrosshairStyle={{ strokeWidth: 1, strokeDasharray: '5 5', opacity: 0.7 }}
-              snapCrosshairToDatumY={!isEditingOrder}
+              snapCrosshairToDatumY={false}
               renderYAxisLabel={({ tooltipData }) =>
                 (isEditingOrder || tooltipData!.nearestDatum?.datum.depth) && (
                   <$YAxisLabelOutput
@@ -392,6 +392,7 @@ export const DepthChart = ({
     </$Container>
   );
 };
+
 const $Container = styled.div`
   width: 0;
   min-width: 100%;
@@ -428,6 +429,7 @@ const $Container = styled.div`
     }
   }
 `;
+
 const $YAxisLabelOutput = styled(AxisLabelOutput)`
   --axisLabel-offset: 0.5rem;
 

--- a/src/views/charts/DepthChart/index.tsx
+++ b/src/views/charts/DepthChart/index.tsx
@@ -415,7 +415,6 @@ const $Container = styled.div`
       animation: ${keyframes`
         from {
           opacity: 0;
-          /* filter: blur(2px); */
         }
       `} 0.1s var(--ease-out-expo);
     }
@@ -424,7 +423,6 @@ const $Container = styled.div`
       animation: ${keyframes`
         to {
           opacity: 0;
-          /* filter: blur(2px); */
         }
       `} 0.2s 0.3s var(--ease-out-expo) forwards;
     }

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -28,7 +28,6 @@ export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
 const $PriceChart = styled.div<{ isChartReady?: boolean }>`
   ${layoutMixins.stack}
   user-select: none;
-  pointer-events: initial; // allow pointer events when dialog overlay is visible
 
   height: 100%;
 

--- a/src/views/forms/AccountManagementForms/DepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/DepositForm.tsx
@@ -863,5 +863,4 @@ const $Form = styled.form`
 `;
 const $Footer = styled.footer`
   ${formMixins.footer}
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 `;

--- a/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
@@ -101,7 +101,6 @@ const $Form = styled.form`
 
 const $Footer = styled.footer`
   ${formMixins.footer}
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 
   button {
     --button-width: 100%;

--- a/src/views/forms/AccountManagementForms/WithdrawForm.tsx
+++ b/src/views/forms/AccountManagementForms/WithdrawForm.tsx
@@ -683,5 +683,4 @@ const $Form = styled.form`
 
 const $Footer = styled.footer`
   ${formMixins.footer}
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 `;

--- a/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
+++ b/src/views/forms/TradeForm/PlaceOrderButtonAndReceipt.tsx
@@ -400,7 +400,6 @@ export const PlaceOrderButtonAndReceipt = ({
 const $Footer = styled.footer`
   ${formMixins.footer}
   padding-bottom: var(--dialog-content-paddingBottom);
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 
   ${layoutMixins.column}
 `;

--- a/src/views/forms/TransferForm.tsx
+++ b/src/views/forms/TransferForm.tsx
@@ -474,7 +474,6 @@ const $Form = styled.form`
 
 const $Footer = styled.footer`
   ${formMixins.footer}
-  --stickyFooterBackdrop-outsetY: var(--dialog-content-paddingBottom);
 `;
 
 const $Row = styled.div`

--- a/src/views/tables/OrderbookTradesTable.tsx
+++ b/src/views/tables/OrderbookTradesTable.tsx
@@ -3,7 +3,7 @@ import styled, { css, keyframes } from 'styled-components';
 import breakpoints from '@/styles/breakpoints';
 
 import { Output } from '@/components/Output';
-import { Table, BaseTableRowData, AllTableProps } from '@/components/Table';
+import { AllTableProps, BaseTableRowData, Table } from '@/components/Table';
 
 import { getSimpleStyledOutputType } from '@/lib/genericFunctionalComponentUtils';
 
@@ -53,6 +53,7 @@ const $OrderbookTradesTable = styled(Table)<OrderbookTradesTableStyleProps>`
 
   thead {
     font: var(--font-mini-book);
+    background-color: var(--color-layer-2);
   }
 
   tbody tr {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Clean up styling nits around the app.

---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<EquityTiers>`, `<Fees>`
  - consistent `theader` background color

- `<FooterDesktop>`, `<HeaderDesktop>`
  - solid background color

- `<AccountInfoSection>`
  - give deposit/withdraw button hover effect 

- `<MarketsDropdown>`
  - solid thead and pagination-footer background color

- `<TvChartBase>`
  - remove being able to interact with tvChart when overlay is present 

- `<FooterMobile>`, `<TradeDialogTrigger>`
  - solid background 

## Components

- `<Tabs>`
  - Fix hiding `forceMount` views (Orderbook)

- `<DropdownMenu>`, `<DropdownSelectMenu>`, `<DropdownHeaderMenu>`, `<Popover>`
  - remove backdrop overlay

## Styles/Mixins

- `styles/formMixins`, `styles/layoutMixins`, 
  - deprecate `withStickyFooterBackdrop`. Remove css vars on forms/dialogs for this style

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
