### PR TITLE
fix(bonsai-core): work around indexer race condition by managing websocket value lifecycles more clearly

### DIFF
--- a/src/abacus-ts/lib/resourceCacheManager.ts
+++ b/src/abacus-ts/lib/resourceCacheManager.ts
@@ -1,3 +1,5 @@
+import { logAbacusTsError } from '../logs';
+
 type CacheEntry<T> = {
   resource: T;
   count: number;
@@ -14,7 +16,7 @@ export class ResourceCacheManager<T, U> {
   constructor(
     private options: {
       constructor: (key: U) => T;
-      destroyer: (resource: NoInfer<T>) => void;
+      destroyer: (resource: NoInfer<T>, key: NoInfer<U>) => void;
       keySerializer: (key: NoInfer<U>) => string;
       destroyDelayMs?: number;
     }
@@ -42,7 +44,14 @@ export class ResourceCacheManager<T, U> {
   markDone(key: U): void {
     const serializedKey = this.options.keySerializer(key);
     const entry = this.cache[serializedKey];
-    if (!entry) return;
+    if (!entry) {
+      logAbacusTsError('ResourceCacheManager', 'tried to mark done unknown key', key);
+      return;
+    }
+    if (entry.count <= 0) {
+      logAbacusTsError('ResourceCacheManager', 'tried to mark done key with no users', key);
+      entry.count = 1;
+    }
 
     entry.count -= 1;
 
@@ -55,9 +64,16 @@ export class ResourceCacheManager<T, U> {
       const delay = this.options.destroyDelayMs ?? 1000;
       entry.destroyTimeout = setTimeout(() => {
         const latestVal = this.cache[serializedKey];
-        if (!latestVal) return;
+        if (!latestVal) {
+          logAbacusTsError(
+            'ResourceCacheManager',
+            'unexpectedly couldnt find resource to destroy',
+            key
+          );
+          return;
+        }
 
-        this.options.destroyer(latestVal.resource);
+        this.options.destroyer(latestVal.resource, key);
         delete this.cache[serializedKey];
       }, delay);
     }

--- a/src/abacus-ts/lib/resourceCacheManager.ts
+++ b/src/abacus-ts/lib/resourceCacheManager.ts
@@ -49,7 +49,7 @@ export class ResourceCacheManager<T, U> {
       return;
     }
     if (entry.count <= 0) {
-      logAbacusTsError('ResourceCacheManager', 'tried to mark done key with no users', key);
+      logAbacusTsError('ResourceCacheManager', 'tried to mark done key with no subscribers', key);
       entry.count = 1;
     }
 
@@ -65,11 +65,7 @@ export class ResourceCacheManager<T, U> {
       entry.destroyTimeout = setTimeout(() => {
         const latestVal = this.cache[serializedKey];
         if (!latestVal) {
-          logAbacusTsError(
-            'ResourceCacheManager',
-            'unexpectedly couldnt find resource to destroy',
-            key
-          );
+          logAbacusTsError('ResourceCacheManager', 'could not find resource to destroy', key);
           return;
         }
 

--- a/src/abacus-ts/websocket/lib/indexerValueManagerHelpers.ts
+++ b/src/abacus-ts/websocket/lib/indexerValueManagerHelpers.ts
@@ -1,0 +1,46 @@
+import { ResourceCacheManager } from '@/abacus-ts/lib/resourceCacheManager';
+import stableStringify from 'fast-json-stable-stringify';
+
+import { IndexerWebsocket } from './indexerWebsocket';
+import { IndexerWebsocketManager } from './indexerWebsocketManager';
+import { WebsocketDerivedValue } from './websocketDerivedValue';
+
+type WebsocketValueCreator<Args, ReturnType> = (
+  websocket: IndexerWebsocket,
+  args: Args
+) => WebsocketDerivedValue<ReturnType>;
+
+export function makeWsValueManager<Args, ReturnType>(
+  creator: WebsocketValueCreator<Args, ReturnType>
+): ResourceCacheManager<WebsocketDerivedValue<ReturnType>, Args & { wsUrl: string }> {
+  return new ResourceCacheManager({
+    constructor: (allArgs: Args & { wsUrl: string }) =>
+      creator(IndexerWebsocketManager.use(allArgs.wsUrl), allArgs),
+
+    destroyer: (instance, { wsUrl }) => {
+      instance.teardown();
+      IndexerWebsocketManager.markDone(wsUrl);
+    },
+
+    // take care - extra properties on the key will cause divergent behavior
+    //     (cache misses, unexpected new object creation, marking incorrect objects as done, etc)
+    // only ever pass the exact key type for correct behavior
+    keySerializer: (allArgs) => stableStringify(allArgs),
+
+    // this is set to just above the websocket subscribe timeout because of race conditions in the indexer backend
+    destroyDelayMs: 21000,
+  });
+}
+
+export function subscribeToWsValue<Args, ReturnType>(
+  manager: ResourceCacheManager<WebsocketDerivedValue<ReturnType>, Args & { wsUrl: string }>,
+  args: NoInfer<Args> & { wsUrl: string },
+  handleChange: (val: NoInfer<ReturnType>) => void
+): () => void {
+  const value = manager.use(args);
+  const unsub = value.subscribe(handleChange);
+  return () => {
+    unsub();
+    manager.markDone(args);
+  };
+}

--- a/src/abacus-ts/websocket/lib/indexerValueManagerHelpers.ts
+++ b/src/abacus-ts/websocket/lib/indexerValueManagerHelpers.ts
@@ -5,6 +5,9 @@ import { IndexerWebsocket } from './indexerWebsocket';
 import { IndexerWebsocketManager } from './indexerWebsocketManager';
 import { WebsocketDerivedValue } from './websocketDerivedValue';
 
+// this is set to just above the websocket subscribe timeout because of race conditions in the indexer backend
+const DESTROY_DELAY_MS = 21000;
+
 type WebsocketValueCreator<Args, ReturnType> = (
   websocket: IndexerWebsocket,
   args: Args
@@ -27,8 +30,7 @@ export function makeWsValueManager<Args, ReturnType>(
     // only ever pass the exact key type for correct behavior
     keySerializer: (allArgs) => stableStringify(allArgs),
 
-    // this is set to just above the websocket subscribe timeout because of race conditions in the indexer backend
-    destroyDelayMs: 21000,
+    destroyDelayMs: DESTROY_DELAY_MS,
   });
 }
 

--- a/src/abacus-ts/websocket/lib/reconnectingWebsocket.ts
+++ b/src/abacus-ts/websocket/lib/reconnectingWebsocket.ts
@@ -196,6 +196,8 @@ class WebSocketConnection {
         1001,
         // normal but no code
         1005,
+        // supposedly abnormal tcp failure but super super common
+        1006,
       ]);
       if (!allowedCodes.has(close.code)) {
         logAbacusTsError('WebSocketConnection', `socket ${this.id} closed abnormally`, {

--- a/src/abacus-ts/websocket/lib/websocketDerivedValue.ts
+++ b/src/abacus-ts/websocket/lib/websocketDerivedValue.ts
@@ -18,14 +18,9 @@ export class WebsocketDerivedValue<T> {
       handleBaseData: (data: any, value: T, fullMessage: any) => T;
       handleUpdates: (updates: any[], value: T, fullMessage: any) => T;
     },
-    value: T,
-    changeHandler: ((val: T) => void) | undefined
+    value: T
   ) {
     this.value = value;
-
-    if (changeHandler) {
-      this.subscribe(changeHandler);
-    }
 
     this.unsubFromWs = websocket.addChannelSubscription({
       channel: sub.channel,

--- a/src/abacus-ts/websocket/trades.ts
+++ b/src/abacus-ts/websocket/trades.ts
@@ -3,28 +3,23 @@ import { useEffect, useState } from 'react';
 import { isWsTradesResponse, isWsTradesUpdateResponses } from '@/types/indexer/indexerChecks';
 import { orderBy } from 'lodash';
 
-import { DydxNetwork } from '@/constants/networks';
-
-import { getSelectedNetwork } from '@/state/appSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketIdIfTradeable } from '@/state/perpetualsSelectors';
 
 import { mergeById } from '@/lib/mergeById';
 
 import { Loadable, loadableIdle, loadableLoaded, loadablePending } from '../lib/loadable';
-import { ResourceCacheManager } from '../lib/resourceCacheManager';
 import { TradesData } from '../rawTypes';
-import { getWebsocketUrlForNetwork } from '../socketSelectors';
+import { selectWebsocketUrl } from '../socketSelectors';
+import { makeWsValueManager, subscribeToWsValue } from './lib/indexerValueManagerHelpers';
 import { IndexerWebsocket } from './lib/indexerWebsocket';
-import { IndexerWebsocketManager } from './lib/indexerWebsocketManager';
 import { WebsocketDerivedValue } from './lib/websocketDerivedValue';
 
 const POST_LIMIT = 250;
 
-function tradesWebsocketValue(
+function tradesWebsocketValueCreator(
   websocket: IndexerWebsocket,
-  marketId: string,
-  onChange?: (val: Loadable<TradesData>) => void
+  { marketId }: { marketId: string }
 ) {
   return new WebsocketDerivedValue<Loadable<TradesData>>(
     websocket,
@@ -51,23 +46,16 @@ function tradesWebsocketValue(
         return loadableLoaded({ trades: sortedMerged.slice(0, POST_LIMIT) });
       },
     },
-    loadablePending(),
-    onChange
+    loadablePending()
   );
 }
 
-export const TradeValuesManager = new ResourceCacheManager({
-  constructor: ({ marketId, network }: { network: DydxNetwork; marketId: string }) =>
-    tradesWebsocketValue(IndexerWebsocketManager.use(getWebsocketUrlForNetwork(network)), marketId),
-  destroyer: (instance) => {
-    instance.teardown();
-  },
-  keySerializer: ({ network, marketId }) => `${network}//////${marketId}`,
-});
+export const TradeValuesManager = makeWsValueManager(tradesWebsocketValueCreator);
 
 export function useCurrentMarketTradesValue() {
-  const selectedNetwork = useAppSelector(getSelectedNetwork);
+  const wsUrl = useAppSelector(selectWebsocketUrl);
   const currentMarketId = useAppSelector(getCurrentMarketIdIfTradeable);
+
   // useSyncExternalStore is better but the API doesn't fit this use case very well
   const [trades, setTrades] = useState<Loadable<TradesData>>(loadableIdle());
 
@@ -75,17 +63,17 @@ export function useCurrentMarketTradesValue() {
     if (currentMarketId == null) {
       return () => null;
     }
-    const tradesManager = TradeValuesManager.use({
-      marketId: currentMarketId,
-      network: selectedNetwork,
-    });
-    const unsubListener = tradesManager.subscribe((val) => setTrades(val));
+
+    const unsubListener = subscribeToWsValue(
+      TradeValuesManager,
+      { wsUrl, marketId: currentMarketId },
+      (val) => setTrades(val)
+    );
 
     return () => {
       setTrades(loadableIdle());
       unsubListener();
-      TradeValuesManager.markDone({ marketId: currentMarketId, network: selectedNetwork });
     };
-  }, [selectedNetwork, currentMarketId]);
+  }, [currentMarketId, wsUrl]);
   return trades;
 }


### PR DESCRIPTION
Now we keep all subscriptions open for an extra 20 seconds to prevent churn. Before if you flipped back and forth quickly (sub, unsub, resub) you'd run into weird race conditions and break things. Now when you unsub we hold onto that subscription for 20 seconds and then destroy it. If you re-sub before destruction we just hand you back the sub we kept around. 