### PR TITLE
fix: bump timeout because message_ids actually aren't in order at all

### DIFF
--- a/src/abacus-ts/websocket/lib/missingMessageDetector.ts
+++ b/src/abacus-ts/websocket/lib/missingMessageDetector.ts
@@ -9,7 +9,7 @@ export class MissingMessageDetector {
 
   constructor(
     private onTimeout: (messageId: number) => void,
-    private timeoutMs: number = timeUnits.second * 25
+    private timeoutMs: number = timeUnits.second * 30
   ) {}
 
   insert(messageId: number): void {

--- a/src/abacus-ts/websocket/lib/missingMessageDetector.ts
+++ b/src/abacus-ts/websocket/lib/missingMessageDetector.ts
@@ -9,7 +9,7 @@ export class MissingMessageDetector {
 
   constructor(
     private onTimeout: (messageId: number) => void,
-    private timeoutMs: number = timeUnits.second * 10
+    private timeoutMs: number = timeUnits.second * 25
   ) {}
 
   insert(messageId: number): void {


### PR DESCRIPTION
Turns out the backend chooses a subscribed message_id BEFORE actually doing anything so it is potentially delayed by up to 20s