### PR TITLE
feat(performance): batch store notifications for fewer rerenders

### DIFF
--- a/src/state/_store.ts
+++ b/src/state/_store.ts
@@ -84,6 +84,10 @@ export const store = configureStore({
     getDefaultMiddleware({
       serializableCheck: false,
     }).concat(appMiddleware as Middleware, localizationMiddleware as Middleware),
+  enhancers: (getDefaultEnhancers) =>
+    getDefaultEnhancers({
+      autoBatch: { type: 'timer', timeout: 250 },
+    }),
   devTools:
     process.env.NODE_ENV !== 'production'
       ? {

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -6,6 +6,8 @@ import { LocalStorageKey } from '@/constants/localStorage';
 
 import { getLocalStorage } from '@/lib/localStorage';
 
+import { autoBatchAllReducers } from './autoBatchHelpers';
+
 export type AccountState = {
   tradingRewards?: TradingRewards;
 
@@ -48,12 +50,14 @@ export const accountSlice = createSlice({
       onboardingState: action.payload,
     }),
 
-    setSubaccountForPostOrders: (state, action: PayloadAction<Nullable<Subaccount>>) => {
-      state.subaccountForPostOrders = action.payload;
-    },
-    clearSubaccountState: (state) => {
-      state.subaccountForPostOrders = undefined;
-    },
+    ...autoBatchAllReducers<AccountState>()({
+      setSubaccountForPostOrders: (state, action: PayloadAction<Nullable<Subaccount>>) => {
+        state.subaccountForPostOrders = action.payload;
+      },
+      clearSubaccountState: (state) => {
+        state.subaccountForPostOrders = undefined;
+      },
+    }),
   },
 });
 

--- a/src/state/autoBatchHelpers.ts
+++ b/src/state/autoBatchHelpers.ts
@@ -6,13 +6,17 @@ export function autoBatchAllReducers<State>() {
     type TransformedReducers = {
       [K in keyof R]: {
         reducer: R[K];
-        prepare: ReturnType<typeof prepareAutoBatched<Parameters<R[K]>[1]['payload']>>;
+        prepare: ReturnType<
+          typeof prepareAutoBatched<
+            Parameters<R[K]>['length'] extends 0 | 1 ? void : Parameters<R[K]>[1]['payload']
+          >
+        >;
       };
     };
 
     return mapValues(reducers, (reducer) => ({
       reducer,
-      prepare: prepareAutoBatched<Parameters<typeof reducer>[1]['payload']>(),
+      prepare: prepareAutoBatched<any>(),
     })) as TransformedReducers;
   };
 }

--- a/src/state/autoBatchHelpers.ts
+++ b/src/state/autoBatchHelpers.ts
@@ -1,0 +1,18 @@
+import { prepareAutoBatched } from '@reduxjs/toolkit';
+import { mapValues } from 'lodash';
+
+export function autoBatchAllReducers<State>() {
+  return <R extends Record<string, (state: State, action: any) => void>>(reducers: R) => {
+    type TransformedReducers = {
+      [K in keyof R]: {
+        reducer: R[K];
+        prepare: ReturnType<typeof prepareAutoBatched<Parameters<R[K]>[1]['payload']>>;
+      };
+    };
+
+    return mapValues(reducers, (reducer) => ({
+      reducer,
+      prepare: prepareAutoBatched<Parameters<typeof reducer>[1]['payload']>(),
+    })) as TransformedReducers;
+  };
+}

