### PR TITLE
fix: destinationAddress for withdraw execution

### DIFF
--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -86,6 +86,7 @@ export const WithdrawForm = ({
   const selectedRoute = selectedSpeed === 'fast' ? routes?.fast : routes?.slow;
 
   const { executeWithdraw, isLoading } = useWithdrawStep({
+    destinationAddress,
     withdrawRoute: selectedRoute,
     onWithdraw,
     onWithdrawSigned,

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/withdrawHooks.ts
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/withdrawHooks.ts
@@ -28,10 +28,12 @@ import { MustBigNumber } from '@/lib/numbers';
 import { getUserAddressesForRoute, isInstantTransfer, parseWithdrawError } from '../utils';
 
 export function useWithdrawStep({
+  destinationAddress,
   withdrawRoute,
   onWithdraw,
   onWithdrawSigned,
 }: {
+  destinationAddress: string;
   withdrawRoute?: RouteResponse;
   onWithdraw: (withdraw: Withdraw) => void;
   onWithdrawSigned: () => void;
@@ -64,9 +66,18 @@ export function useWithdrawStep({
       nobleAddress,
       dydxAddress,
       osmosisAddress,
-      neutronAddress
+      neutronAddress,
+      destinationAddress
     );
-  }, [dydxAddress, neutronAddress, nobleAddress, osmosisAddress, sourceAccount, withdrawRoute]);
+  }, [
+    dydxAddress,
+    neutronAddress,
+    nobleAddress,
+    osmosisAddress,
+    sourceAccount,
+    withdrawRoute,
+    destinationAddress,
+  ]);
 
   const getCosmosSigner = useCallback(
     async (chainID: string) => {

--- a/src/views/dialogs/TransferDialogs/utils.ts
+++ b/src/views/dialogs/TransferDialogs/utils.ts
@@ -39,11 +39,23 @@ export function getUserAddressesForRoute(
   nobleAddress?: string,
   dydxAddress?: string,
   osmosisAddress?: string,
-  neutronAddress?: string
+  neutronAddress?: string,
+  destinationAddress?: string // Withdraw Only: The final stop for the transfer
 ): UserAddress[] {
   const chains = route.requiredChainAddresses;
+  const destinationChain = route.destAssetChainID;
 
-  return chains.map((chainId) => {
+  return chains.map((chainId, idx) => {
+    // Withdraw Only: The last chain in the route and the destination address is valid
+    if (
+      chainId === destinationChain &&
+      idx === chains.length - 1 &&
+      destinationAddress &&
+      isValidWithdrawalAddress(destinationAddress, chainId)
+    ) {
+      return { chainID: chainId, address: destinationAddress };
+    }
+
     switch (chainId) {
       case CosmosChainId.Noble:
         if (!nobleAddress) throw new Error('nobleAddress undefined');


### PR DESCRIPTION
Update `getUserAddressesForRoute` so that the last object in `UserAddress[]` is the destination address when withdrawing.