### PR TITLE
feat(withdraw-ui): route execution, loading states, and small fixes

### DIFF
--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -346,7 +346,7 @@ export const Output = ({
   const { decimal: decimalSeparator, group: groupSeparator } = useLocaleSeparators();
 
   if (!!isLoading || !!isDetailsLoading) {
-    return <LoadingOutput />;
+    return <LoadingOutput className={className} />;
   }
 
   switch (type) {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -3,6 +3,9 @@ import { arbitrum, base, mainnet, optimism, polygon } from 'viem/chains';
 import { CosmosChainId } from './graz';
 import { SOLANA_MAINNET_ID } from './solana';
 
+// USDC has a assetId of 0 on the dYdX Chain
+export const USDC_ASSET_ID = 0;
+
 export const USDC_ADDRESSES = {
   [mainnet.id]: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   [base.id]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -39,4 +42,14 @@ export const WITHDRAWABLE_ASSETS: TokenForTransfer[] = [
   { chainId: optimism.id.toString(), denom: USDC_ADDRESSES[optimism.id], decimals: USDC_DECIMALS },
   { chainId: polygon.id.toString(), denom: USDC_ADDRESSES[polygon.id], decimals: USDC_DECIMALS },
   { chainId: SOLANA_MAINNET_ID, denom: USDC_ADDRESSES[SOLANA_MAINNET_ID], decimals: USDC_DECIMALS },
+  {
+    chainId: CosmosChainId.Neutron,
+    denom: USDC_ADDRESSES[CosmosChainId.Neutron],
+    decimals: USDC_DECIMALS,
+  },
+  {
+    chainId: CosmosChainId.Osmosis,
+    denom: USDC_ADDRESSES[CosmosChainId.Osmosis],
+    decimals: USDC_DECIMALS,
+  },
 ];

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -28,6 +28,11 @@ export type TokenForTransfer = {
 };
 
 export const WITHDRAWABLE_ASSETS: TokenForTransfer[] = [
+  {
+    chainId: CosmosChainId.Noble,
+    denom: USDC_ADDRESSES[CosmosChainId.Noble],
+    decimals: USDC_DECIMALS,
+  },
   { chainId: mainnet.id.toString(), denom: USDC_ADDRESSES[mainnet.id], decimals: USDC_DECIMALS },
   { chainId: arbitrum.id.toString(), denom: USDC_ADDRESSES[arbitrum.id], decimals: USDC_DECIMALS },
   { chainId: base.id.toString(), denom: USDC_ADDRESSES[base.id], decimals: USDC_DECIMALS },
@@ -37,11 +42,6 @@ export const WITHDRAWABLE_ASSETS: TokenForTransfer[] = [
   {
     chainId: CosmosChainId.Neutron,
     denom: USDC_ADDRESSES[CosmosChainId.Neutron],
-    decimals: USDC_DECIMALS,
-  },
-  {
-    chainId: CosmosChainId.Noble,
-    denom: USDC_ADDRESSES[CosmosChainId.Noble],
     decimals: USDC_DECIMALS,
   },
   {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -39,14 +39,4 @@ export const WITHDRAWABLE_ASSETS: TokenForTransfer[] = [
   { chainId: optimism.id.toString(), denom: USDC_ADDRESSES[optimism.id], decimals: USDC_DECIMALS },
   { chainId: polygon.id.toString(), denom: USDC_ADDRESSES[polygon.id], decimals: USDC_DECIMALS },
   { chainId: SOLANA_MAINNET_ID, denom: USDC_ADDRESSES[SOLANA_MAINNET_ID], decimals: USDC_DECIMALS },
-  {
-    chainId: CosmosChainId.Neutron,
-    denom: USDC_ADDRESSES[CosmosChainId.Neutron],
-    decimals: USDC_DECIMALS,
-  },
-  {
-    chainId: CosmosChainId.Osmosis,
-    denom: USDC_ADDRESSES[CosmosChainId.Osmosis],
-    decimals: USDC_DECIMALS,
-  },
 ];

--- a/src/state/transfers.ts
+++ b/src/state/transfers.ts
@@ -14,7 +14,12 @@ export type Deposit = {
 
 export type Withdraw = {
   type: 'withdraw';
-  // TODO: add withdraw details here
+  txHash: string;
+  chainId: string;
+  status: 'pending' | 'success' | 'error';
+  estimatedAmountUsd: string;
+  actualAmountUsd?: string;
+  isInstantWithdraw: boolean;
 };
 
 export type Transfer = Deposit | Withdraw;

--- a/src/views/dialogs/DepositDialog2/DepositForm.tsx
+++ b/src/views/dialogs/DepositDialog2/DepositForm.tsx
@@ -28,7 +28,7 @@ import { orEmptyObj } from '@/lib/typeUtils';
 
 import { AmountInput } from './AmountInput';
 import { DepositSteps } from './DepositSteps';
-import { RouteOptions } from './RouteOptions';
+import { DepositRouteOptions } from './RouteOptions';
 import { useBalance, useDepositDeltas, useDepositRoutes } from './queries';
 import { DepositStep, getTokenSymbol, useDepositSteps } from './utils';
 
@@ -202,7 +202,7 @@ export const DepositForm = ({
           onTokenClick={onTokenSelect}
           error={error}
         />
-        <RouteOptions
+        <DepositRouteOptions
           routes={routes}
           isLoading={isFetching}
           disabled={!amount || parseUnits(amount, token.decimals) === BigInt(0)}

--- a/src/views/dialogs/DepositDialog2/RouteOptions.tsx
+++ b/src/views/dialogs/DepositDialog2/RouteOptions.tsx
@@ -3,9 +3,11 @@ import { ReactNode, useMemo } from 'react';
 import { RouteResponse } from '@skip-go/client';
 import { formatUnits } from 'viem';
 
+import { STRING_KEYS } from '@/constants/localization';
 import { USD_DECIMALS } from '@/constants/numbers';
 
 import { SkipRouteSpeed } from '@/hooks/transfers/skipClient';
+import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { LightningIcon, ShieldIcon } from '@/icons';
 
@@ -19,7 +21,7 @@ type Props = {
   onSelectSpeed: (route: SkipRouteSpeed) => void;
 };
 
-export const RouteOptions = ({
+export const DepositRouteOptions = ({
   routes,
   isLoading,
   selectedSpeed,
@@ -114,6 +116,62 @@ export const RouteOptions = ({
         // TODO(deposit2.0): localization
         title="~20 mins"
         description={slowRouteDescription}
+      />
+    </div>
+  );
+};
+
+export const WithdrawRouteOptions = ({
+  routes,
+  isLoading,
+  selectedSpeed,
+  onSelectSpeed,
+  disabled,
+}: Props) => {
+  const stringGetter = useStringGetter();
+  const fastRouteDescription = useMemo(() => {
+    const fastOperationFee = routes?.fast?.estimatedFees[0]?.usdAmount;
+
+    if (!routes || disabled) return '-';
+    if (!routes.fast) return stringGetter({ key: STRING_KEYS.UNAVAILABLE });
+
+    return (
+      <span tw="inline-block">
+        {fastOperationFee ? (
+          <Output
+            tw="inline-block"
+            type={OutputType.Fiat}
+            fractionDigits={USD_DECIMALS}
+            value={fastOperationFee}
+            isLoading={isLoading}
+          />
+        ) : (
+          <span tw="text-color-positive">{stringGetter({ key: STRING_KEYS.FREE })}</span>
+        )}
+      </span>
+    );
+  }, [routes, disabled, stringGetter, isLoading]);
+
+  return (
+    <div tw="flex gap-0.5">
+      <RouteOption
+        icon={
+          <span
+            style={{
+              color:
+                selectedSpeed === 'fast' && !isLoading
+                  ? 'var(--color-favorite)'
+                  : 'var(--color-text-0)',
+            }}
+          >
+            <LightningIcon />
+          </span>
+        }
+        selected={selectedSpeed === 'fast'}
+        disabled={disabled || !routes?.fast || isLoading}
+        onClick={() => onSelectSpeed('fast')}
+        title={stringGetter({ key: STRING_KEYS.INSTANT })}
+        description={fastRouteDescription}
       />
     </div>
   );

--- a/src/views/dialogs/DepositDialog2/RouteOptions.tsx
+++ b/src/views/dialogs/DepositDialog2/RouteOptions.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useMemo } from 'react';
 
 import { RouteResponse } from '@skip-go/client';
+import tw from 'twin.macro';
 import { formatUnits } from 'viem';
 
 import { STRING_KEYS } from '@/constants/localization';
@@ -80,12 +81,11 @@ export const DepositRouteOptions = ({
       <RouteOption
         icon={
           <span
-            style={{
-              color:
-                selectedSpeed === 'fast' && !isLoading
-                  ? 'var(--color-favorite)'
-                  : 'var(--color-text-0)',
-            }}
+            css={[
+              selectedSpeed === 'fast' && !isLoading
+                ? tw`text-color-favorite`
+                : `text-color-text-0`,
+            ]}
           >
             <LightningIcon />
           </span>
@@ -157,12 +157,11 @@ export const WithdrawRouteOptions = ({
       <RouteOption
         icon={
           <span
-            style={{
-              color:
-                selectedSpeed === 'fast' && !isLoading
-                  ? 'var(--color-favorite)'
-                  : 'var(--color-text-0)',
-            }}
+            css={[
+              selectedSpeed === 'fast' && !isLoading
+                ? tw`text-color-favorite`
+                : `text-color-text-0`,
+            ]}
           >
             <LightningIcon />
           </span>

--- a/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
+++ b/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
@@ -1,11 +1,7 @@
-import { Dispatch, Fragment, SetStateAction, useMemo } from 'react';
+import { Dispatch, Fragment, SetStateAction } from 'react';
 
 import { CHAIN_INFO } from '@/constants/chains';
-import { SOLANA_MAINNET_ID } from '@/constants/solana';
 import { WITHDRAWABLE_ASSETS } from '@/constants/tokens';
-import { WalletNetworkType } from '@/constants/wallets';
-
-import { useAccounts } from '@/hooks/useAccounts';
 
 import { AssetIcon } from '@/components/AssetIcon';
 
@@ -20,28 +16,15 @@ export const ChainSelect = ({
   selectedChain: string;
   setSelectedChain: Dispatch<SetStateAction<string>>;
 }) => {
-  const { sourceAccount } = useAccounts();
-  const { chain } = sourceAccount;
-
   const onChainClick = (newChainId: string) => () => {
     setSelectedChain(newChainId);
     onBack();
   };
 
-  const assets = useMemo(() => {
-    return WITHDRAWABLE_ASSETS.filter((asset) => {
-      if (asset.chainId === SOLANA_MAINNET_ID) {
-        return chain === WalletNetworkType.Solana;
-      }
-
-      return true;
-    });
-  }, [chain]);
-
   return (
     <div tw="flex flex-col gap-0.5 py-1">
       <div tw="flex flex-col">
-        {Object.values(assets).map(({ chainId }) => (
+        {Object.values(WITHDRAWABLE_ASSETS).map(({ chainId }) => (
           <Fragment key={chainId}>
             <button
               disabled={disabled}

--- a/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
+++ b/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
@@ -6,10 +6,12 @@ import { WITHDRAWABLE_ASSETS } from '@/constants/tokens';
 import { AssetIcon } from '@/components/AssetIcon';
 
 export const ChainSelect = ({
+  disabled,
   onBack,
   selectedChain,
   setSelectedChain,
 }: {
+  disabled?: boolean;
   onBack: () => void;
   selectedChain: string;
   setSelectedChain: Dispatch<SetStateAction<string>>;
@@ -25,6 +27,7 @@ export const ChainSelect = ({
         {Object.values(WITHDRAWABLE_ASSETS).map(({ chainId }) => (
           <Fragment key={chainId}>
             <button
+              disabled={disabled}
               onClick={onChainClick(chainId)}
               type="button"
               style={{

--- a/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
+++ b/src/views/dialogs/WithdrawDialog2/ChainSelect.tsx
@@ -1,7 +1,11 @@
-import { Dispatch, Fragment, SetStateAction } from 'react';
+import { Dispatch, Fragment, SetStateAction, useMemo } from 'react';
 
 import { CHAIN_INFO } from '@/constants/chains';
+import { SOLANA_MAINNET_ID } from '@/constants/solana';
 import { WITHDRAWABLE_ASSETS } from '@/constants/tokens';
+import { WalletNetworkType } from '@/constants/wallets';
+
+import { useAccounts } from '@/hooks/useAccounts';
 
 import { AssetIcon } from '@/components/AssetIcon';
 
@@ -16,15 +20,28 @@ export const ChainSelect = ({
   selectedChain: string;
   setSelectedChain: Dispatch<SetStateAction<string>>;
 }) => {
+  const { sourceAccount } = useAccounts();
+  const { chain } = sourceAccount;
+
   const onChainClick = (newChainId: string) => () => {
     setSelectedChain(newChainId);
     onBack();
   };
 
+  const assets = useMemo(() => {
+    return WITHDRAWABLE_ASSETS.filter((asset) => {
+      if (asset.chainId === SOLANA_MAINNET_ID) {
+        return chain === WalletNetworkType.Solana;
+      }
+
+      return true;
+    });
+  }, [chain]);
+
   return (
     <div tw="flex flex-col gap-0.5 py-1">
       <div tw="flex flex-col">
-        {Object.values(WITHDRAWABLE_ASSETS).map(({ chainId }) => (
+        {Object.values(assets).map(({ chainId }) => (
           <Fragment key={chainId}>
             <button
               disabled={disabled}

--- a/src/views/dialogs/WithdrawDialog2/WithdrawDialog2.tsx
+++ b/src/views/dialogs/WithdrawDialog2/WithdrawDialog2.tsx
@@ -3,24 +3,25 @@ import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { mainnet } from 'viem/chains';
 
-import { CHAIN_INFO } from '@/constants/chains';
+import { CHAIN_INFO, isEvmDepositChainId } from '@/constants/chains';
 import { DepositDialog2Props, DialogProps } from '@/constants/dialogs';
-import { CosmosChainId } from '@/constants/graz';
+import { CosmosChainId, NEUTRON_BECH32_PREFIX, OSMO_BECH32_PREFIX } from '@/constants/graz';
 import { STRING_KEYS } from '@/constants/localization';
 import { SOLANA_MAINNET_ID } from '@/constants/solana';
 import { WalletNetworkType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
-import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { Dialog, DialogPlacement } from '@/components/Dialog';
+
+import { convertBech32Address } from '@/lib/addressUtils';
 
 import { ChainSelect } from './ChainSelect';
 import { WithdrawForm } from './WithdrawForm';
 
 export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>) => {
-  const { sourceAccount } = useAccounts();
+  const { dydxAddress, sourceAccount, nobleAddress } = useAccounts();
   const [destinationAddress, setDestinationAddress] = useState(sourceAccount.address ?? '');
   const [destinationChain, setDestinationChain] = useState(
     sourceAccount.chain === WalletNetworkType.Evm
@@ -30,9 +31,10 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
         : CosmosChainId.Noble
   );
 
+  const destinationChainRef = useRef(CHAIN_INFO[destinationChain]?.walletNetworkType);
+
   const [amount, setAmount] = useState('');
 
-  const { isMobile } = useBreakpoints();
   const stringGetter = useStringGetter();
 
   const [formState, setFormState] = useState<'form' | 'chain-select'>('form');
@@ -49,10 +51,56 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
   };
 
   useEffect(() => {
-    if (CHAIN_INFO[destinationChain]?.walletNetworkType !== sourceAccount.chain) {
-      setDestinationAddress('');
-    }
-  }, [sourceAccount, destinationChain]);
+    const currentDestinationChainType = CHAIN_INFO[destinationChain]?.walletNetworkType;
+
+    // Do not update destination address if chainType goes from EVM -> EVM
+    // Cosmos uses different Bech32Prefixes for different chains, so it is excluded from this check
+    if (
+      currentDestinationChainType === WalletNetworkType.Evm &&
+      destinationChainRef.current === currentDestinationChainType
+    )
+      return;
+
+    setDestinationAddress(() => {
+      destinationChainRef.current = currentDestinationChainType;
+
+      if (dydxAddress) {
+        if (destinationChain === CosmosChainId.Neutron) {
+          return convertBech32Address({
+            address: dydxAddress,
+            bech32Prefix: NEUTRON_BECH32_PREFIX,
+          });
+        }
+
+        if (destinationChain === CosmosChainId.Osmosis) {
+          return convertBech32Address({ address: dydxAddress, bech32Prefix: OSMO_BECH32_PREFIX });
+        }
+      }
+
+      if (destinationChain === CosmosChainId.Noble && nobleAddress) {
+        return nobleAddress;
+      }
+
+      if (sourceAccount.address != null) {
+        const { address: sourceWalletAddress } = sourceAccount;
+        if (
+          destinationChain === SOLANA_MAINNET_ID &&
+          sourceAccount.chain === WalletNetworkType.Solana
+        ) {
+          return sourceWalletAddress;
+        }
+
+        if (
+          isEvmDepositChainId(destinationChain) &&
+          sourceAccount.chain === WalletNetworkType.Evm
+        ) {
+          return sourceWalletAddress;
+        }
+      }
+
+      return '';
+    });
+  }, [destinationChain, dydxAddress, nobleAddress, sourceAccount]);
 
   return (
     <$Dialog
@@ -65,33 +113,36 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
       title={<div tw="text-center">{dialogTitle}</div>}
       placement={DialogPlacement.Default}
     >
-      <div tw="flex w-[200%] overflow-hidden">
-        <div
-          tw="w-[50%]"
-          style={{ marginLeft: formState === 'form' ? 0 : '-50%', transition: 'margin 500ms' }}
-        >
-          <WithdrawForm
-            amount={amount}
-            setAmount={setAmount}
-            destinationAddress={destinationAddress}
-            setDestinationAddress={setDestinationAddress}
-            destinationChain={destinationChain}
-            onChainSelect={() => setFormState('chain-select')}
-          />
-        </div>
-        <div
-          ref={chainSelectRef}
-          tw="w-[50%] overflow-scroll"
-          style={{
-            height: formState === 'form' ? 0 : '100%',
-            maxHeight: isMobile ? '50vh' : '25rem',
-          }}
-        >
-          <ChainSelect
-            selectedChain={destinationChain}
-            setSelectedChain={setDestinationChain}
-            onBack={onShowForm}
-          />
+      <div tw="w-[100%] overflow-hidden">
+        <div tw="flex w-[200%]">
+          <div
+            tw="w-[50%]"
+            style={{ marginLeft: formState === 'form' ? 0 : '-50%', transition: 'margin 500ms' }}
+          >
+            <WithdrawForm
+              amount={amount}
+              setAmount={setAmount}
+              destinationAddress={destinationAddress}
+              setDestinationAddress={setDestinationAddress}
+              destinationChain={destinationChain}
+              onChainSelect={() => setFormState('chain-select')}
+            />
+          </div>
+          <div
+            ref={chainSelectRef}
+            tw="w-[50%] overflow-scroll"
+            style={{
+              pointerEvents: formState === 'form' ? 'none' : undefined,
+              height: formState === 'form' ? 0 : '100%',
+            }}
+          >
+            <ChainSelect
+              disabled={formState === 'form'}
+              selectedChain={destinationChain}
+              setSelectedChain={setDestinationChain}
+              onBack={onShowForm}
+            />
+          </div>
         </div>
       </div>
     </$Dialog>

--- a/src/views/dialogs/WithdrawDialog2/WithdrawDialog2.tsx
+++ b/src/views/dialogs/WithdrawDialog2/WithdrawDialog2.tsx
@@ -11,6 +11,7 @@ import { SOLANA_MAINNET_ID } from '@/constants/solana';
 import { WalletNetworkType } from '@/constants/wallets';
 
 import { useAccounts } from '@/hooks/useAccounts';
+import usePrevious from '@/hooks/usePrevious';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { Dialog, DialogPlacement } from '@/components/Dialog';
@@ -31,7 +32,7 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
         : CosmosChainId.Noble
   );
 
-  const destinationChainRef = useRef(CHAIN_INFO[destinationChain]?.walletNetworkType);
+  const previousChainRef = usePrevious(CHAIN_INFO[destinationChain]?.walletNetworkType);
 
   const [amount, setAmount] = useState('');
 
@@ -57,13 +58,11 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
     // Cosmos uses different Bech32Prefixes for different chains, so it is excluded from this check
     if (
       currentDestinationChainType === WalletNetworkType.Evm &&
-      destinationChainRef.current === currentDestinationChainType
+      previousChainRef === currentDestinationChainType
     )
       return;
 
     setDestinationAddress(() => {
-      destinationChainRef.current = currentDestinationChainType;
-
       if (dydxAddress) {
         if (destinationChain === CosmosChainId.Neutron) {
           return convertBech32Address({

--- a/src/views/dialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -26,7 +26,7 @@ import { WithdrawRouteOptions } from '../DepositDialog2/RouteOptions';
 import { AddressInput } from './AddressInput';
 import { AmountInput } from './AmountInput';
 import { useWithdrawalDeltas, useWithdrawalRoutes } from './queries';
-import { useWithdrawSteps } from './utils';
+import { useWithdrawStep } from './utils';
 
 export const WithdrawForm = ({
   amount,
@@ -72,7 +72,7 @@ export const WithdrawForm = ({
 
   const selectedRoute = selectedSpeed === 'fast' ? routes?.fast : routes?.slow;
 
-  const { executeWithdraw } = useWithdrawSteps({
+  const { executeWithdraw, isLoading } = useWithdrawStep({
     withdrawRoute: selectedRoute,
     onWithdraw: () => {},
   });
@@ -158,7 +158,10 @@ export const WithdrawForm = ({
       {error && <AlertMessage type={AlertType.Error}>{error.message}</AlertMessage>}
       <Button
         tw="mt-2 w-full"
-        state={{ isLoading: isFetching, isDisabled: !selectedRoute || destinationAddress === '' }}
+        state={{
+          isLoading: isFetching || isLoading,
+          isDisabled: !selectedRoute || destinationAddress === '',
+        }}
         onClick={onWithdrawClick}
         action={ButtonAction.Primary}
       >

--- a/src/views/dialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -22,7 +22,7 @@ import { useAppSelector } from '@/state/appTypes';
 
 import { orEmptyObj } from '@/lib/typeUtils';
 
-import { RouteOptions } from '../DepositDialog2/RouteOptions';
+import { WithdrawRouteOptions } from '../DepositDialog2/RouteOptions';
 import { AddressInput } from './AddressInput';
 import { AmountInput } from './AmountInput';
 import { useWithdrawalDeltas, useWithdrawalRoutes } from './queries';
@@ -88,6 +88,7 @@ export const WithdrawForm = ({
             <Output
               tw="inline"
               type={OutputType.Fiat}
+              isLoading={isFetching}
               value={formatUnits(BigInt(selectedRoute.amountOut), USDC_DECIMALS)}
             />
           ),
@@ -97,7 +98,7 @@ export const WithdrawForm = ({
           label: stringGetter({ key: STRING_KEYS.FREE_COLLATERAL }),
           value: (
             <DiffOutput
-              withDiff={!freeCollateral?.eq(updatedFreeCollateral ?? 0)}
+              withDiff={!freeCollateral?.eq(updatedFreeCollateral ?? 0) && !isFetching}
               type={OutputType.Fiat}
               value={freeCollateral}
               newValue={updatedFreeCollateral}
@@ -109,7 +110,7 @@ export const WithdrawForm = ({
           label: stringGetter({ key: STRING_KEYS.MARGIN_USAGE }),
           value: (
             <DiffOutput
-              withDiff={!marginUsage?.eq(updatedMarginUsage ?? 0)}
+              withDiff={!marginUsage?.eq(updatedMarginUsage ?? 0) && !isFetching}
               type={OutputType.Percent}
               value={marginUsage}
               newValue={updatedMarginUsage}
@@ -121,7 +122,7 @@ export const WithdrawForm = ({
           label: stringGetter({ key: STRING_KEYS.EQUITY }),
           value: (
             <DiffOutput
-              withDiff={!equity?.eq(updatedEquity ?? 0)}
+              withDiff={!equity?.eq(updatedEquity ?? 0) && !isFetching}
               type={OutputType.Fiat}
               value={equity}
               newValue={updatedEquity}
@@ -145,7 +146,7 @@ export const WithdrawForm = ({
         onDestinationClicked={onChainSelect}
       />
       <AmountInput value={amount} onChange={setAmount} />
-      <RouteOptions
+      <WithdrawRouteOptions
         routes={routes}
         isLoading={isFetching}
         disabled={

--- a/src/views/dialogs/WithdrawDialog2/queries.ts
+++ b/src/views/dialogs/WithdrawDialog2/queries.ts
@@ -18,13 +18,15 @@ async function getSkipWithdrawalRoutes(
   amount: string
 ) {
   const routeOptions: RouteRequest = {
+    allowMultiTx: true,
+    allowSwaps: true,
     sourceAssetDenom: DYDX_CHAIN_USDC_DENOM,
     sourceAssetChainID: DYDX_DEPOSIT_CHAIN,
     destAssetDenom: token.denom,
     destAssetChainID: token.chainId,
     amountIn: parseUnits(amount, token.decimals).toString(),
     smartRelay: true,
-    smartSwapOptions: { evmSwaps: true },
+    smartSwapOptions: { evmSwaps: true, splitRoutes: true },
   };
 
   const [slow, fast] = await Promise.all([
@@ -32,9 +34,7 @@ async function getSkipWithdrawalRoutes(
     skipClient.route({ ...routeOptions, goFast: true }),
   ]);
 
-  // @ts-ignore SDK doesn't know about .goFastTransfer
-  const isFastRouteAvailable = Boolean(fast.operations.find((op) => op.goFastTransfer));
-  return { slow, fast: isFastRouteAvailable ? fast : undefined };
+  return { slow, fast };
 }
 
 export function useWithdrawalRoutes({

--- a/src/views/dialogs/WithdrawDialog2/utils.ts
+++ b/src/views/dialogs/WithdrawDialog2/utils.ts
@@ -4,6 +4,7 @@ import { TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT } from '@dydxprotocol/v4-client-j
 import { RouteResponse, UserAddress } from '@skip-go/client';
 
 import { CosmosChainId } from '@/constants/graz';
+import { USDC_ASSET_ID } from '@/constants/tokens';
 
 import { useSkipClient } from '@/hooks/transfers/skipClient';
 import { useAccounts } from '@/hooks/useAccounts';
@@ -76,7 +77,7 @@ export function useWithdrawSteps({
               number: 0,
             },
             recipient: dydxAddress,
-            assetId: 0,
+            assetId: USDC_ASSET_ID,
             quantums: withdrawRoute.amountIn,
           }),
           msgTypeURL: TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT,

--- a/src/views/dialogs/WithdrawDialog2/utils.ts
+++ b/src/views/dialogs/WithdrawDialog2/utils.ts
@@ -28,8 +28,14 @@ export function useWithdrawSteps({
   onWithdraw: (withdraw: Withdraw) => void;
 }) {
   const { skipClient } = useSkipClient();
-  const { dydxAddress, localDydxWallet, localNobleWallet, nobleAddress, sourceAccount } =
-    useAccounts();
+  const {
+    dydxAddress,
+    localDydxWallet,
+    localNobleWallet,
+    nobleAddress,
+    osmosisAddress,
+    sourceAccount,
+  } = useAccounts();
 
   const userAddresses: UserAddress[] | undefined = useMemo(() => {
     if (
@@ -40,8 +46,14 @@ export function useWithdrawSteps({
       return undefined;
     }
 
-    return getUserAddressesForRoute(withdrawRoute, sourceAccount, nobleAddress, dydxAddress);
-  }, [dydxAddress, nobleAddress, sourceAccount, withdrawRoute]);
+    return getUserAddressesForRoute(
+      withdrawRoute,
+      sourceAccount,
+      nobleAddress,
+      dydxAddress,
+      osmosisAddress
+    );
+  }, [dydxAddress, nobleAddress, osmosisAddress, sourceAccount, withdrawRoute]);
 
   const getCosmosSigner = useCallback(
     async (chainID: string) => {

--- a/src/views/dialogs/WithdrawDialog2/utils.ts
+++ b/src/views/dialogs/WithdrawDialog2/utils.ts
@@ -1,0 +1,113 @@
+import { useCallback, useMemo } from 'react';
+
+import { TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT } from '@dydxprotocol/v4-client-js';
+import { RouteResponse, UserAddress } from '@skip-go/client';
+
+import { CosmosChainId } from '@/constants/graz';
+
+import { useSkipClient } from '@/hooks/transfers/skipClient';
+import { useAccounts } from '@/hooks/useAccounts';
+
+import { Withdraw } from '@/state/transfers';
+
+import { getUserAddressesForRoute } from '../DepositDialog2/utils';
+
+export function isInstantWithdraw(route: RouteResponse) {
+  // @ts-ignore SDK doesn't know about .goFastTransfer
+  return Boolean(route.operations.find((op) => op.goFastTransfer));
+}
+
+export function useWithdrawSteps({
+  // withdrawToken,
+  withdrawRoute,
+  onWithdraw,
+}: {
+  // withdrawToken?: TokenForTransfer;
+  withdrawRoute?: RouteResponse;
+  onWithdraw: (withdraw: Withdraw) => void;
+}) {
+  const { skipClient } = useSkipClient();
+  const { dydxAddress, localDydxWallet, localNobleWallet, nobleAddress, sourceAccount } =
+    useAccounts();
+
+  const userAddresses: UserAddress[] | undefined = useMemo(() => {
+    if (
+      dydxAddress == null ||
+      withdrawRoute == null ||
+      withdrawRoute.requiredChainAddresses.length === 0
+    ) {
+      return undefined;
+    }
+
+    return getUserAddressesForRoute(withdrawRoute, sourceAccount, nobleAddress, dydxAddress);
+  }, [dydxAddress, nobleAddress, sourceAccount, withdrawRoute]);
+
+  const getCosmosSigner = useCallback(
+    async (chainID: string) => {
+      if (chainID === CosmosChainId.Noble) {
+        if (!localNobleWallet?.offlineSigner) {
+          throw new Error('No local noblewallet offline signer. Cannot submit tx');
+        }
+        return localNobleWallet.offlineSigner;
+      }
+
+      if (!localDydxWallet?.offlineSigner)
+        throw new Error('No local dydxwallet offline signer. Cannot submit tx');
+
+      return localDydxWallet.offlineSigner;
+    },
+    [localDydxWallet, localNobleWallet]
+  );
+
+  const executeWithdraw = useCallback(async () => {
+    try {
+      if (!withdrawRoute) throw new Error('No route found');
+      if (!userAddresses) throw new Error('No user addresses found');
+      if (!localDydxWallet && !localNobleWallet) throw new Error('No local wallets found');
+
+      await skipClient.executeRoute({
+        getCosmosSigner,
+        route: withdrawRoute,
+        userAddresses,
+        beforeMsg: {
+          msg: JSON.stringify({
+            sender: {
+              owner: dydxAddress,
+              number: 0,
+            },
+            recipient: dydxAddress,
+            assetId: 0,
+            quantums: withdrawRoute.amountIn,
+          }),
+          msgTypeURL: TYPE_URL_MSG_WITHDRAW_FROM_SUBACCOUNT,
+        },
+        onTransactionBroadcast: async ({ txHash, chainID }) => {
+          onWithdraw({
+            type: 'withdraw',
+            txHash,
+            chainId: chainID,
+            status: 'pending',
+            estimatedAmountUsd: withdrawRoute.usdAmountOut ?? '',
+            isInstantWithdraw: isInstantWithdraw(withdrawRoute),
+          });
+        },
+      });
+    } catch (error) {
+      // eslint-disable-next-line prettier/prettier, no-console
+      console.error(error);
+    }
+  }, [
+    dydxAddress,
+    withdrawRoute,
+    skipClient,
+    userAddresses,
+    onWithdraw,
+    getCosmosSigner,
+    localDydxWallet,
+    localNobleWallet,
+  ]);
+
+  return {
+    executeWithdraw,
+  };
+}


### PR DESCRIPTION
Add route execution logic, loading states, and small UI fixes.
- Only support Solana if sourceAccount is sol based
- Remove cosmos withdrawals except Noble
- separate DepositRouteOptions and WithdrawRouteOptions as they diverge in fees/estimatedTime
- If user has not manually inputted an address, Automatically populate address field depending on chain selected
