### PR TITLE
fix: don't store duplicate height results

### DIFF
--- a/src/bonsai/rest/height.ts
+++ b/src/bonsai/rest/height.ts
@@ -84,8 +84,10 @@ export function setUpIndexerHeightQuery(store: RootStore) {
       return () => doIndexerHeightQuery(indexerClient);
     },
     onNoQuery: () => store.dispatch(setIndexerHeightRaw(loadableIdle())),
-    onResult: (result) =>
-      store.dispatch(setIndexerHeightRaw(collapseLoadables(queryResultToLoadable(result)))),
+    onResult: (result) => {
+      console.log('res', result);
+      store.dispatch(setIndexerHeightRaw(collapseLoadables(queryResultToLoadable(result))));
+    },
     getQueryKey: () => ['indexerHeight'],
     ...heightPollingOptions,
   });

--- a/src/bonsai/rest/height.ts
+++ b/src/bonsai/rest/height.ts
@@ -84,10 +84,8 @@ export function setUpIndexerHeightQuery(store: RootStore) {
       return () => doIndexerHeightQuery(indexerClient);
     },
     onNoQuery: () => store.dispatch(setIndexerHeightRaw(loadableIdle())),
-    onResult: (result) => {
-      console.log('res', result);
-      store.dispatch(setIndexerHeightRaw(collapseLoadables(queryResultToLoadable(result))));
-    },
+    onResult: (result) =>
+      store.dispatch(setIndexerHeightRaw(collapseLoadables(queryResultToLoadable(result)))),
     getQueryKey: () => ['indexerHeight'],
     ...heightPollingOptions,
   });


### PR DESCRIPTION
react query actually double-dispatches for each load - one for status: success and fetchStatus: fetching then status: success and fetchStatus: idle