### PR TITLE
feat: re-add testnet faucet as its own dialog

### DIFF
--- a/src/layout/DialogManager.tsx
+++ b/src/layout/DialogManager.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import { DialogTypes } from '@/constants/dialogs';
+import { isMainnet } from '@/constants/networks';
 
 import { CriteriaDialog } from '@/views/Affiliates/CriteriaDialog';
 import { AcknowledgeTermsDialog } from '@/views/dialogs/AcknowledgeTermsDialog';
@@ -42,6 +43,7 @@ import { ShareAffiliateDialog } from '@/views/dialogs/ShareAffiliateDialog';
 import { SharePNLAnalyticsDialog } from '@/views/dialogs/SharePNLAnalyticsDialog';
 import { StakeDialog } from '@/views/dialogs/StakeDialog';
 import { StakingRewardDialog } from '@/views/dialogs/StakingRewardDialog';
+import { TestnetFaucetDialog } from '@/views/dialogs/TestnetFaucetDialog';
 import { TradeDialog } from '@/views/dialogs/TradeDialog';
 import { TransferDialog } from '@/views/dialogs/TransferDialog';
 import { DepositDialog2 } from '@/views/dialogs/TransferDialogs/DepositDialog2/DepositDialog2';
@@ -85,7 +87,12 @@ export const DialogManager = React.memo(() => {
     ComplianceConfig: (args) => <ComplianceConfigDialog {...args} {...modalProps} />,
     ConfirmPendingDeposit: (args) => <ConfirmPendingDepositDialog {...args} {...modalProps} />,
     Deposit: (args) => <DepositDialog {...args} {...modalProps} />,
-    Deposit2: (args) => <DepositDialog2 {...args} {...modalProps} />,
+    Deposit2: (args) =>
+      isMainnet ? (
+        <DepositDialog2 {...args} {...modalProps} />
+      ) : (
+        <TestnetFaucetDialog {...modalProps} />
+      ),
     DisconnectWallet: (args) => <DisconnectDialog {...args} {...modalProps} />,
     DisplaySettings: (args) => <DisplaySettingsDialog {...args} {...modalProps} />,
     ExchangeOffline: (args) => <ExchangeOfflineDialog {...args} {...modalProps} />,

--- a/src/views/dialogs/TestnetFaucetDialog.tsx
+++ b/src/views/dialogs/TestnetFaucetDialog.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+import { AnalyticsEvents } from '@/constants/analytics';
+import { DepositDialogProps, DialogProps } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
+
+import { useBreakpoints } from '@/hooks/useBreakpoints';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { layoutMixins } from '@/styles/layoutMixins';
+
+import { Dialog, DialogPlacement } from '@/components/Dialog';
+
+import { track } from '@/lib/analytics/analytics';
+
+import { TestnetDepositForm } from '../forms/AccountManagementForms/TestnetDepositForm';
+
+export const TestnetFaucetDialog = ({ setIsOpen }: DialogProps<DepositDialogProps>) => {
+  const stringGetter = useStringGetter();
+  const { isMobile } = useBreakpoints();
+
+  return (
+    <Dialog
+      isOpen
+      withAnimation
+      setIsOpen={setIsOpen}
+      title={stringGetter({ key: STRING_KEYS.DEPOSIT })}
+      placement={isMobile ? DialogPlacement.FullScreen : DialogPlacement.Default}
+    >
+      <$Content>
+        <TestnetDepositForm
+          onDeposit={() => {
+            track(AnalyticsEvents.TransferFaucet());
+          }}
+        />
+      </$Content>
+    </Dialog>
+  );
+};
+
+const $Content = styled.div`
+  ${layoutMixins.flexColumn}
+  gap: 1rem;
+
+  form {
+    flex: 1;
+  }
+`;


### PR DESCRIPTION
- We only had a TestnetDepositForm, pulled it into its own dialog and handling at the DialogManager level