### PR TITLE
feat(bonsai-core): restart websocket if a message is missing for 10s

### DIFF
--- a/src/abacus-ts/websocket/lib/missingMessageDetector.ts
+++ b/src/abacus-ts/websocket/lib/missingMessageDetector.ts
@@ -1,0 +1,48 @@
+import { timeUnits } from '@/constants/time';
+
+export class MissingMessageDetector {
+  private maxSeenId: number | undefined;
+
+  private missing: {
+    [id: number]: NodeJS.Timeout;
+  } = {};
+
+  constructor(
+    private onTimeout: (messageId: number) => void,
+    private timeoutMs: number = timeUnits.second * 30
+  ) {}
+
+  insert(messageId: number): void {
+    if (this.maxSeenId == null) {
+      this.maxSeenId = messageId;
+      return;
+    }
+
+    if (messageId <= this.maxSeenId) {
+      // This is a message filling a gap OR smaller than our initial message
+      if (messageId in this.missing) {
+        clearTimeout(this.missing[messageId]);
+        delete this.missing[messageId];
+      }
+      return;
+    }
+
+    // Add missing ids between maxId and messageId
+    // eslint-disable-next-line no-plusplus
+    for (let id = this.maxSeenId + 1; id < messageId; id++) {
+      this.missing[id] = setTimeout(() => {
+        if (id in this.missing) {
+          this.onTimeout(id);
+          delete this.missing[id];
+        }
+      }, this.timeoutMs);
+    }
+
+    this.maxSeenId = messageId;
+  }
+
+  cleanup(): void {
+    Object.values(this.missing).forEach((info) => clearTimeout(info));
+    this.missing = {};
+  }
+}

--- a/src/abacus-ts/websocket/lib/missingMessageDetector.ts
+++ b/src/abacus-ts/websocket/lib/missingMessageDetector.ts
@@ -9,7 +9,7 @@ export class MissingMessageDetector {
 
   constructor(
     private onTimeout: (messageId: number) => void,
-    private timeoutMs: number = timeUnits.second * 30
+    private timeoutMs: number = timeUnits.second * 10
   ) {}
 
   insert(messageId: number): void {


### PR DESCRIPTION
Logs indicate sometimes websockets drop messages and Roy did some digging last week and found that this is indeed possible even though websockets are using TCP which shouldn't drop messages since websocket<>tcp connection isn't 1:1. 