### PR TITLE
feat: Add logic for deposit steps

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -48,5 +48,8 @@ export const CHAIN_INFO: { [chainId: string]: Chain } = {
 };
 
 export const EVM_DEPOSIT_CHAINS = [mainnet, base, optimism, arbitrum, polygon];
+export function isEvmDepositChainId(chainId: string) {
+  return EVM_DEPOSIT_CHAINS.map((chain) => String(chain.id)).includes(chainId);
+}
 
 export const DYDX_DEPOSIT_CHAIN = 'dydx-mainnet-1';

--- a/src/hooks/transfers/skipClient.tsx
+++ b/src/hooks/transfers/skipClient.tsx
@@ -5,15 +5,20 @@ import {
   TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT,
 } from '@dydxprotocol/v4-client-js';
 import { SkipClient } from '@skip-go/client';
+import { WalletClient } from 'viem';
+import { useWalletClient } from 'wagmi';
 
 import { getNeutronChainId, getNobleChainId, getOsmosisChainId } from '@/constants/graz';
 import { getSolanaChainId } from '@/constants/solana';
+import { WalletNetworkType } from '@/constants/wallets';
 
 import { getSelectedDydxChainId } from '@/state/appSelectors';
 import { useAppSelector } from '@/state/appTypes';
+import { SourceAccount } from '@/state/wallet';
 
 import { RPCUrlsByChainId } from '@/lib/wagmi';
 
+import { useAccounts } from '../useAccounts';
 import { useDydxClient } from '../useDydxClient';
 import { useEndpointsConfig } from '../useEndpointsConfig';
 
