### PR TITLE
fix: recover keys disabled

### DIFF
--- a/src/views/dialogs/OnboardingTriggerButton.tsx
+++ b/src/views/dialogs/OnboardingTriggerButton.tsx
@@ -53,7 +53,9 @@ export const OnboardingTriggerButton = ({
       size={size}
       type={ButtonType.Button}
       state={{
-        isDisabled: disableConnectButton || isAccountViewOnly,
+        isDisabled:
+          disableConnectButton ||
+          (onboardingState === OnboardingState.AccountConnected && isAccountViewOnly),
       }}
       onClick={openOnboardingDialog}
     >


### PR DESCRIPTION
Broken here: https://github.com/dydxprotocol/v4-web/pull/1551/files#diff-3b56b92474ce34542f3ba0c8dfc5b7998bf2817778dba10974d188e82ff2aa63R56

Need Jared to validate my logic here is right but it seems good.

Issue: https://linear.app/dydx/issue/BUG2-305/unable-to-click-on-recover-keys