### PR TITLE
chore: log time query success

### DIFF
--- a/src/lib/timeOffset.ts
+++ b/src/lib/timeOffset.ts
@@ -1,4 +1,4 @@
-import { logBonsaiInfo } from '@/bonsai/logs';
+import { logBonsaiInfo, wrapAndLogBonsaiError } from '@/bonsai/logs';
 import { utils } from '@dydxprotocol/v4-client-js';
 import { isFinite } from 'lodash';
 
@@ -21,7 +21,10 @@ async function getTimestampOffset() {
         removeTrailingSlash
       );
       const start = Date.now();
-      const res = await fetch(`${indexerUrl}/v4/time`, { method: 'GET' });
+      const res = await wrapAndLogBonsaiError(
+        () => fetch(`${indexerUrl}/v4/time`, { method: 'GET' }),
+        'timeOffset'
+      )();
       const end = Date.now();
 
       const serverDate = (await res.json()).iso;


### PR DESCRIPTION
This is important imo because it's basically a test for whether the user's internet is working and will provide a baseline for how often we should expect queries to fail. 