### PR TITLE
fix: crash when sourceAccount address is invalid

### DIFF
--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/AddressInput.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/AddressInput.tsx
@@ -34,7 +34,7 @@ export const AddressInput = ({
 }: AddressInputProps) => {
   const stringGetter = useStringGetter();
   const { sourceAccount } = useAccounts();
-  const [invalidAddress, setInvalidAddress] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   const onValueChange: EventHandler<SyntheticInputEvent> = (e) => {
     onChange(e.target.value);
@@ -43,13 +43,11 @@ export const AddressInput = ({
   const hasValidAddress = isValidWithdrawalAddress(value, destinationChain);
 
   const onBlur = () => {
-    if (value.length > 0 && !hasValidAddress) {
-      setInvalidAddress(true);
-    }
+    setIsFocused(false);
   };
 
   const onFocus = () => {
-    setInvalidAddress(false);
+    setIsFocused(true);
   };
 
   return (
@@ -57,7 +55,7 @@ export const AddressInput = ({
       <div tw="flex flex-1 flex-col gap-0.5 text-small">
         <div>
           {stringGetter({ key: STRING_KEYS.ADDRESS })}{' '}
-          {invalidAddress && (
+          {!hasValidAddress && !isFocused && value.trim() !== '' && (
             <WithTooltip tooltipString={stringGetter({ key: STRING_KEYS.INVALID_ADDRESS_TITLE })}>
               <Icon tw="text-color-error" size="0.75rem" iconName={IconName.Warning} />
             </WithTooltip>

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -28,6 +28,7 @@ import { log } from '@/lib/telemetry';
 import { orEmptyObj } from '@/lib/typeUtils';
 
 import { TransferRouteOptions } from '../RouteOptions';
+import { isValidWithdrawalAddress } from '../utils';
 import { AddressInput } from './AddressInput';
 import { AmountInput } from './AmountInput';
 import { useWithdrawalDeltas, useWithdrawalRoutes } from './queries';
@@ -115,7 +116,8 @@ export const WithdrawForm = ({
     destinationAddress === '' ||
     amount === '' ||
     !!validationError ||
-    !isDebouncedAmountSame;
+    !isDebouncedAmountSame ||
+    !isValidWithdrawalAddress(destinationAddress, destinationChain);
 
   const buttonInner = error ? (
     <div tw="row gap-0.5">

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/withdrawHooks.ts
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/withdrawHooks.ts
@@ -28,7 +28,12 @@ import { MustBigNumber } from '@/lib/numbers';
 import { log } from '@/lib/telemetry';
 
 import { DYDX_DEPOSIT_CHAIN } from '../consts';
-import { getUserAddressesForRoute, isInstantTransfer, parseWithdrawError } from '../utils';
+import {
+  getUserAddressesForRoute,
+  isInstantTransfer,
+  isValidWithdrawalAddress,
+  parseWithdrawError,
+} from '../utils';
 
 export function useWithdrawStep({
   destinationAddress,
@@ -57,10 +62,14 @@ export function useWithdrawStep({
   const [isLoading, setIsLoading] = useState(false);
 
   const userAddresses: UserAddress[] | undefined = useMemo(() => {
+    const lastChainId = withdrawRoute?.requiredChainAddresses.at(-1);
+
     if (
+      destinationAddress.trim() === '' ||
       dydxAddress == null ||
       withdrawRoute == null ||
-      withdrawRoute.requiredChainAddresses.length === 0
+      lastChainId == null ||
+      !isValidWithdrawalAddress(destinationAddress, lastChainId)
     ) {
       return undefined;
     }

--- a/src/views/dialogs/TransferDialogs/utils.ts
+++ b/src/views/dialogs/TransferDialogs/utils.ts
@@ -47,12 +47,7 @@ export function getUserAddressesForRoute(
 
   return chains.map((chainId, idx) => {
     // Withdraw Only: The last chain in the route and the destination address is valid
-    if (
-      chainId === destinationChain &&
-      idx === chains.length - 1 &&
-      destinationAddress &&
-      isValidWithdrawalAddress(destinationAddress, chainId)
-    ) {
+    if (chainId === destinationChain && idx === chains.length - 1 && destinationAddress) {
       return { chainID: chainId, address: destinationAddress };
     }
 


### PR DESCRIPTION
- Update invalidAddress warning so it does not need a setState
- move check for valid address outside of getUserAddressesForRoute
- update address population side effect