### PR TITLE
feat: use osmosis and neutron addresses in cosmos token balance lookups

### DIFF
--- a/src/views/dialogs/DepositDialog2/queries.ts
+++ b/src/views/dialogs/DepositDialog2/queries.ts
@@ -20,15 +20,17 @@ import { useParameterizedSelector } from '@/hooks/useParameterizedSelector';
 import { SourceAccount } from '@/state/wallet';
 
 export function useBalances() {
-  const { sourceAccount } = useAccounts();
+  const { sourceAccount, nobleAddress, osmosisAddress, neutronAddress } = useAccounts();
   const { skipClient } = useSkipClient();
 
   return useQuery({
-    queryKey: ['balances', sourceAccount.address],
+    queryKey: ['balances', sourceAccount.address, nobleAddress, osmosisAddress, neutronAddress],
     queryFn: async () => {
-      return skipClient.balances(networkTypeToBalances(sourceAccount));
+      return skipClient.balances(
+        networkTypeToBalances(sourceAccount, nobleAddress, osmosisAddress, neutronAddress)
+      );
     },
-    enabled: Boolean(sourceAccount.address),
+    enabled: Boolean(sourceAccount.address && nobleAddress && osmosisAddress && neutronAddress),
     staleTime: 5 * timeUnits.minute,
     refetchOnMount: 'always',
   });
@@ -60,7 +62,12 @@ function getNativeEvmTokenDenom(chain: Chain) {
   return `${chain.name.toLowerCase()}-native`;
 }
 
-function networkTypeToBalances(sourceAccount: SourceAccount): BalanceRequest {
+function networkTypeToBalances(
+  sourceAccount: SourceAccount,
+  nobleAddress?: string,
+  osmosisAddress?: string,
+  neutronAddress?: string
+): BalanceRequest {
   if (!sourceAccount.address) {
     throw new Error('fetching balances for undefined address');
   }
@@ -91,18 +98,22 @@ function networkTypeToBalances(sourceAccount: SourceAccount): BalanceRequest {
   }
 
   if (sourceAccount.chain === WalletNetworkType.Cosmos) {
+    if (!neutronAddress || !osmosisAddress || !nobleAddress) {
+      throw new Error('cosmos addresses not defined');
+    }
+
     return {
       chains: {
         [CosmosChainId.Neutron]: {
-          address: sourceAccount.address!,
+          address: neutronAddress,
           denoms: [USDC_ADDRESSES[CosmosChainId.Neutron]],
         },
         [CosmosChainId.Osmosis]: {
-          address: sourceAccount.address!,
+          address: osmosisAddress,
           denoms: [USDC_ADDRESSES[CosmosChainId.Osmosis]],
         },
         [CosmosChainId.Noble]: {
-          address: sourceAccount.address!,
+          address: nobleAddress,
           denoms: [USDC_ADDRESSES[CosmosChainId.Noble]],
         },
       },

--- a/src/views/dialogs/DepositDialog2/utils.ts
+++ b/src/views/dialogs/DepositDialog2/utils.ts
@@ -46,7 +46,8 @@ export function getUserAddressesForRoute(
   route: RouteResponse,
   sourceAccount: SourceAccount,
   nobleAddress?: string,
-  dydxAddress?: string
+  dydxAddress?: string,
+  osmosisAddress?: string
 ): UserAddress[] {
   const chains = route.requiredChainAddresses;
 
@@ -56,8 +57,8 @@ export function getUserAddressesForRoute(
         if (!nobleAddress) throw new Error('nobleAddress undefined');
         return { chainID: chainId, address: nobleAddress };
       case CosmosChainId.Osmosis:
-        // TODO(deposit2.0): handle osmosis case!
-        return { chainID: chainId, address: 'osmo1c2jm54xlan3jjfdxeggv7rm3905sscxjr2gtn5' };
+        if (!osmosisAddress) throw new Error('osmosisAddress undefined');
+        return { chainID: chainId, address: osmosisAddress };
       case DYDX_DEPOSIT_CHAIN:
         if (!dydxAddress) throw new Error('dydxAddress undefined');
         return { chainID: chainId, address: dydxAddress };
@@ -106,7 +107,7 @@ export function useDepositSteps({
 }) {
   const walletChainId = useChainId();
   const { skipClient } = useSkipClient();
-  const { nobleAddress, dydxAddress } = useAccounts();
+  const { nobleAddress, dydxAddress, osmosisAddress } = useAccounts();
 
   async function getStepsQuery() {
     if (!depositRoute || !sourceAccount.address) return [];
@@ -141,7 +142,8 @@ export function useDepositSteps({
       depositRoute,
       sourceAccount,
       nobleAddress,
-      dydxAddress
+      dydxAddress,
+      osmosisAddress
     );
 
     if (isEvmDepositChainId(depositToken.chainId)) {


### PR DESCRIPTION
This PR gets the user's osmosis and neutron addresses. We need to pass in their osmosis address in case a Skip route goes through an Osmosis pool (very likely) and their funds get stuck. For osmosis & neutron we need it to fetch their balances if they're connected with a Keplr wallet.