### PR TITLE
feat: add free collateral diffs and sync deposit success state with free collateral updates

### DIFF
--- a/src/bonsai/calculators/accountActions.ts
+++ b/src/bonsai/calculators/accountActions.ts
@@ -79,7 +79,7 @@ function addUsdcAssetPosition(
 
 export type UsdcDepositArgs = {
   subaccountNumber: number;
-  depositAmount: string;
+  depositAmount?: string;
 };
 
 export function createUsdcDepositOperations(
@@ -88,7 +88,7 @@ export function createUsdcDepositOperations(
 ): SubaccountBatchedOperations {
   const updatedParentSubaccountData = addUsdcAssetPosition(parentSubaccount, {
     side: IndexerPositionSide.LONG,
-    size: depositAmount,
+    size: depositAmount ?? '0',
     subaccountNumber,
   });
 

--- a/src/components/QrCode.tsx
+++ b/src/components/QrCode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 import QRCodeStyling, { Options } from 'qr-code-styling';
 import styled from 'styled-components';
@@ -21,71 +21,67 @@ type StyleProps = {
 const DARK_LOGO_MARK_URL = '/logos/logo-mark-dark.svg';
 const LIGHT_LOGO_MARK_URL = '/logos/logo-mark-light.svg';
 
-export const QrCode = ({
-  className,
-  value,
-  hasLogo,
-  size = 300,
-  options,
-}: ElementProps & StyleProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const appTheme: AppTheme = useAppSelector(getAppTheme);
+export const QrCode = memo(
+  ({ className, value, hasLogo, size = 300, options }: ElementProps & StyleProps) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const appTheme: AppTheme = useAppSelector(getAppTheme);
 
-  const { current: qrCode } = useRef(
-    new QRCodeStyling({
-      type: 'svg',
-      width: size,
-      height: size,
-      data: value,
-      margin: 8,
-      backgroundOptions: {
-        color: 'var(--color-layer-4)',
-      },
-      imageOptions: {
-        imageSize: 0.4,
-        margin: 12,
-      },
-      dotsOptions: {
-        type: 'dots',
-        color: 'var(--color-text-2)',
-      },
-      cornersDotOptions: {
-        type: 'square',
-      },
-      image: hasLogo
-        ? appTheme === AppTheme.Light
-          ? DARK_LOGO_MARK_URL
-          : LIGHT_LOGO_MARK_URL
-        : undefined,
-      cornersSquareOptions: {
-        type: 'extra-rounded',
-        color: 'var(--color-text-2)',
-      },
-      qrOptions: {
-        errorCorrectionLevel: 'M',
-      },
-      ...options,
-    })
-  );
+    const { current: qrCode } = useRef(
+      new QRCodeStyling({
+        type: 'svg',
+        width: size,
+        height: size,
+        data: value,
+        margin: 8,
+        backgroundOptions: {
+          color: 'var(--color-layer-4)',
+        },
+        imageOptions: {
+          imageSize: 0.4,
+          margin: 12,
+        },
+        dotsOptions: {
+          type: 'dots',
+          color: 'var(--color-text-2)',
+        },
+        cornersDotOptions: {
+          type: 'square',
+        },
+        image: hasLogo
+          ? appTheme === AppTheme.Light
+            ? DARK_LOGO_MARK_URL
+            : LIGHT_LOGO_MARK_URL
+          : undefined,
+        cornersSquareOptions: {
+          type: 'extra-rounded',
+          color: 'var(--color-text-2)',
+        },
+        qrOptions: {
+          errorCorrectionLevel: 'M',
+        },
+        ...options,
+      })
+    );
 
-  useEffect(() => {
-    qrCode.append(ref.current ?? undefined);
-  }, []);
+    useEffect(() => {
+      qrCode.append(ref.current ?? undefined);
+    }, []);
 
-  useEffect(() => {
-    ref.current?.firstElementChild?.setAttribute('viewBox', `0 0 ${size} ${size}`);
-  }, [ref.current]);
+    useEffect(() => {
+      ref.current?.firstElementChild?.setAttribute('viewBox', `0 0 ${size} ${size}`);
+    }, [ref.current]);
 
-  useEffect(() => {
-    if (hasLogo) {
-      qrCode.update({
-        image: appTheme === AppTheme.Light ? DARK_LOGO_MARK_URL : LIGHT_LOGO_MARK_URL,
-      });
-    }
-  }, [appTheme, hasLogo]);
+    useEffect(() => {
+      if (hasLogo) {
+        qrCode.update({
+          image: appTheme === AppTheme.Light ? DARK_LOGO_MARK_URL : LIGHT_LOGO_MARK_URL,
+        });
+      }
+    }, [appTheme, hasLogo]);
 
-  return <$QrCode className={className} ref={ref} />;
-};
+    return <$QrCode className={className} ref={ref} />;
+  }
+);
 const $QrCode = styled.div`
   width: 100%;
   border-radius: 0.75em;

--- a/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositDialog2.tsx
@@ -119,11 +119,17 @@ export const DepositDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>) 
               ref={tokenSelectRef}
               tw="w-[50%] overflow-scroll"
               style={{
+                pointerEvents: formState === 'form' ? 'none' : undefined,
                 height: formState === 'form' ? 0 : '100%',
                 maxHeight: isMobile ? '50vh' : '30rem',
               }}
             >
-              <TokenSelect token={token} setToken={setToken} onBack={onShowForm} />
+              <TokenSelect
+                disabled={formState === 'form'}
+                token={token}
+                setToken={setToken}
+                onBack={onShowForm}
+              />
             </div>
           </div>
         </div>

--- a/src/views/dialogs/DepositDialog2/DepositForm.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositForm.tsx
@@ -68,7 +68,7 @@ export const DepositForm = ({
 
   // Difference between selectedRoute and depositRoute:
   // selectedRoute may be the cached route from the previous query response,
-  // whereas depositRoute is undefined while the current route request is still loading
+  // whereas depositRoute is undefined while the current route query is still loading
   const selectedRoute = selectedSpeed === 'fast' ? routes?.fast : routes?.slow;
   const depositRoute = !isPlaceholderData ? selectedRoute : undefined;
 

--- a/src/views/dialogs/DepositDialog2/DepositStatus.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositStatus.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { BonsaiCore } from '@/bonsai/ontology';
+import { ArrowRightIcon } from '@radix-ui/react-icons';
 
 import { ButtonAction } from '@/constants/buttons';
 
@@ -64,15 +65,21 @@ export const DepositStatus = ({ txHash, chainId, onClose }: DepositStatusProps) 
         </div>
       </div>
       <div tw="flex items-center justify-between self-stretch">
-        <div tw="text-color-text-0">Your deposit</div>
-        {/* TODO(deposit2.0): Show actual deposit amount here */}
-        <div>
-          <Output
-            tw="inline"
-            value={deposit.estimatedAmountUsd}
-            type={OutputType.Fiat}
-            slotLeft="~"
-          />
+        <div tw="text-color-text-0">{depositSuccess ? 'Available balance' : 'Your deposit'}</div>
+        <div tw="flex items-center gap-0.125">
+          {depositSuccess ? (
+            <>
+              <ArrowRightIcon tw="text-green" />
+              <Output tw="inline" value={freeCollateral} type={OutputType.Fiat} />
+            </>
+          ) : (
+            <Output
+              tw="inline"
+              value={deposit.estimatedAmountUsd}
+              type={OutputType.Fiat}
+              slotLeft="~"
+            />
+          )}
         </div>
       </div>
       <Button onClick={onClose} action={depositSuccess ? ButtonAction.Primary : ButtonAction.Base}>

--- a/src/views/dialogs/DepositDialog2/TokenSelect.tsx
+++ b/src/views/dialogs/DepositDialog2/TokenSelect.tsx
@@ -16,10 +16,13 @@ import { useBalances } from './queries';
 import { getTokenSymbol } from './utils';
 
 export const TokenSelect = ({
+  disabled,
   onBack,
   token,
   setToken,
 }: {
+  // disable buttons to prevent tab events while TokenSelect has 0 height
+  disabled?: boolean;
   onBack: () => void;
   token: TokenForTransfer;
   setToken: Dispatch<SetStateAction<TokenForTransfer>>;
@@ -71,6 +74,7 @@ export const TokenSelect = ({
         {withBalances.map((balance, i) => (
           <Fragment key={balance.denom}>
             <button
+              disabled={disabled}
               onClick={onTokenClick({
                 chainId: balance.chainId,
                 denom: balance.denom,
@@ -123,6 +127,7 @@ export const TokenSelect = ({
         {noBalances.map((balance, i) => (
           <Fragment key={balance.denom}>
             <button
+              disabled={disabled}
               onClick={onTokenClick({
                 chainId: balance.chainId,
                 denom: balance.denom,

--- a/src/views/dialogs/DepositDialog2/queries.ts
+++ b/src/views/dialogs/DepositDialog2/queries.ts
@@ -156,7 +156,7 @@ export function isInstantDeposit(route: RouteResponse) {
   return Boolean(route.operations.find((op) => op.goFastTransfer));
 }
 
-export function useDepositDeltas({ depositAmount }: { depositAmount: string }) {
+export function useDepositDeltas({ depositAmount }: { depositAmount?: string }) {
   const depositInput = useMemo(
     () => ({
       subaccountNumber: 0,


### PR DESCRIPTION
This PR adds info about difference in free collateral given a certain deposit amount in USD. It also syncs the success state of the `DepositStatus` modal to wait for the subaccount sweep to complete.

<img width="615" alt="image" src="https://github.com/user-attachments/assets/a785851d-79b5-4dc1-baf2-ac3920660f2c" />
