### PR TITLE
fix: safe sub to react query observers

### DIFF
--- a/src/bonsai/rest/assets.ts
+++ b/src/bonsai/rest/assets.ts
@@ -14,6 +14,7 @@ import { loadableIdle } from '../lib/loadable';
 import { mapLoadableData } from '../lib/mapLoadable';
 import { logBonsaiError, wrapAndLogBonsaiError } from '../logs';
 import { queryResultToLoadable } from './lib/queryResultToLoadable';
+import { safeSubscribeObserver } from './lib/safeSubscribe';
 
 export function setUpAssetsQuery(store: RootStore) {
   const observer = new QueryObserver(appQueryClient, {
@@ -26,7 +27,7 @@ export function setUpAssetsQuery(store: RootStore) {
     staleTime: timeUnits.minute * 5,
   });
 
-  const unsubscribe = observer.subscribe((result) => {
+  const unsubscribe = safeSubscribeObserver(observer, (result) => {
     try {
       store.dispatch(
         setAllAssetsRaw(

--- a/src/bonsai/rest/geo.ts
+++ b/src/bonsai/rest/geo.ts
@@ -14,6 +14,7 @@ import { loadableIdle } from '../lib/loadable';
 import { mapLoadableData } from '../lib/mapLoadable';
 import { logBonsaiError, wrapAndLogBonsaiError } from '../logs';
 import { queryResultToLoadable } from './lib/queryResultToLoadable';
+import { safeSubscribeObserver } from './lib/safeSubscribe';
 
 async function fetchGeo(url: string): Promise<{ data: string | undefined }> {
   const response = await fetch(url);
@@ -46,7 +47,7 @@ export function setUpGeoQuery(store: RootStore) {
       retryDelay: (attempt) => timeUnits.second * 3 * 2 ** attempt,
     });
 
-    const unsubscribe = observer.subscribe((result) => {
+    const unsubscribe = safeSubscribeObserver(observer, (result) => {
       try {
         store.dispatch(
           setComplianceGeoRaw(mapLoadableData(queryResultToLoadable(result), (r) => r.data))

--- a/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
+++ b/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
@@ -17,6 +17,7 @@ import { createAppSelector } from '@/state/appTypes';
 
 import { createStoreEffect } from '../../lib/createStoreEffect';
 import { CompositeClientManager } from './compositeClientManager';
+import { safeSubscribeObserver } from './safeSubscribe';
 
 type PassedQueryOptions<R> = Pick<
   QueryObserverOptions<R>,
@@ -125,7 +126,7 @@ export function createIndexerQueryStoreEffect<T, R>(
         ...otherOpts,
       });
 
-      const unsubscribe = observer.subscribe((result) => {
+      const unsubscribe = safeSubscribeObserver(observer, (result) => {
         try {
           config.onResult(result);
         } catch (e) {
@@ -216,7 +217,7 @@ export function createValidatorQueryStoreEffect<T, R>(
         ...otherOpts,
       });
 
-      const unsubscribe = observer.subscribe((result) => {
+      const unsubscribe = safeSubscribeObserver(observer, (result) => {
         try {
           config.onResult(result);
         } catch (e) {
@@ -279,7 +280,7 @@ export function createNobleQueryStoreEffect<T, R>(
       ...otherOpts,
     });
 
-    const unsubscribe = observer.subscribe((result) => {
+    const unsubscribe = safeSubscribeObserver(observer, (result) => {
       try {
         config.onResult(result);
       } catch (e) {

--- a/src/bonsai/rest/lib/safeSubscribe.ts
+++ b/src/bonsai/rest/lib/safeSubscribe.ts
@@ -1,0 +1,10 @@
+import { QueryObserver } from '@tanstack/react-query';
+
+export function safeSubscribeObserver<Obs extends QueryObserver<any, any, any, any, any>>(
+  observer: Obs,
+  handleResult: Parameters<Obs['subscribe']>[0]
+): () => void {
+  handleResult(observer.getCurrentResult());
+  const unsub = observer.subscribe(handleResult);
+  return unsub;
+}


### PR DESCRIPTION
It turns out calling observer.subscribe() only gets you future updates which is typically fine since we just created the observer and refetchOnMount is usually true so it fires off a load but if the query key is warm then the observer creation will fire off an update with the value to no listeners then the subscribe gets nothing until the next staleTime. 

This line: https://github.com/TanStack/query/blob/main/packages/query-core/src/queryObserver.ts#L106 is supposed to account for this case but since refetchOnMount is true we miss that rescue attempt. 

I note that the way useQuery accounts for this is even stranger and I can't quite get it to work: 
https://github.com/TanStack/query/blob/main/packages/react-query/src/useBaseQuery.ts#L94
they call getOptimisticResult on every render (which requires all your options) then in the subscription call updateResult
https://github.com/TanStack/query/blob/main/packages/react-query/src/useBaseQuery.ts#L106 
but in my tests updateResult seems to do nothing and I don't understand what the optimistic result does even after scanning the source for it: 
https://github.com/TanStack/query/blob/main/packages/query-core/src/queryObserver.ts#L226. Sadly they don't document queryObserver AT ALL anywhere for some reason. 

I am pretty sure for our use case, calling getCurrentValue then subscribing should be totally safe/accurate but being 100% sure would require reading a lot more of react query source code. 