### PR TITLE
feat(bonsai-core): orderbook

### DIFF
--- a/src/abacus-ts/calculators/orderbook.ts
+++ b/src/abacus-ts/calculators/orderbook.ts
@@ -1,22 +1,136 @@
-import { OrderbookData } from '../types/rawTypes';
-import { OrderbookProcessedData } from '../types/summaryTypes';
+import { isTruthy } from '@/lib/isTruthy';
+import { MustBigNumber } from '@/lib/numbers';
+import { objectEntries } from '@/lib/objectHelpers';
 
-export const calculateOrderbook = (
-  orderbook: OrderbookData,
-  groupingMultiplier: number
-): OrderbookProcessedData => {
+import { OrderbookData } from '../types/rawTypes';
+import { OrderbookLine, OrderbookProcessedData } from '../types/summaryTypes';
+
+export const calculateOrderbook = ({
+  orderbook,
+  _groupingMultiplier = undefined,
+}: {
+  orderbook: OrderbookData | undefined;
+  _groupingMultiplier?: number;
+}): OrderbookProcessedData | undefined => {
+  if (orderbook == null) {
+    return undefined;
+  }
+
   const { asks, bids } = orderbook;
 
-  // Sort by price level and un-cross orderbook
-  const groupedAsks = groupOrders(asks, groupingMultiplier);
-  const groupedBids = groupOrders(bids, groupingMultiplier);
+  /**
+   * 1. Process raw orderbook data
+   * 2. filter out lines with size <= 0
+   * 3. sort by price
+   */
+  const asksBase: Omit<OrderbookLine, 'depth' | 'depthCost'>[] = objectEntries(asks)
+    .map(mapRawOrderbookLine)
+    .filter(isTruthy)
+    .sort((a, b) => a.price - b.price);
 
-  // multiply by groupingMultiplier
+  const bidsBase: Omit<OrderbookLine, 'depth' | 'depthCost'>[] = objectEntries(bids)
+    .map(mapRawOrderbookLine)
+    .filter(isTruthy)
+    .sort((a, b) => a.price - b.price);
+
+  // calculate depth and depthCost
+  const asksComposite = calculateDepthAndDepthCost(asksBase);
+  const bidsComposite = calculateDepthAndDepthCost(bidsBase);
+
+  // un-cross orderbook
+  const uncrossedBook: { asks: OrderbookLine[]; bids: OrderbookLine[] } = uncrossOrderbook(
+    asksComposite,
+    bidsComposite
+  );
+
+  // calculate midPrice, spread, and spreadPercent
+  const lowestAsk = uncrossedBook.asks.at(0);
+  const highestBid = uncrossedBook.bids.at(-1);
+  const midPrice = lowestAsk && highestBid && (lowestAsk.price + highestBid.price) / 2;
+  const spread = lowestAsk && highestBid && lowestAsk.price - highestBid.price;
+  const spreadPercent = spread && midPrice && (spread / midPrice) * 100;
+
+  // TODO: multiply by groupingMultiplier
 
   return {
-    asks: groupedAsks,
-    bids: groupedBids,
-    spread: 0,
-    spreadPercent: 0,
+    ...uncrossedBook,
+    midPrice,
+    spread,
+    spreadPercent,
   };
 };
+
+function uncrossOrderbook(asks: OrderbookLine[], bids: OrderbookLine[]) {
+  if (asks.length === 0 || bids.length === 0) {
+    return { asks, bids };
+  }
+
+  const asksCopy = [...asks];
+  const bidsCopy = [...bids];
+
+  let ask = asksCopy.at(-1);
+  let bid = bidsCopy.at(0);
+
+  while (ask && bid && isCrossed(ask, bid)) {
+    if (ask.offset === bid.offset) {
+      // If offsets are the same, give precedence to the larger size. In this case,
+      // one of the sizes "should" be zero, but we simply check for the larger size.
+      if (ask.size > bid.size) {
+        // remove the bid
+        bid = bidsCopy.pop();
+      } else {
+        // remove the ask
+        ask = asksCopy.shift();
+      }
+    } else {
+      // If offsets are different, remove the older offset.
+      if (ask.offset < bid.offset) {
+        // remove the ask
+        ask = asksCopy.shift();
+      } else {
+        // remove the bid
+        bid = bidsCopy.pop();
+      }
+    }
+  }
+
+  return { asks: asksCopy, bids: bidsCopy };
+}
+
+function calculateDepthAndDepthCost(lines: Omit<OrderbookLine, 'depth' | 'depthCost'>[]) {
+  let depth = 0;
+  let depthCost = 0;
+
+  return lines.map((line) => {
+    depth += line.size;
+    depthCost += line.sizeCost;
+
+    return {
+      ...line,
+      depth,
+      depthCost,
+    };
+  });
+}
+
+function mapRawOrderbookLine(rawOrderbookLineEntry: [string, { size: string; offset: number }]) {
+  const [price, { size, offset }] = rawOrderbookLineEntry;
+  const sizeBN = MustBigNumber(size);
+  const priceBN = MustBigNumber(price);
+
+  if (sizeBN.isZero()) return undefined;
+
+  return {
+    price: priceBN.toNumber(),
+    size: sizeBN.toNumber(),
+    sizeCost: priceBN.times(sizeBN).toNumber(),
+    offset,
+  };
+}
+
+function isCrossed(
+  ask: Omit<OrderbookLine, 'depth' | 'depthCost'>,
+  bid: Omit<OrderbookLine, 'depth' | 'depthCost'>
+) {
+  return ask.price <= bid.price;
+}

--- a/src/abacus-ts/calculators/orderbook.ts
+++ b/src/abacus-ts/calculators/orderbook.ts
@@ -1,0 +1,22 @@
+import { OrderbookData } from '../types/rawTypes';
+import { OrderbookProcessedData } from '../types/summaryTypes';
+
+export const calculateOrderbook = (
+  orderbook: OrderbookData,
+  groupingMultiplier: number
+): OrderbookProcessedData => {
+  const { asks, bids } = orderbook;
+
+  // Sort by price level and un-cross orderbook
+  const groupedAsks = groupOrders(asks, groupingMultiplier);
+  const groupedBids = groupOrders(bids, groupingMultiplier);
+
+  // multiply by groupingMultiplier
+
+  return {
+    asks: groupedAsks,
+    bids: groupedBids,
+    spread: 0,
+    spreadPercent: 0,
+  };
+};

--- a/src/abacus-ts/ontology.ts
+++ b/src/abacus-ts/ontology.ts
@@ -36,6 +36,10 @@ import {
   selectRawValidatorHeightDataLoading,
 } from './selectors/base';
 import {
+  selectCurrentMarketOrderbookData,
+  selectCurrentMarketOrderbookLoading,
+} from './selectors/markets';
+import {
   selectAllMarketSummaries,
   selectAllMarketSummariesLoading,
   selectCurrentMarketInfo,
@@ -102,6 +106,10 @@ export const BonsaiHelpers = {
     marketInfo: selectCurrentMarketInfo,
     // marketInfo but with only the properties that rarely change, for fewer rerenders
     stableMarketInfo: selectCurrentMarketInfoStable,
+    orderbook: {
+      data: selectCurrentMarketOrderbookData,
+      loading: selectCurrentMarketOrderbookLoading,
+    },
     account: {
       openOrders: selectCurrentMarketOpenOrders,
       orderHistory: selectCurrentMarketOrderHistory,

--- a/src/abacus-ts/selectors/base.ts
+++ b/src/abacus-ts/selectors/base.ts
@@ -10,6 +10,7 @@ export const selectRawAssetsData = (state: RootState) => state.raw.markets.asset
 export const selectRawAssets = (state: RootState) => state.raw.markets.assets;
 export const selectRawSparklines = (state: RootState) => state.raw.markets.sparklines;
 export const selectRawSparklinesData = (state: RootState) => state.raw.markets.sparklines.data;
+export const selectRawOrderbooks = (state: RootState) => state.raw.markets.orderbooks;
 
 export const selectRawParentSubaccount = (state: RootState) => state.raw.account.parentSubaccount;
 export const selectRawParentSubaccountData = (state: RootState) =>

--- a/src/abacus-ts/selectors/markets.ts
+++ b/src/abacus-ts/selectors/markets.ts
@@ -1,8 +1,15 @@
 import { createAppSelector } from '@/state/appTypes';
+import { getCurrentMarketId } from '@/state/perpetualsSelectors';
 
 import { calculateAllMarkets, formatSparklineData } from '../calculators/markets';
+import { calculateOrderbook } from '../calculators/orderbook';
 import { mergeLoadableStatus } from '../lib/mapLoadable';
-import { selectRawMarketsData, selectRawSparklines, selectRawSparklinesData } from './base';
+import {
+  selectRawMarketsData,
+  selectRawOrderbooks,
+  selectRawSparklines,
+  selectRawSparklinesData,
+} from './base';
 
 export const selectAllMarketsInfo = createAppSelector([selectRawMarketsData], (markets) =>
   calculateAllMarkets(markets)
@@ -15,4 +22,23 @@ export const selectSparklinesLoading = createAppSelector(
 
 export const selectSparkLinesData = createAppSelector([selectRawSparklinesData], (sparklines) =>
   formatSparklineData(sparklines)
+);
+
+export const selectCurrentMarketOrderbookLoading = createAppSelector(
+  [selectRawOrderbooks, getCurrentMarketId],
+  (rawOrderbooks, currentMarketId) =>
+    currentMarketId && rawOrderbooks[currentMarketId]
+      ? mergeLoadableStatus(rawOrderbooks[currentMarketId])
+      : 'pending'
+);
+
+export const selectCurrentMarketOrderbook = createAppSelector(
+  [selectRawOrderbooks, getCurrentMarketId, (_s, groupingMultiplier: number) => groupingMultiplier],
+  (rawOrderbooks, currentMarketId, groupingMultiplier) => {
+    if (!currentMarketId || !rawOrderbooks[currentMarketId]?.data) {
+      return undefined;
+    }
+
+    return calculateOrderbook(rawOrderbooks[currentMarketId].data, groupingMultiplier);
+  }
 );

--- a/src/abacus-ts/selectors/markets.ts
+++ b/src/abacus-ts/selectors/markets.ts
@@ -24,21 +24,38 @@ export const selectSparkLinesData = createAppSelector([selectRawSparklinesData],
   formatSparklineData(sparklines)
 );
 
-export const selectCurrentMarketOrderbookLoading = createAppSelector(
-  [selectRawOrderbooks, getCurrentMarketId],
-  (rawOrderbooks, currentMarketId) =>
-    currentMarketId && rawOrderbooks[currentMarketId]
-      ? mergeLoadableStatus(rawOrderbooks[currentMarketId])
-      : 'pending'
-);
-
 export const selectCurrentMarketOrderbook = createAppSelector(
-  [selectRawOrderbooks, getCurrentMarketId, (_s, groupingMultiplier: number) => groupingMultiplier],
-  (rawOrderbooks, currentMarketId, groupingMultiplier) => {
-    if (!currentMarketId || !rawOrderbooks[currentMarketId]?.data) {
+  [selectRawOrderbooks, getCurrentMarketId],
+  (rawOrderbooks, currentMarketId) => {
+    if (!currentMarketId || !rawOrderbooks[currentMarketId]) {
       return undefined;
     }
 
-    return calculateOrderbook(rawOrderbooks[currentMarketId].data, groupingMultiplier);
+    return rawOrderbooks[currentMarketId];
+  }
+);
+
+export const selectCurrentMarketOrderbookLoading = createAppSelector(
+  [selectCurrentMarketOrderbook],
+  (currentMarketOrderbook) =>
+    currentMarketOrderbook ? mergeLoadableStatus(currentMarketOrderbook) : 'pending'
+);
+
+export const selectCurrentMarketOrderbookData = createAppSelector(
+  [selectCurrentMarketOrderbook],
+  (currentMarketOrderbook) => calculateOrderbook({ orderbook: currentMarketOrderbook?.data })
+);
+
+export const createSelectCurrentMarketOrderbook = createAppSelector(
+  [selectCurrentMarketOrderbook, (_s, groupingMultiplier?: number) => groupingMultiplier],
+  (currentMarketOrderbook, groupingMultiplier) => {
+    if (currentMarketOrderbook?.data == null) {
+      return undefined;
+    }
+
+    return calculateOrderbook({
+      orderbook: currentMarketOrderbook.data,
+      _groupingMultiplier: groupingMultiplier,
+    });
   }
 );

--- a/src/abacus-ts/types/rawTypes.ts
+++ b/src/abacus-ts/types/rawTypes.ts
@@ -15,8 +15,8 @@ export type MarketsData = { [marketId: string]: IndexerWsBaseMarketObject };
 export type OrdersData = { [orderId: string]: IndexerCompositeOrderObject };
 
 export type OrderbookData = {
-  bids: { [price: string]: string };
-  asks: { [price: string]: string };
+  bids: { [price: string]: { size: string; offset: number } };
+  asks: { [price: string]: { size: string; offset: number } };
 };
 
 export interface ParentSubaccountData {

--- a/src/abacus-ts/types/summaryTypes.ts
+++ b/src/abacus-ts/types/summaryTypes.ts
@@ -274,6 +274,7 @@ export type OrderbookLine = {
 export type OrderbookProcessedData = {
   asks: OrderbookLine[];
   bids: OrderbookLine[];
+  midPrice: number | undefined;
   spread: number | undefined;
   spreadPercent: number | undefined;
 };

--- a/src/abacus-ts/types/summaryTypes.ts
+++ b/src/abacus-ts/types/summaryTypes.ts
@@ -248,3 +248,19 @@ export type ConfigTiers = {
   feeTiers: FeeTiers | undefined;
   equityTiers: EquityTiers | undefined;
 };
+
+export type OrderbookLine = {
+  price: number;
+  size: number;
+  depth: number;
+  sizeCost: number;
+  depthCost: number;
+  offset: number;
+};
+
+export type OrderbookProcessedData = {
+  asks: OrderbookLine[];
+  bids: OrderbookLine[];
+  spread: number | undefined;
+  spreadPercent: number | undefined;
+};

--- a/src/types/indexer/indexerChecks.ts
+++ b/src/types/indexer/indexerChecks.ts
@@ -13,6 +13,8 @@ import {
   IndexerWsCandleResponse,
   IndexerWsCandleResponseObject,
   IndexerWsMarketUpdateResponse,
+  IndexerWsOrderbookChannelBatchDataMessage,
+  IndexerWsOrderbookSubscribedMessage,
   IndexerWsOrderbookUpdateResponse,
   IndexerWsParentSubaccountSubscribedResponse,
   IndexerWsParentSubaccountUpdateObject,
@@ -26,6 +28,10 @@ export const isWsParentSubaccountUpdates =
   typia.createAssert<IndexerWsParentSubaccountUpdateObject[]>();
 export const isWsPerpetualMarketResponse = typia.createAssert<IndexerWsPerpetualMarketResponse>();
 export const isWsMarketUpdateResponses = typia.createAssert<IndexerWsMarketUpdateResponse[]>();
+export const isWsOrderbookSubscribedMessage =
+  typia.createAssert<IndexerWsOrderbookSubscribedMessage>();
+export const isWsOrderbookChannelBatchDataMessage =
+  typia.createAssert<IndexerWsOrderbookChannelBatchDataMessage>();
 export const isWsOrderbookResponse = typia.createAssert<IndexerOrderbookResponseObject>();
 export const isWsOrderbookUpdateResponses =
   typia.createAssert<IndexerWsOrderbookUpdateResponse[]>();

--- a/src/types/indexer/indexerManual.ts
+++ b/src/types/indexer/indexerManual.ts
@@ -10,6 +10,7 @@ import {
   IndexerIsoString,
   IndexerLiquidity,
   IndexerMarketType,
+  IndexerOrderbookResponseObject,
   IndexerOrderResponseObject,
   IndexerOrderSide,
   IndexerOrderType,
@@ -97,6 +98,25 @@ export type IndexerWsBaseMarketObject = Omit<
 
 export interface IndexerWsPerpetualMarketResponse {
   markets: { [key: string]: IndexerWsBaseMarketObject };
+}
+
+export interface IndexerWsOrderbookSubscribedMessage {
+  channel: 'v4_orderbook';
+  connection_id: string;
+  contents: IndexerOrderbookResponseObject;
+  id: string;
+  message_id: number;
+  type: 'subscribed';
+}
+
+export interface IndexerWsOrderbookChannelBatchDataMessage {
+  channel: 'v4_orderbook';
+  connection_id: string;
+  contents: IndexerWsOrderbookUpdateResponse[];
+  id: string;
+  message_id: number;
+  type: 'channel_batch_data';
+  version: string;
 }
 
 export interface IndexerWsOrderbookUpdateResponse {


### PR DESCRIPTION
<!-- Featured screenshots/recordings -->

<!-- Overall purpose of the PR -->
Add calculator functions to Bonsai. Tested by comparing to Abacus Orderbook along with replacing `orderbook` within `useOrderbookValues` for visual confirmation.

---

<!-- Reorder/delete the following sections accordingly: -->

## Abacus TS
- `calculators/orderbook`
  - add orderbook helpers to calculate `ask, bids, midPrice, spread, spreadPercent`

-  `ontology.ts`
  - add `orderbook` within `BonsaiHelpers.currentMarket` 

- `selectors/base` and `selectors/markets`
  - add rawOrderbook selector and createSelector for currentMarket orderbook data/loading

- `rawTypes`
  - update OrderbookData to include `offset` 

- `summaryTypes`
  - add `OrderbookLine` and `OrderbookProcessedData`

- `indexerManual` and `indexerChecks`
  - add validation for full websocket message for v4_orderbook

- `websockets/orderbook`
  - use messageId as offset 
---

<!-- Additional screenshots/recordings, before/after comparisons, testing instructions etc. -->