@@ -33,6 +38,9 @@ const useSkipClientContext = () => {
     useEndpointsConfig();
   const { compositeClient } = useDydxClient();
   const selectedDydxChainId = useAppSelector(getSelectedDydxChainId);
+  const { sourceAccount } = useAccounts();
+  const { data: walletClient } = useWalletClient();
+
   const { skipClient, skipInstanceId } = useMemo(
     () => ({
       skipClient: new SkipClient({
@@ -49,6 +57,7 @@ const useSkipClientContext = () => {
             throw new Error(`Error: no rpc endpoint found for chainId: ${chainId}`);
           },
         },
+        getEVMSigner: async () => getEVMSigner(walletClient, sourceAccount),
         registryTypes: [[TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT, MsgWithdrawFromSubaccount]],
       }),
       skipInstanceId: crypto.randomUUID(),
@@ -60,8 +69,25 @@ const useSkipClientContext = () => {
       osmosisValidator,
       selectedDydxChainId,
       solanaRpcUrl,
+      sourceAccount,
       validators,
+      walletClient,
     ]
   );
   return { skipClient, skipInstanceId };
+};
+
+const getEVMSigner = async (
+  walletClient: WalletClient | undefined,
+  sourceAccount: SourceAccount
+) => {
+  if (!sourceAccount.walletInfo || sourceAccount.chain !== WalletNetworkType.Evm) {
+    throw new Error('Wallet is not evm');
+  }
+
+  if (!walletClient) {
+    throw new Error('wallet not connected');
+  }
+
+  return Promise.resolve(walletClient);
 };

--- a/src/lib/viem.ts
+++ b/src/lib/viem.ts
@@ -1,0 +1,27 @@
+import { createPublicClient, http } from 'viem';
+import { arbitrum, base, mainnet, optimism, polygon } from 'viem/chains';
+
+import { ChainId, getAlchemyRPCUrlForChainId } from './wagmi';
+
+export const VIEM_PUBLIC_CLIENTS = {
+  [mainnet.id]: createPublicClient({
+    chain: mainnet,
+    transport: http(getAlchemyRPCUrlForChainId(ChainId.ETH_MAINNET)),
+  }),
+  [base.id]: createPublicClient({
+    chain: base,
+    transport: http(getAlchemyRPCUrlForChainId(ChainId.BASE_MAINNET)),
+  }),
+  [arbitrum.id]: createPublicClient({
+    chain: arbitrum,
+    transport: http(getAlchemyRPCUrlForChainId(ChainId.ARB_MAINNET)),
+  }),
+  [optimism.id]: createPublicClient({
+    chain: optimism,
+    transport: http(getAlchemyRPCUrlForChainId(ChainId.OPT_MAINNET)),
+  }),
+  [polygon.id]: createPublicClient({
+    chain: polygon,
+    transport: http(getAlchemyRPCUrlForChainId(ChainId.POLYGON_MAINNET)),
+  }),
+} as const;

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -94,7 +94,7 @@ const WAGMI_SUPPORTED_CHAINS: Chain[] = [
   kava,
 ];
 
-enum ChainId {
+export enum ChainId {
   ETH_MAINNET = '1',
   ETH_SEPOLIA = '11155111',
   POLYGON_MAINNET = '137',
@@ -107,7 +107,7 @@ enum ChainId {
   BASE_SEPOLIA = '84532',
 }
 
-const getAlchemyRPCUrlForChainId = (chainId: ChainId) => {
+export const getAlchemyRPCUrlForChainId = (chainId: ChainId) => {
   const alchemyKey = import.meta.env.VITE_ALCHEMY_API_KEY;
   if (!alchemyKey) return undefined;
   switch (chainId) {

--- a/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
@@ -75,16 +75,17 @@ export const DepositDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>) 
   const { skipClient } = useSkipClient();
 
   useEffect(() => {
-    if (!broadcastedTx) return;
+    async function waitForConfirmation() {
+      if (!broadcastedTx) return;
 
-    skipClient.waitForTransaction({
-      chainID: broadcastedTx.chainId,
-      txHash: broadcastedTx.txHash,
-      onTransactionTracked: async (txInfo) => {
-        console.log('explorer link', txInfo.explorerLink);
-        setTxConfirmed(true);
-      },
-    });
+      await skipClient.waitForTransaction({
+        chainID: broadcastedTx.chainId,
+        txHash: broadcastedTx.txHash,
+      });
+      setTxConfirmed(true);
+    }
+
+    waitForConfirmation();
   }, [broadcastedTx, skipClient]);
 
   return (
@@ -98,8 +99,9 @@ export const DepositDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>) 
       title={<div tw="text-center">{dialogTitle}</div>}
       placement={DialogPlacement.Default}
     >
-      {broadcastedTx && !txConfirmed && <div>Your transaction is pending...</div>}
-      {broadcastedTx && txConfirmed && <div>DONE!</div>}
+      {/* TODO(deposit2.0): Implement real progress UI here */}
+      {broadcastedTx && !txConfirmed && <div tw="flex h-10">Your deposit is pending...</div>}
+      {broadcastedTx && txConfirmed && <div tw="flex h-10">DONE!!</div>}
       {!broadcastedTx && (
         <div tw="w-[100%] overflow-hidden">
           <div tw="flex w-[200%]">

--- a/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
@@ -74,6 +74,7 @@ export const DepositDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>) 
 
   const { skipClient } = useSkipClient();
 
+  // TODO(deposit2.0): Move transaction status tracking to global scope so user can exit the modal
   useEffect(() => {
     async function waitForConfirmation() {
       if (!broadcastedTx) return;

--- a/src/views/dialogs/DepositDialog2/DepositForm.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositForm.tsx
@@ -184,6 +184,7 @@ export const DepositForm = ({
                 <div>
                   {i + 1}. {step.type}
                 </div>
+                {/* TODO(deposit2.0): handle solana and cosmos signer here too */}
                 <button type="button" onClick={() => step.executeStep(walletClient, skipClient)}>
                   Do step
                 </button>

--- a/src/views/dialogs/DepositDialog2/DepositForm.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositForm.tsx
@@ -1,13 +1,16 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 
 import { formatUnits, parseUnits } from 'viem';
+import { useChainId, useSwitchChain } from 'wagmi';
 
 import { ButtonAction, ButtonType } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { TokenForTransfer, USDC_DECIMALS } from '@/constants/tokens';
+import { WalletNetworkType } from '@/constants/wallets';
 
-import { SkipRouteSpeed } from '@/hooks/transfers/skipClient';
+import { SkipRouteSpeed, useSkipClient } from '@/hooks/transfers/skipClient';
+import { useAccounts } from '@/hooks/useAccounts';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -22,7 +25,7 @@ import { openDialog } from '@/state/dialogs';
 import { AmountInput } from './AmountInput';
 import { RouteOptions } from './RouteOptions';
 import { useBalance, useDepositRoutes } from './queries';
-import { getTokenSymbol } from './utils';
+import { getTokenSymbol, getUserAddressesForRoute } from './utils';
 
 export const DepositForm = ({
   onTokenSelect,
@@ -30,16 +33,20 @@ export const DepositForm = ({
   setAmount,
   token,
   onClose,
+  onDeposit,
 }: {
   onTokenSelect: () => void;
   amount: string;
   setAmount: Dispatch<SetStateAction<string>>;
   token: TokenForTransfer;
   onClose: () => void;
+  onDeposit: ({ txHash, chainId }: { txHash: string; chainId: string }) => void;
 }) => {
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
   const tokenBalance = useBalance(token.chainId, token.denom);
+  const { skipClient } = useSkipClient();
+  const walletChainId = useChainId();
 
   const [selectedSpeed, setSelectedSpeed] = useState<SkipRouteSpeed>('fast');
   const debouncedAmount = useDebounce(amount);
@@ -56,6 +63,23 @@ export const DepositForm = ({
 
   const selectedRoute = selectedSpeed === 'fast' ? routes?.fast : routes?.slow;
   const depositRoute = !isPlaceholderData ? selectedRoute : undefined;
+  console.log('depositRoute', depositRoute);
+
+  const { sourceAccount, dydxAddress, nobleAddress } = useAccounts();
+  const onCorrectChain = useMemo(() => {
+    // Solana and Keplr wallets don't need to switch chains
+    if (sourceAccount.chain !== WalletNetworkType.Evm) return true;
+
+    return String(walletChainId) === token.chainId;
+  }, [sourceAccount.chain, token.chainId, walletChainId]);
+
+  const [awaitingWalletAction, setAwaitingWalletAction] = useState(false);
+  const { switchChainAsync } = useSwitchChain();
+  const onSwitchChain = async () => {
+    setAwaitingWalletAction(true);
+    await switchChainAsync({ chainId: Number(token.chainId) });
+    setAwaitingWalletAction(false);
+  };
 
   const hasSufficientBalance = depositRoute
     ? tokenBalance.raw && BigInt(depositRoute.amountIn) <= BigInt(tokenBalance.raw)
@@ -75,9 +99,58 @@ export const DepositForm = ({
           <div>Min deposit is $10</div>
         </div>
       );
+    if (awaitingWalletAction) return `Continue in wallet...`;
+    if (!depositDisabled && !onCorrectChain) return `Switch network`;
 
     return stringGetter({ key: STRING_KEYS.DEPOSIT_FUNDS });
-  }, [error, hasSufficientBalance, stringGetter, token.denom]);
+  }, [
+    awaitingWalletAction,
+    depositDisabled,
+    error,
+    hasSufficientBalance,
+    onCorrectChain,
+    stringGetter,
+    token.denom,
+  ]);
+
+  const onDepositClick = async () => {
+    if (depositDisabled) return;
+
+    setAwaitingWalletAction(true);
+    const userAddresses = getUserAddressesForRoute(
+      depositRoute,
+      sourceAccount,
+      nobleAddress,
+      dydxAddress
+    );
+
+    try {
+      await skipClient.executeRoute({
+        // TODO(deposit2.0): add custom slippageTolerancePercentage here too;
+        route: depositRoute,
+        userAddresses,
+        onApproveAllowance: async ({ status }) => {
+          console.log('allowance approved', status);
+        },
+        onValidateGasBalance: async ({ txIndex, status }) => {
+          console.log('onValidateGasBalance', txIndex, status);
+        },
+        onTransactionTracked: async ({ txHash, explorerLink }) => {
+          console.log('onTransactionTracked', txHash, explorerLink);
+        },
+        onTransactionSigned: async ({ chainID }) => {
+          console.log('onTransactionSigned', chainID);
+        },
+        // TODO(deposit2.0): also handle onApproveAllowance here
+        onTransactionBroadcast: async ({ txHash, chainID }) => {
+          console.log('onTransactionBroadcast', txHash);
+          onDeposit({ txHash, chainId: chainID });
+        },
+      });
+    } catch (e) {
+      setAwaitingWalletAction(false);
+    }
+  };
 
   return (
     <div tw="flex min-h-10 flex-col gap-2 p-1.25">
@@ -125,6 +198,7 @@ export const DepositForm = ({
       <div tw="flex flex-col gap-0.5">
         <Button
           tw="w-full"
+          onClick={onCorrectChain ? onDepositClick : onSwitchChain}
           state={{ isDisabled: depositDisabled, isLoading: isFetching }}
           disabled={depositDisabled}
           action={ButtonAction.Primary}

--- a/src/views/dialogs/DepositDialog2/utils.ts
+++ b/src/views/dialogs/DepositDialog2/utils.ts
@@ -1,11 +1,22 @@
-import { RouteResponse, UserAddress } from '@skip-go/client';
+import { OfflineSigner } from '@cosmjs/proto-signing';
+import { ERC20Approval, RouteResponse, SkipClient, UserAddress } from '@skip-go/client';
+import { useQuery } from '@tanstack/react-query';
+import { Address, maxUint256, WalletClient } from 'viem';
+import { useChainId } from 'wagmi';
 
+import ERC20ABI from '@/abi/erc20.json';
 import { DYDX_DEPOSIT_CHAIN, isEvmDepositChainId } from '@/constants/chains';
 import { CosmosChainId } from '@/constants/graz';
 import { SOLANA_MAINNET_ID } from '@/constants/solana';
+import { TokenForTransfer } from '@/constants/tokens';
 import { WalletNetworkType } from '@/constants/wallets';
 
+import { useSkipClient } from '@/hooks/transfers/skipClient';
+import { useAccounts } from '@/hooks/useAccounts';
+
 import { SourceAccount } from '@/state/wallet';
+
+import { VIEM_PUBLIC_CLIENTS } from '@/lib/viem';
 
 // Because our deposit flow only supports ETH and USDC
 export function getTokenSymbol(denom: string) {
@@ -52,4 +63,178 @@ export function getUserAddressesForRoute(
         throw new Error(`unhandled chainId ${chainId} for user address ${sourceAccount.address}`);
     }
   });
+}
+
+export type DepositStep =
+  | {
+      type: 'network' | 'approve';
+      executeStep: (signer: WalletClient) => Promise<boolean>;
+    }
+  | {
+      type: 'deposit';
+      // TODO(deposit2.0): add solana signer type support too;
+      executeStep: (
+        signer: WalletClient | OfflineSigner,
+        skipClient: SkipClient
+      ) => Promise<boolean>;
+    };
+
+// Prepares all the steps the user needs to take in their wallet to complete their deposit
+export function useDepositSteps({
+  sourceAccount,
+  depositToken,
+  depositRoute,
+  onDeposit,
+}: {
+  sourceAccount: SourceAccount;
+  depositToken: TokenForTransfer;
+  depositRoute?: RouteResponse;
+  onDeposit: ({ txHash, chainId }: { txHash: string; chainId: string }) => void;
+}) {
+  const walletChainId = useChainId();
+  const { skipClient } = useSkipClient();
+  const { nobleAddress, dydxAddress } = useAccounts();
+
+  async function getStepsQuery() {
+    if (!depositRoute || !sourceAccount.address) return [];
+
+    const steps: DepositStep[] = [];
+
+    /* ----- 1. Switch network in wallet -------- */
+    if (
+      // Solana and Keplr wallets dont need to 'switch network'
+      sourceAccount.chain === WalletNetworkType.Evm &&
+      String(walletChainId) !== depositToken.chainId
+    ) {
+      steps.push({
+        type: 'network',
+        executeStep: async (signer: WalletClient) => {
+          try {
+            await signer.switchChain({ id: Number(depositToken.chainId) });
+            return true;
+          } catch (e) {
+            return false;
+          }
+        },
+      });
+    }
+
+    /* ----- 2. Token allowance checks -------- */
+    // Only evm tokens may need token allowance checks
+    const userAddresses = getUserAddressesForRoute(
+      depositRoute,
+      sourceAccount,
+      nobleAddress,
+      dydxAddress
+    );
+
+    if (isEvmDepositChainId(depositToken.chainId)) {
+      const messages = await skipClient.messages({
+        ...depositRoute,
+        amountOut: depositRoute.estimatedAmountOut ?? '0',
+        addressList: userAddressHelper(depositRoute, userAddresses),
+      });
+
+      let approvalMaybeNeeded: (ERC20Approval & { chainId: string }) | undefined;
+      for (let i = 0; i < messages.txs.length; i += 1) {
+        const tx = messages.txs[i];
+        if (tx && 'evmTx' in tx && tx.evmTx.requiredERC20Approvals.length) {
+          approvalMaybeNeeded = {
+            ...tx.evmTx.requiredERC20Approvals[0]!,
+            chainId: tx.evmTx.chainID,
+          };
+        }
+      }
+
+      if (approvalMaybeNeeded) {
+        const viemClient =
+          VIEM_PUBLIC_CLIENTS[
+            Number(approvalMaybeNeeded.chainId) as keyof typeof VIEM_PUBLIC_CLIENTS
+          ];
+        const allowance = (await viemClient.readContract({
+          abi: ERC20ABI,
+          address: approvalMaybeNeeded.tokenContract as Address,
+          functionName: 'allowance',
+          args: [sourceAccount.address, approvalMaybeNeeded.spender],
+        })) as bigint;
+
+        if (BigInt(allowance) < BigInt(approvalMaybeNeeded.amount)) {
+          steps.push({
+            type: 'approve',
+            executeStep: async (signer: WalletClient) => {
+              try {
+                const txHash = await signer.writeContract({
+                  account: sourceAccount.address as Address,
+                  address: approvalMaybeNeeded.tokenContract as Address,
+                  abi: ERC20ABI,
+                  functionName: 'approve',
+                  args: [approvalMaybeNeeded.spender as Address, maxUint256],
+                  chain: signer.chain,
+                });
+                const receipt = await viemClient.waitForTransactionReceipt({ hash: txHash });
+                // TODO future improvement: also check to see if approval amount is sufficient here
+                return receipt.status === 'success';
+              } catch (e) {
+                return false;
+              }
+            },
+          });
+        }
+      }
+    }
+
+    /* ----- 3. Actual deposit transaction -------- */
+    steps.push({
+      type: 'deposit',
+      // TODO(deposit2.0): Update .executeRoute call here once the SDK allows passing in the updated signer object
+      // passing in updatedSkipClient is hack until that is available
+      executeStep: async (_: unknown, updatedSkipClient: SkipClient) => {
+        try {
+          await updatedSkipClient.executeRoute({
+            route: depositRoute,
+            userAddresses,
+            // TODO(deposit2.0): add custom slippage tolerance here
+            onTransactionBroadcast: async ({ txHash, chainID }) => {
+              onDeposit({ txHash, chainId: chainID });
+            },
+          });
+          return true;
+        } catch (e) {
+          return false;
+        }
+      },
+    });
+
+    return steps;
+  }
+
+  return useQuery({
+    queryKey: [
+      'skip-deposit-steps',
+      sourceAccount.address,
+      depositRoute?.amountIn,
+      depositRoute?.sourceAssetChainID,
+      depositRoute?.sourceAssetDenom,
+    ],
+    queryFn: getStepsQuery,
+  });
+}
+
+// Copied from Skip https://github.com/skip-mev/skip-go/blob/147937416c81a69a447f4825b8c86806c5688194/packages/client/src/client.ts#L319
+function userAddressHelper(route: RouteResponse, userAddresses: UserAddress[]) {
+  let addressList: string[] = [];
+  let i = 0;
+  for (let j = 0; j < userAddresses.length; j += 1) {
+    if (route.requiredChainAddresses[i] !== userAddresses[j]?.chainID) {
+      i = j;
+      continue;
+    }
+    addressList.push(userAddresses[j]!.address!);
+    i += 1;
+  }
+
+  if (addressList.length !== route.requiredChainAddresses.length) {
+    addressList = userAddresses.map((x) => x.address);
+  }
+  return addressList;
 }

--- a/src/views/dialogs/DepositDialog2/utils.ts
+++ b/src/views/dialogs/DepositDialog2/utils.ts
@@ -1,3 +1,12 @@
+import { RouteResponse, UserAddress } from '@skip-go/client';
+
+import { DYDX_DEPOSIT_CHAIN, isEvmDepositChainId } from '@/constants/chains';
+import { CosmosChainId } from '@/constants/graz';
+import { SOLANA_MAINNET_ID } from '@/constants/solana';
+import { WalletNetworkType } from '@/constants/wallets';
+
+import { SourceAccount } from '@/state/wallet';
+
 // Because our deposit flow only supports ETH and USDC
 export function getTokenSymbol(denom: string) {
   if (denom === 'polygon-native') {
@@ -11,4 +20,36 @@ export function getTokenSymbol(denom: string) {
 
 export function isNativeTokenDenom(denom: string) {
   return denom.endsWith('native');
+}
+
+export function getUserAddressesForRoute(
+  route: RouteResponse,
+  sourceAccount: SourceAccount,
+  nobleAddress?: string,
+  dydxAddress?: string
+): UserAddress[] {
+  const chains = route.requiredChainAddresses;
+
+  return chains.map((chainId) => {
+    switch (chainId) {
+      case CosmosChainId.Noble:
+        if (!nobleAddress) throw new Error('nobleAddress undefined');
+        return { chainID: chainId, address: nobleAddress };
+      case CosmosChainId.Osmosis:
+        // TODO(deposit2.0): handle osmosis case!
+        return { chainID: chainId, address: 'osmo1c2jm54xlan3jjfdxeggv7rm3905sscxjr2gtn5' };
+      case DYDX_DEPOSIT_CHAIN:
+        if (!dydxAddress) throw new Error('dydxAddress undefined');
+        return { chainID: chainId, address: dydxAddress };
+      default:
+        if (
+          (isEvmDepositChainId(chainId) && sourceAccount.chain === WalletNetworkType.Evm) ||
+          (chainId === SOLANA_MAINNET_ID && sourceAccount.chain === SOLANA_MAINNET_ID)
+        ) {
+          return { chainID: chainId, address: sourceAccount.address as string };
+        }
+
+        throw new Error(`unhandled chainId ${chainId} for user address ${sourceAccount.address}`);
+    }
+  });
 }


### PR DESCRIPTION
UI IS STILL UGLY!

this PR adds logic for preparing the different steps that the user will need to take in order for their deposit to complete. the bulk of the logic is in `src/views/dialogs/DepositDialog2/utils.ts`

note this is mostly just relevant for evm users, since solana/keplr dont really have concept of switching chains or token approvals.
