### PR TITLE
chore: subscript on orderbook

### DIFF
--- a/src/constants/unicode.ts
+++ b/src/constants/unicode.ts
@@ -1,4 +1,20 @@
-export const UNICODE = {
+export const UNICODE: {
+  MINUS: string;
+  PLUS: string;
+  SUBSCRIPT: Record<number, string>;
+} = {
   MINUS: '\u2212',
   PLUS: '\u002b',
+  SUBSCRIPT: {
+    0: '\u2080',
+    1: '\u2081',
+    2: '\u2082',
+    3: '\u2083',
+    4: '\u2084',
+    5: '\u2085',
+    6: '\u2086',
+    7: '\u2087',
+    8: '\u2088',
+    9: '\u2089',
+  },
 };

--- a/src/hooks/Orderbook/useDrawOrderbook.ts
+++ b/src/hooks/Orderbook/useDrawOrderbook.ts
@@ -244,6 +244,7 @@ export const useDrawOrderbook = ({
             groupSeparator,
             selectedLocale,
             fractionDigits: tickSizeDecimals,
+            withSubscript: true,
           }),
           getXByColumn({ canvasWidth, colIdx: 0 }) - ORDERBOOK_ROW_PADDING_RIGHT,
           y

--- a/src/views/CanvasOrderbook/OrderbookControls.tsx
+++ b/src/views/CanvasOrderbook/OrderbookControls.tsx
@@ -82,6 +82,7 @@ export const OrderbookControls = ({ className, assetId, grouping }: OrderbookCon
             </$WithSeparators>
           </$ButtonGroup>
           <Output
+            withSubscript
             value={grouping?.tickSize}
             type={OutputType.Fiat}
             fractionDigits={tickSizeDecimals === 1 ? 2 : tickSizeDecimals}

--- a/src/views/CanvasOrderbook/OrderbookRow.tsx
+++ b/src/views/CanvasOrderbook/OrderbookRow.tsx
@@ -62,6 +62,7 @@ export const OrderbookMiddleRow = forwardRef<HTMLDivElement, StyleProps & Elemen
         <span>{stringGetter({ key: STRING_KEYS.PRICE })}</span>
         <span tw="flex flex-col">
           <Output
+            withSubscript
             type={OutputType.Number}
             value={orderbookMidMarketPrice}
             fractionDigits={tickSizeDecimals}


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->
<img width="300" alt="Screen Shot 2025-01-06 at 12 32 25 PM" src="https://github.com/user-attachments/assets/06ef1267-028e-4119-b2ce-bb1a832dac0a" />

<!-- Overall purpose of the PR -->
Add subscript support to Orderbook controls and canvas.
---

<!-- Reorder/delete the following sections accordingly: -->

## Views

- `<OrderbookControls>`, `<OrderbookRow>`
  - `withSubscript` on `<Output>`

## Hooks

- `useDrawOrderbook`
  - use `withSubscript` in  `formatNumberOutput`

## Components

- `<Output>`
  - Add `withSubscript` parameter to  `formatNumberOutput`. Uses formatZeroNumbers to inject subscript unicode into a string.
  - This change is only for the formatting function and not `<Output>` component, which will rely on `<NumberValue>` component.

---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
