### PR TITLE
chore(funkit): bump funkit version 4.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@dydxprotocol/v4-localization": "^1.1.259",
     "@dydxprotocol/v4-proto": "^7.0.0-dev.0",
     "@emotion/is-prop-valid": "^1.3.0",
-    "@funkit/connect": "^4.1.6",
+    "@funkit/connect": "^4.1.7",
     "@hugocxl/react-to-image": "^0.0.9",
     "@js-joda/core": "^5.5.3",
     "@keplr-wallet/types": "^0.12.121",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^1.3.0
     version: 1.3.0
   '@funkit/connect':
-    specifier: ^4.1.6
-    version: 4.1.6(@tanstack/react-query@5.37.1)(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.7.2)(viem@2.17.0)(wagmi@2.10.9)
+    specifier: ^4.1.7
+    version: 4.1.7(@tanstack/react-query@5.37.1)(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.7.2)(viem@2.17.0)(wagmi@2.10.9)
   '@hugocxl/react-to-image':
     specifier: ^0.0.9
     version: 0.0.9(html-to-image@1.11.11)(react@18.2.0)
@@ -4403,8 +4403,8 @@ packages:
       viem: 2.17.0(typescript@5.7.2)
     dev: false
 
-  /@funkit/connect@4.1.6(@tanstack/react-query@5.37.1)(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.7.2)(viem@2.17.0)(wagmi@2.10.9):
-    resolution: {integrity: sha512-Cn3HM+or9yQRIEAaGTvTyYNAb7joIcWpynDmgrkjdIqgZedHOEIr1iQd9d6HN8+pSw4j0V8YW/3ApuBADvAHiQ==}
+  /@funkit/connect@4.1.7(@tanstack/react-query@5.37.1)(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.7.2)(viem@2.17.0)(wagmi@2.10.9):
+    resolution: {integrity: sha512-bM6adjE+BmKqvMxowwin797WU4aTsah5iq8sexgT640M3bRVCkKcDAKrwnTb7LIAXJtkzztD/MDdieSmYWW+/g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'


### PR DESCRIPTION
# Funkit <> dYdX Integration

Bump `@funkit/connect` from `v4.1.6` -> `v4.1.7`. See [CHANGELOG.md](https://www.npmjs.com/package/@funkit/connect?activeTab=code) for version changes. 
 - Key callout: Binance flow improvements

--- 

[Connect wallet] option no longer shows up if underlying wagmi connection is dropped (e.g. pure solana wallet connected or user deliberately disconnect via MM & not dydx)


<img width="1453" alt="image" src="https://github.com/user-attachments/assets/5c8b9351-7362-4fa3-9042-18d77e939683" />