--- a/src/state/localOrders.ts
+++ b/src/state/localOrders.ts
@@ -25,6 +25,8 @@ import {
 
 import { isTruthy } from '@/lib/isTruthy';
 
+import { autoBatchAllReducers } from './autoBatchHelpers';
+
 export interface LocalOrdersState {
   localPlaceOrders: LocalPlaceOrderData[];
   localCancelOrders: LocalCancelOrderData[];
@@ -48,107 +50,111 @@ export const localOrdersSlice = createSlice({
     clearLocalOrders: () => {
       return initialState;
     },
-    updateOrders: (state, action: PayloadAction<SubaccountOrder[]>) => {
-      const { payload: orders } = action;
-      let { localCloseAllPositions } = state;
-      const canceledOrders = orders.filter(
-        (order) =>
-          order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Canceled
-      );
-      const placedOrderClientIds = new Set(
-        orders
-          .filter(
-            (order) =>
-              order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Open
-          )
-          .map((o) => o.clientId)
-      );
-      const filledOrderClientIds = new Set(
-        orders
-          .filter(
-            (order) =>
-              order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Filled
-          )
-          .map((order) => order.clientId)
-          .filter(isTruthy)
-      );
+    ...autoBatchAllReducers<LocalOrdersState>()({
+      updateOrders: (state, action: PayloadAction<SubaccountOrder[]>) => {
+        const { payload: orders } = action;
+        let { localCloseAllPositions } = state;
+        const canceledOrders = orders.filter(
+          (order) =>
+            order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Canceled
+        );
+        const placedOrderClientIds = new Set(
+          orders
+            .filter(
+              (order) =>
+                order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Open
+            )
+            .map((o) => o.clientId)
+        );
+        const filledOrderClientIds = new Set(
+          orders
+            .filter(
+              (order) =>
+                order.status != null && getSimpleOrderStatus(order.status) === OrderStatus.Filled
+            )
+            .map((order) => order.clientId)
+            .filter(isTruthy)
+        );
 
-      // no relevant cancel or filled orders
-      if (!canceledOrders.length && (!localCloseAllPositions || !filledOrderClientIds.size))
-        return state;
+        // no relevant cancel or filled orders
+        if (!canceledOrders.length && (!localCloseAllPositions || !filledOrderClientIds.size))
+          return state;
 
-      const canceledOrderIdsInPayload = new Set(canceledOrders.map((order) => order.id));
-      // ignore locally canceled orders since it's intentional and already handled
-      // by local cancel tracking and notification
-      const isOrderCanceledByBackend = (orderId: string) =>
-        canceledOrderIdsInPayload.has(orderId) &&
-        !state.localCancelOrders.some((order) => order.orderId === orderId);
+        const canceledOrderIdsInPayload = new Set(canceledOrders.map((order) => order.id));
+        // ignore locally canceled orders since it's intentional and already handled
+        // by local cancel tracking and notification
+        const isOrderCanceledByBackend = (orderId: string) =>
+          canceledOrderIdsInPayload.has(orderId) &&
+          !state.localCancelOrders.some((order) => order.orderId === orderId);
 
-      const getNewCanceledOrderIds = (batch: LocalCancelAllData) => {
-        const newCanceledOrderIds = batch.orderIds.filter((o) => canceledOrderIdsInPayload.has(o));
-        return uniq([...(batch.canceledOrderIds ?? []), ...newCanceledOrderIds]);
-      };
-
-      if (localCloseAllPositions) {
-        localCloseAllPositions = {
-          ...localCloseAllPositions,
-          filledOrderClientIds: uniq([
-            ...localCloseAllPositions.submittedOrderClientIds.filter((id) =>
-              filledOrderClientIds.has(id)
-            ),
-            ...localCloseAllPositions.filledOrderClientIds,
-          ]),
-          failedOrderClientIds: uniq([
-            ...intersection(
-              localCloseAllPositions.submittedOrderClientIds,
-              canceledOrders.map((order) => order.clientId).filter(isTruthy)
-            ),
-            ...localCloseAllPositions.failedOrderClientIds,
-          ]),
+        const getNewCanceledOrderIds = (batch: LocalCancelAllData) => {
+          const newCanceledOrderIds = batch.orderIds.filter((o) =>
+            canceledOrderIdsInPayload.has(o)
+          );
+          return uniq([...(batch.canceledOrderIds ?? []), ...newCanceledOrderIds]);
         };
-      }
 
-      return {
-        ...state,
-        localPlaceOrders: state.localPlaceOrders.map((order) => {
-          // Check if order should be canceled
-          if (
-            order.orderId &&
-            canceledOrderIdsInPayload.has(order.orderId) &&
-            isOrderCanceledByBackend(order.orderId)
-          ) {
-            return {
-              ...order,
-              submissionStatus: PlaceOrderStatuses.Canceled,
-            };
-          }
+        if (localCloseAllPositions) {
+          localCloseAllPositions = {
+            ...localCloseAllPositions,
+            filledOrderClientIds: uniq([
+              ...localCloseAllPositions.submittedOrderClientIds.filter((id) =>
+                filledOrderClientIds.has(id)
+              ),
+              ...localCloseAllPositions.filledOrderClientIds,
+            ]),
+            failedOrderClientIds: uniq([
+              ...intersection(
+                localCloseAllPositions.submittedOrderClientIds,
+                canceledOrders.map((order) => order.clientId).filter(isTruthy)
+              ),
+              ...localCloseAllPositions.failedOrderClientIds,
+            ]),
+          };
+        }
 
-          if (
-            order.clientId &&
-            order.submissionStatus < PlaceOrderStatuses.Placed &&
-            placedOrderClientIds.has(order.clientId)
-          ) {
-            return {
-              ...order,
-              orderId: orders.find((o) => o.clientId === order.clientId)?.id,
-              submissionStatus: PlaceOrderStatuses.Placed,
-            };
-          }
+        return {
+          ...state,
+          localPlaceOrders: state.localPlaceOrders.map((order) => {
+            // Check if order should be canceled
+            if (
+              order.orderId &&
+              canceledOrderIdsInPayload.has(order.orderId) &&
+              isOrderCanceledByBackend(order.orderId)
+            ) {
+              return {
+                ...order,
+                submissionStatus: PlaceOrderStatuses.Canceled,
+              };
+            }
 
-          return order;
-        }),
-        localCancelOrders: state.localCancelOrders.map((order) =>
-          canceledOrderIdsInPayload.has(order.orderId)
-            ? { ...order, submissionStatus: CancelOrderStatuses.Canceled }
-            : order
-        ),
-        localCancelAlls: mapValues(state.localCancelAlls, (batch) => ({
-          ...batch,
-          canceledOrderIds: getNewCanceledOrderIds(batch),
-        })),
-        localCloseAllPositions,
-      };
-    },
+            if (
+              order.clientId &&
+              order.submissionStatus < PlaceOrderStatuses.Placed &&
+              placedOrderClientIds.has(order.clientId)
+            ) {
+              return {
+                ...order,
+                orderId: orders.find((o) => o.clientId === order.clientId)?.id,
+                submissionStatus: PlaceOrderStatuses.Placed,
+              };
+            }
+
+            return order;
+          }),
+          localCancelOrders: state.localCancelOrders.map((order) =>
+            canceledOrderIdsInPayload.has(order.orderId)
+              ? { ...order, submissionStatus: CancelOrderStatuses.Canceled }
+              : order
+          ),
+          localCancelAlls: mapValues(state.localCancelAlls, (batch) => ({
+            ...batch,
+            canceledOrderIds: getNewCanceledOrderIds(batch),
+          })),
+          localCloseAllPositions,
+        };
+      },
+    }),
     updateFilledOrders: (state, action: PayloadAction<SubaccountFill[]>) => {
       const filledOrderIds = action.payload.map((fill) => fill.orderId).filter(isTruthy);
       if (filledOrderIds.length === 0) return state;

--- a/src/state/perpetuals.ts
+++ b/src/state/perpetuals.ts
@@ -6,6 +6,8 @@ import { DEFAULT_MARKETID, MarketFilters } from '@/constants/markets';
 
 import { getLocalStorage } from '@/lib/localStorage';
 
+import { autoBatchAllReducers } from './autoBatchHelpers';
+
 export interface PerpetualsState {
   currentMarketId?: string;
   // if user is viewing is a live, tradeable market: its id; otherwise: undefined
@@ -39,9 +41,11 @@ export const perpetualsSlice = createSlice({
     ) => {
       state.currentMarketIdIfTradeable = action.payload;
     },
-    setAbacusHasMarkets: (state: PerpetualsState, action: PayloadAction<boolean>) => {
-      state.abacusHasMarkets = action.payload;
-    },
+    ...autoBatchAllReducers<PerpetualsState>()({
+      setAbacusHasMarkets: (state: PerpetualsState, action: PayloadAction<boolean>) => {
+        state.abacusHasMarkets = action.payload;
+      },
+    }),
     resetPerpetualsState: () =>
       ({
         ...initialState,

--- a/src/state/raw.ts
+++ b/src/state/raw.ts
@@ -30,6 +30,8 @@ import {
 
 import { calc } from '@/lib/do';
 
+import { autoBatchAllReducers } from './autoBatchHelpers';
+
 interface NetworkState {
   indexerClientReady: boolean;
   compositeClientReady: boolean;
@@ -124,7 +126,7 @@ const initialState: RawDataState = {
 export const rawSlice = createSlice({
   name: 'Raw data',
   initialState,
-  reducers: {
+  reducers: autoBatchAllReducers<RawDataState>()({
     setAllMarketsRaw: (state, action: PayloadAction<Loadable<MarketsData>>) => {
       state.markets.allMarkets = action.payload;
     },
@@ -218,7 +220,7 @@ export const rawSlice = createSlice({
     ) => {
       state.compliance.sourceAddressScreenV2 = action.payload;
     },
-  },
+  }),
 });
 
 const HEIGHTS_BUFFER_LENGTH = 12;


### PR DESCRIPTION
Raw data updates are fine to delay, so we use redux-toolkit batching to reduce the number of react re-renders to at most 4/second. All user input actions should not be batched so still respond instantly to user input. 