### PR TITLE
fix: type of last order

### DIFF
--- a/src/lib/abacus/stateNotification.ts
+++ b/src/lib/abacus/stateNotification.ts
@@ -92,7 +92,10 @@ class AbacusStateNotifier implements AbacusStateNotificationProtocol {
   }
 
   // this can be migrated when the trade/close position forms are migrated
-  lastOrderChanged(order: SubaccountOrder) {
+  lastOrderChanged(order: SubaccountOrder | null | undefined) {
+    if (order == null) {
+      return;
+    }
     this.store?.dispatch(setLatestOrder({ clientId: order.clientId, id: order.id }));
   }
 


### PR DESCRIPTION
Not sure why this wasn't caught by typescript, must be because it's assuming we're implementing a different method or something? 