### PR TITLE
chore: clean and standardize around getTime, shallowEqual, and safeAssign

### DIFF
--- a/src/bonsai/accountRefreshSignal.ts
+++ b/src/bonsai/accountRefreshSignal.ts
@@ -21,7 +21,7 @@ export function refreshIndexerQueryOnAccountSocketRefresh(key: any[]) {
         .findAll({ queryKey: ['indexer', ...key], exact: false })
         .map((q) => q.state.dataUpdatedAt)
     );
-    if ((minTime ?? 0) < new Date().valueOf() - BUFFER_REFRESH_TIME) {
+    if ((minTime ?? 0) < new Date().getTime() - BUFFER_REFRESH_TIME) {
       appQueryClient.invalidateQueries({ queryKey: ['indexer', ...key], exact: false });
     }
   });

--- a/src/bonsai/calculators/orders.ts
+++ b/src/bonsai/calculators/orders.ts
@@ -67,9 +67,9 @@ function calculateSubaccountOrder(
     size: MustBigNumber(base.size),
     totalFilled: MustBigNumber(base.totalFilled),
     goodTilBlock: MaybeBigNumber(base.goodTilBlock)?.toNumber(),
-    goodTilBlockTimeMilliseconds: mapIfPresent(base.goodTilBlockTime, (u) => new Date(u).valueOf()),
+    goodTilBlockTimeMilliseconds: mapIfPresent(base.goodTilBlockTime, (u) => new Date(u).getTime()),
     goodTilBlockTimeSeconds: mapIfPresent(base.goodTilBlockTime, (u) =>
-      Math.floor(new Date(u).valueOf() / 1000)
+      Math.floor(new Date(u).getTime() / 1000)
     ),
     createdAtHeight: MaybeBigNumber(base.createdAtHeight)?.toNumber(),
     postOnly: !!base.postOnly,
@@ -151,7 +151,7 @@ function maybeUpdateOrderIfExpired(
     return {
       ...order,
       status,
-      updatedAtMilliseconds: new Date(height.time).valueOf(),
+      updatedAtMilliseconds: new Date(height.time).getTime(),
       updatedAtHeight: height.height,
     };
   }

--- a/src/components/GuardedMobileRoute.tsx
+++ b/src/components/GuardedMobileRoute.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { shallowEqual } from 'react-redux';
 import { Outlet, useNavigate } from 'react-router-dom';
 
 import { DialogTypes } from '@/constants/dialogs';
@@ -16,8 +15,8 @@ export const GuardedMobileRoute = () => {
   const { isTablet } = useBreakpoints();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
-  const activeDialog = useAppSelector(getActiveDialog, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
+  const activeDialog = useAppSelector(getActiveDialog);
   const prevActiveDialog = useRef(activeDialog);
 
   useEffect(() => {
@@ -35,7 +34,7 @@ export const GuardedMobileRoute = () => {
       navigate('/');
     }
     prevActiveDialog.current = activeDialog;
-  }, [activeDialog, canAccountTrade, isTablet]);
+  }, [activeDialog, canAccountTrade, isTablet, navigate]);
 
   return <Outlet />;
 };

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -24,12 +24,12 @@ export const RelativeTime = ({
     return () => clearInterval(i);
   }, []);
 
-  return timestamp && new Date(timestamp).valueOf() ? (
+  return timestamp && new Date(timestamp).getTime() ? (
     <time
       dateTime={new Date(timestamp).toISOString()}
       title={new Date(timestamp).toLocaleString(locale)}
     >
-      {formatRelativeTime(new Date(timestamp).valueOf(), { locale, format, resolution })}
+      {formatRelativeTime(new Date(timestamp).getTime(), { locale, format, resolution })}
     </time>
   ) : null;
 };

--- a/src/hooks/Orderbook/useOrderbookValues.ts
+++ b/src/hooks/Orderbook/useOrderbookValues.ts
@@ -4,8 +4,6 @@ import { BonsaiHelpers } from '@/bonsai/ontology';
 
 import { GROUPING_MULTIPLIER_LIST, GroupingMultiplier } from '@/constants/orderbook';
 
-import { safeAssign } from '@/lib/objectHelpers';
-
 import { useParameterizedSelector } from '../useParameterizedSelector';
 
 export const useCalculateOrderbookData = ({ rowsPerSide }: { rowsPerSide: number }) => {
@@ -36,27 +34,17 @@ export const useCalculateOrderbookData = ({ rowsPerSide }: { rowsPerSide: number
 
   return useMemo(() => {
     const asks = (orderbook?.asks ?? [])
-      .map((row, idx: number) =>
-        safeAssign(
-          {},
-          {
-            key: `ask-${idx}`,
-          },
-          row
-        )
-      )
+      .map((row, idx: number) => ({
+        key: `ask-${idx}`,
+        ...row,
+      }))
       .slice(0, rowsPerSide);
 
     const bids = (orderbook?.bids ?? [])
-      .map((row, idx: number) =>
-        safeAssign(
-          {},
-          {
-            key: `bid-${idx}`,
-          },
-          row
-        )
-      )
+      .map((row, idx: number) => ({
+        key: `bid-${idx}`,
+        ...row,
+      }))
       .slice(0, rowsPerSide);
 
     const spread = orderbook?.spread;

--- a/src/hooks/tradingView/useChartLines.tsx
+++ b/src/hooks/tradingView/useChartLines.tsx
@@ -71,7 +71,7 @@ export const useChartLines = ({
   const isAccountConnected = useAppSelector(getIsAccountConnected);
 
   const currentMarketId = useAppSelector(getCurrentMarketId);
-  const currentMarketPositionData = useAppSelector(getCurrentMarketPositionData, shallowEqual);
+  const currentMarketPositionData = useAppSelector(getCurrentMarketPositionData);
   const currentMarketOrders: SubaccountOrder[] = useAppSelector(
     getCurrentMarketOrders,
     shallowEqual

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { shallowEqual } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 import {
@@ -254,7 +253,7 @@ export const useAnalytics = () => {
   }, [previousSelectedWallet, selectedWallet]);
 
   // AnalyticsEvent.TradeOrderTypeSelected
-  const { type: selectedOrderType } = useAppSelector(getTradeFormValues, shallowEqual);
+  const { type: selectedOrderType } = useAppSelector(getTradeFormValues);
   const [hasSelectedOrderTypeChanged, setHasSelectedOrderTypeChanged] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/useClosePositionFormInputs.ts
+++ b/src/hooks/useClosePositionFormInputs.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { OrderSizeInputs } from '@/bonsai/forms/trade/types';
 import { BonsaiHelpers } from '@/bonsai/ontology';
 import { NumberFormatValues } from 'react-number-format';
-import { shallowEqual, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { TOKEN_DECIMALS, USD_DECIMALS } from '@/constants/numbers';
 
@@ -28,10 +28,7 @@ export const useClosePositionFormInputs = () => {
     useAppSelector(BonsaiHelpers.currentMarket.stableMarketInfo)
   );
 
-  const midMarketPrice = useAppSelector(
-    BonsaiHelpers.currentMarket.midPrice.data,
-    shallowEqual
-  )?.toNumber();
+  const midMarketPrice = useAppSelector(BonsaiHelpers.currentMarket.midPrice.data)?.toNumber();
 
   const onAmountInput = useCallback(
     ({ formattedValue }: { floatValue?: number; formattedValue: string }) => {

--- a/src/hooks/useCommandMenu.ts
+++ b/src/hooks/useCommandMenu.ts
@@ -1,7 +1,5 @@
 import { useCallback, useEffect } from 'react';
 
-import { shallowEqual } from 'react-redux';
-
 import { DialogTypes } from '@/constants/dialogs';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
@@ -10,7 +8,7 @@ import { getActiveDialog } from '@/state/dialogsSelectors';
 
 export const useCommandMenu = () => {
   const dispatch = useAppDispatch();
-  const activeDialog = useAppSelector(getActiveDialog, shallowEqual);
+  const activeDialog = useAppSelector(getActiveDialog);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { ComplianceStatus } from '@/bonsai/types/summaryTypes';
-import { shallowEqual } from 'react-redux';
 
 import { OnboardingState } from '@/constants/account';
 import { CLOSE_ONLY_GRACE_PERIOD, ComplianceStates } from '@/constants/compliance';
@@ -29,7 +28,7 @@ import { useURLConfigs } from './useURLConfigs';
 export const useComplianceState = () => {
   const stringGetter = useStringGetter();
   const { help } = useURLConfigs();
-  const complianceStatus = useAppSelector(getComplianceStatus, shallowEqual);
+  const complianceStatus = useAppSelector(getComplianceStatus);
   const complianceUpdatedAt = useAppSelector(getComplianceUpdatedAt);
   const geo = useAppSelector(getGeo);
   const selectedLocale = useAppSelector(getSelectedLocale);
@@ -67,7 +66,7 @@ export const useComplianceState = () => {
         key: STRING_KEYS.CLOSE_ONLY_MESSAGE_WITH_HELP,
         params: {
           DATE: updatedAtDate
-            ? formatDateOutput(updatedAtDate.valueOf(), OutputType.DateTime, {
+            ? formatDateOutput(updatedAtDate.getTime(), OutputType.DateTime, {
                 dateFormat: 'medium',
                 selectedLocale,
               })

--- a/src/hooks/useCurrentMarketId.ts
+++ b/src/hooks/useCurrentMarketId.ts
@@ -42,7 +42,7 @@ export const useCurrentMarketId = () => {
   const activeTradeBoxDialog = useAppSelector(getActiveTradeBoxDialog);
   const hasLoadedLaunchableMarkets = launchableMarkets.data.length > 0;
   const hasSeenPredictionMarketIntroDialog = useAppSelector(getHasSeenPredictionMarketIntroDialog);
-  const launchedMarketIds = useAppSelector(getLaunchedMarketIds, shallowEqual);
+  const launchedMarketIds = useAppSelector(getLaunchedMarketIds);
 
   const { filteredMarkets: predictionMarkets } = useMarketsData({
     filter: MarketFilters.PREDICTION_MARKET,

--- a/src/hooks/useStringGetter.ts
+++ b/src/hooks/useStringGetter.ts
@@ -1,11 +1,9 @@
-import { shallowEqual } from 'react-redux';
-
 import type { StringGetterFunction } from '@/constants/localization';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getLocaleStringGetter } from '@/state/localizationSelectors';
 
 export const useStringGetter = (): StringGetterFunction => {
-  const stringGetterFunction = useAppSelector(getLocaleStringGetter, shallowEqual);
+  const stringGetterFunction = useAppSelector(getLocaleStringGetter);
   return stringGetterFunction;
 };

--- a/src/hooks/useTriggerOrdersFormInputs.ts
+++ b/src/hooks/useTriggerOrdersFormInputs.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { PositionUniqueId, SubaccountOrder } from '@/bonsai/types/summaryTypes';
-import { shallowEqual, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getTriggersFormPosition, getTriggersFormSummary } from '@/state/inputsSelectors';
@@ -19,7 +19,7 @@ export const useTriggerOrdersFormInputs = ({
   takeProfitOrder?: SubaccountOrder;
 }) => {
   const dispatch = useDispatch();
-  const { errors, summary } = useAppSelector(getTriggersFormSummary, shallowEqual);
+  const { errors, summary } = useAppSelector(getTriggersFormSummary);
 
   const position = useAppSelector(getTriggersFormPosition);
   const stopLossOrderSize = stopLossOrder?.size.toNumber();

--- a/src/layout/Header/HeaderDesktop.tsx
+++ b/src/layout/Header/HeaderDesktop.tsx
@@ -1,4 +1,3 @@
-import { shallowEqual } from 'react-redux';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -34,7 +33,7 @@ import { LanguageSelector } from '@/views/menus/LanguageSelector';
 import { NetworkSelectMenu } from '@/views/menus/NetworkSelectMenu';
 import { NotificationsMenu } from '@/views/menus/NotificationsMenu';
 
-import { getOnboardingState, getSubaccount } from '@/state/accountSelectors';
+import { getOnboardingState, getSubaccountFreeCollateral } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { getHasSeenLaunchIncentives } from '@/state/appUiConfigsSelectors';
 import { openDialog } from '@/state/dialogs';
@@ -50,8 +49,7 @@ export const HeaderDesktop = () => {
   const onboardingState = useAppSelector(getOnboardingState);
   const { complianceState } = useComplianceState();
 
-  const subAccount = useAppSelector(getSubaccount, shallowEqual);
-  const { freeCollateral: availableBalance } = subAccount ?? {};
+  const availableBalance = useAppSelector(getSubaccountFreeCollateral);
 
   const affiliatesEnabled = useStatsigGateValue(StatsigFlags.ffEnableAffiliates);
 
@@ -189,7 +187,7 @@ export const HeaderDesktop = () => {
                 shape={ButtonShape.Pill}
                 size={ButtonSize.XSmall}
                 action={
-                  !availableBalance || availableBalance.gt(0)
+                  !availableBalance || availableBalance > 0
                     ? ButtonAction.Secondary
                     : ButtonAction.Primary
                 }

--- a/src/lib/marketsHelpers.ts
+++ b/src/lib/marketsHelpers.ts
@@ -8,7 +8,6 @@ import {
   getMarketIdFromAsset,
 } from './assetUtils';
 import { BIG_NUMBERS, MustBigNumber } from './numbers';
-import { safeAssign } from './objectHelpers';
 
 export const FALLBACK_MARKET_LEVERAGE = 5;
 
@@ -104,7 +103,7 @@ export function getMarketDataFromAsset(asset: AssetData, favoritedMarkets: strin
   const displayId = getDisplayableTickerFromMarket(ticker);
   const displayableAsset = getDisplayableAssetFromTicker(ticker);
 
-  return safeAssign({}, {
+  return {
     id: ticker,
     assetId,
     displayId,
@@ -133,5 +132,5 @@ export function getMarketDataFromAsset(asset: AssetData, favoritedMarkets: strin
     marketCap: marketCap ?? reportedMarketCap,
     sectorTags: sectorTags ?? [],
     isFavorite: favoritedMarkets.includes(ticker),
-  } satisfies MarketData);
+  } satisfies MarketData;
 }

--- a/src/lib/objectHelpers.ts
+++ b/src/lib/objectHelpers.ts
@@ -12,8 +12,3 @@ export const objectFromEntries = <const T extends ReadonlyArray<readonly [Proper
 // Object.keys() with key types preserved - NOT SAFE for mutable variables, only readonly/consts that are never modified
 // since typescript is structurally typed and objects can contain extra keys and still be valid objects of type T
 export const objectKeys = <T extends object>(t: T) => Object.keys(t) as Array<keyof T>;
-
-// An alias for Object.assign. Our Kotlin-generated types contian properties as getter functions which typescript can't be sure
-// can be safely splatted like {...someObject}. Object.assign is slightly slower but guarantees all the properties will get copied
-// and the result is typed correctly by the type system
-export const safeAssign = Object.assign;

--- a/src/pages/portfolio/AccountDetailsAndHistory.tsx
+++ b/src/pages/portfolio/AccountDetailsAndHistory.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 
 import { TooltipContextType } from '@visx/xychart';
 import BigNumber from 'bignumber.js';
-import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 
 import { OnboardingState } from '@/constants/account';
@@ -98,7 +97,7 @@ export const AccountDetailsAndHistory = () => {
   const selectedLocale = useAppSelector(getSelectedLocale);
   const onboardingState = useAppSelector(getOnboardingState);
 
-  const { equity, leverage, marginUsage } = orEmptyObj(useAppSelector(getSubaccount, shallowEqual));
+  const { equity, leverage, marginUsage } = orEmptyObj(useAppSelector(getSubaccount));
 
   const [tooltipContext, setTooltipContext] = useState<TooltipContextType<PnlDatum>>();
 

--- a/src/pages/portfolio/AccountOverviewSection.tsx
+++ b/src/pages/portfolio/AccountOverviewSection.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 
-import { shallowEqual } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -20,7 +19,7 @@ import { Tag, TagSign, TagType } from '@/components/Tag';
 import { WithLabel } from '@/components/WithLabel';
 import { WithTooltip } from '@/components/WithTooltip';
 
-import { getSubaccount } from '@/state/accountSelectors';
+import { getSubaccountEquity, getSubaccountFreeCollateral } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
@@ -67,9 +66,11 @@ export const AccountOverviewSection = () => {
   const navigate = useNavigate();
   const stringGetter = useStringGetter();
 
-  const { equity, freeCollateral } = orEmptyObj(useAppSelector(getSubaccount, shallowEqual));
+  const equity = useAppSelector(getSubaccountEquity);
+  const freeCollateral = useAppSelector(getSubaccountFreeCollateral);
+
   const { balanceUsdc: vaultBalance } = orEmptyObj(useLoadedVaultAccount().data);
-  const totalValue = mapIfPresent(equity?.toNumber(), (e) => e + (vaultBalance ?? 0));
+  const totalValue = mapIfPresent(equity, (e) => e + (vaultBalance ?? 0));
 
   const handleViewVault = useCallback(() => {
     track(AnalyticsEvents.ClickViewVaultFromOverview());
@@ -84,15 +85,13 @@ export const AccountOverviewSection = () => {
     {
       id: 'free-collateral',
       label: stringGetter({ key: STRING_KEYS.FREE_COLLATERAL }),
-      amount: mapIfPresent(freeCollateral?.toNumber(), (fc) => Math.max(fc, 0.0)),
+      amount: mapIfPresent(freeCollateral, (fc) => Math.max(fc, 0.0)),
       color: ColorToken.GrayPurple2,
     },
     {
       id: 'open-positions',
       label: stringGetter({ key: STRING_KEYS.POSITION_MARGIN }),
-      amount: mapIfPresent(equity?.toNumber(), freeCollateral?.toNumber(), (e, f) =>
-        Math.max(e - Math.max(f, 0), 0)
-      ),
+      amount: mapIfPresent(equity, freeCollateral, (e, f) => Math.max(e - Math.max(f, 0), 0)),
       color: ColorToken.Yellow1,
     },
     {

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense } from 'react';
 
 import { BonsaiCore } from '@/bonsai/ontology';
-import { shallowEqual } from 'react-redux';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -30,7 +29,7 @@ import { WithSidebar } from '@/components/WithSidebar';
 import { FillsTable, FillsTableColumnKey } from '@/views/tables/FillsTable';
 import { TransferHistoryTable } from '@/views/tables/TransferHistoryTable';
 
-import { getOnboardingState, getSubaccount } from '@/state/accountSelectors';
+import { getOnboardingState, getSubaccountFreeCollateral } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
 
@@ -60,7 +59,7 @@ const PortfolioPage = () => {
   const initialPageSize = 20;
 
   const onboardingState = useAppSelector(getOnboardingState);
-  const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
+  const freeCollateral = useAppSelector(getSubaccountFreeCollateral);
   const { nativeTokenBalance } = useAccountBalance();
 
   const numTotalOpenOrders = useAppSelector(BonsaiCore.account.openOrders.data).length;
@@ -71,7 +70,7 @@ const PortfolioPage = () => {
   const numPositions = shortenNumberForDisplay(numTotalPositions);
   const numOrders = shortenNumberForDisplay(numTotalOpenOrders);
 
-  const usdcBalance = freeCollateral?.toNumber() ?? 0;
+  const usdcBalance = freeCollateral ?? 0;
 
   useDocumentTitle(stringGetter({ key: STRING_KEYS.PORTFOLIO }));
 

--- a/src/pages/token/StakingPanel.tsx
+++ b/src/pages/token/StakingPanel.tsx
@@ -1,4 +1,3 @@
-import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 import tw from 'twin.macro';
 
@@ -37,7 +36,7 @@ export const StakingPanel = ({ className }: { className?: string }) => {
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
 
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
   const stakingApr = useStakingAPR();
 
   const { complianceState } = useComplianceState();

--- a/src/pages/vaults/VaultDepositWithdrawForm.tsx
+++ b/src/pages/vaults/VaultDepositWithdrawForm.tsx
@@ -67,7 +67,6 @@ import { dd } from '@/lib/analytics/datadog';
 import { assertNever } from '@/lib/assertNever';
 import { mapIfPresent, runFn } from '@/lib/do';
 import { MustBigNumber, getNumberSign } from '@/lib/numbers';
-import { safeAssign } from '@/lib/objectHelpers';
 import { sleep } from '@/lib/timeUtils';
 import { orEmptyObj } from '@/lib/typeUtils';
 
@@ -162,7 +161,7 @@ export const VaultDepositWithdrawForm = ({
           }
           return { long, short };
         });
-        return safeAssign({}, error, errorStrings);
+        return { ...error, ...errorStrings };
       }),
     [slippagePercent, stringGetter, validationResponse.errors, vaultLearnMore]
   );
@@ -228,11 +227,11 @@ export const VaultDepositWithdrawForm = ({
           return;
         }
 
-        const startTime = new Date().valueOf();
+        const startTime = new Date().getTime();
         await depositToMegavault(cachedAmount);
-        const intermediateTime = new Date().valueOf();
+        const intermediateTime = new Date().getTime();
         await sleep(INDEXER_LAG_ALLOWANCE);
-        const finalTime = new Date().valueOf();
+        const finalTime = new Date().getTime();
 
         track(
           AnalyticsEvents.SuccessfulVaultOperation({
@@ -286,14 +285,14 @@ export const VaultDepositWithdrawForm = ({
 
         const preEstimate = validationResponse.summaryData.estimatedAmountReceived;
 
-        const startTime = new Date().valueOf();
+        const startTime = new Date().getTime();
         const result = await withdrawFromMegavault(
           submissionData.withdraw.shares,
           submissionData.withdraw.minAmount
         );
-        const intermediateTime = new Date().valueOf();
+        const intermediateTime = new Date().getTime();
         await sleep(INDEXER_LAG_ALLOWANCE);
-        const finalTime = new Date().valueOf();
+        const finalTime = new Date().getTime();
 
         const events = (result as IndexedTx | undefined)?.events;
         const actualAmount = events

--- a/src/pages/vaults/VaultLockedSharesTable.tsx
+++ b/src/pages/vaults/VaultLockedSharesTable.tsx
@@ -80,7 +80,7 @@ const VaultLockedSharesTable = ({
               unlockBlockHeight,
               height,
               // add a day so users don't get confused about why their money isn't unlocked when the day arrives
-              (unblock, actual) => new Date().valueOf() + (unblock - actual) * 1000 + timeUnits.day
+              (unblock, actual) => new Date().getTime() + (unblock - actual) * 1000 + timeUnits.day
             );
             return (
               <Output

--- a/src/pages/vaults/VaultPnlChart.tsx
+++ b/src/pages/vaults/VaultPnlChart.tsx
@@ -25,7 +25,6 @@ import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 import { getSelectedLocale } from '@/state/localizationSelectors';
 
 import { MustBigNumber, getNumberSign } from '@/lib/numbers';
-import { safeAssign } from '@/lib/objectHelpers';
 
 type VaultPnlChartProps = { className?: string };
 
@@ -53,7 +52,7 @@ export const VaultPnlChart = ({ className }: VaultPnlChartProps) => {
   const [hoveredTime, setHoveredTime] = useState<number | undefined>(undefined);
 
   const data = useMemo(
-    () => vaultPnl.map((v, index) => safeAssign({}, v, { index })),
+    () => vaultPnl.map((v, index) => ({ ...v, index })),
     // need to churn reference so chart updates axes
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [vaultPnl, selectedChart]
@@ -212,7 +211,7 @@ export const VaultPnlChart = ({ className }: VaultPnlChartProps) => {
                 dateOptions={{ format: 'medium' }}
               />
             ) : (
-              <Output value={new Date().valueOf()} type={OutputType.Date} />
+              <Output value={new Date().getTime()} type={OutputType.Date} />
             )}
           </div>
           <div tw="row gap-0.5 font-base-medium">

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -28,6 +28,12 @@ import { getCurrentMarketId } from './currentMarketSelectors';
  */
 export const getSubaccount = BonsaiCore.account.parentSubaccountSummary.data;
 
+export const getSubaccountEquity = createAppSelector([getSubaccount], (s) => s?.equity.toNumber());
+
+export const getSubaccountFreeCollateral = createAppSelector([getSubaccount], (s) =>
+  s?.freeCollateral.toNumber()
+);
+
 /**
  * @param state
  * @returns list of a subaccount's open positions. Each item in the list is an open position in a different market.

--- a/src/views/charts/PnlChart.tsx
+++ b/src/views/charts/PnlChart.tsx
@@ -4,7 +4,6 @@ import { BonsaiHooks } from '@/bonsai/ontology';
 import { curveLinear } from '@visx/curve';
 import type { TooltipContextType } from '@visx/xychart';
 import { debounce } from 'lodash';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { NORMAL_DEBOUNCE_MS } from '@/constants/debounce';
@@ -19,7 +18,7 @@ import { ToggleGroup } from '@/components/ToggleGroup';
 import { TimeSeriesChart } from '@/components/visx/TimeSeriesChart';
 
 import { getSubaccountId } from '@/state/accountInfoSelectors';
-import { getSubaccount } from '@/state/accountSelectors';
+import { getSubaccountEquity } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 import { getChartDotBackground } from '@/state/appUiConfigsSelectors';
 
@@ -77,14 +76,14 @@ export const PnlChart = ({
   slotEmpty,
 }: PnlChartProps) => {
   const { isTablet } = useBreakpoints();
-  const { equity: equityBn } = useAppSelector(getSubaccount, shallowEqual) ?? {};
+  const equity = useAppSelector(getSubaccountEquity);
   const now = useNow({ intervalMs: timeUnits.minute });
 
   const chartDotsBackground = useAppSelector(getChartDotBackground);
 
   // Chart data
   const { data: pnlData } = BonsaiHooks.useParentSubaccountHistoricalPnls();
-  const subaccountId = useAppSelector(getSubaccountId, shallowEqual);
+  const subaccountId = useAppSelector(getSubaccountId);
 
   const [periodOptions, setPeriodOptions] = useState<HistoricalPnlPeriod[]>([
     HistoricalPnlPeriod.Period1d,
@@ -98,7 +97,6 @@ export const PnlChart = ({
 
   const lastPnlTick = pnlData?.[pnlData.length - 1];
 
-  const equity = equityBn?.toNumber();
   const data = useMemo(
     () =>
       lastPnlTick
@@ -117,7 +115,7 @@ export const PnlChart = ({
                 subaccountId: subaccountId ?? 0,
                 equity: Number(datum.equity),
                 totalPnl: Number(datum.totalPnl),
-                createdAt: new Date(datum.createdAtMilliseconds).valueOf(),
+                createdAt: new Date(datum.createdAtMilliseconds).getTime(),
                 side: {
                   [-1]: PnlSide.Loss,
                   0: PnlSide.Flat,

--- a/src/views/dialogs/CancelPendingOrdersDialog.tsx
+++ b/src/views/dialogs/CancelPendingOrdersDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { BonsaiHelpers } from '@/bonsai/ontology';
-import { shallowEqual } from 'react-redux';
 
 import { CancelPendingOrdersDialogProps, DialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -22,7 +21,7 @@ export const CancelPendingOrdersDialog = ({
   marketId,
 }: DialogProps<CancelPendingOrdersDialogProps>) => {
   const stringGetter = useStringGetter();
-  const allPending = useAppSelector(getNonZeroPendingPositions, shallowEqual);
+  const allPending = useAppSelector(getNonZeroPendingPositions);
   const pendingPosition = useMemo(
     () => allPending?.find((p) => p.marketId === marketId),
     [allPending, marketId]

--- a/src/views/dialogs/ComplianceConfigDialog.tsx
+++ b/src/views/dialogs/ComplianceConfigDialog.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import { loadableLoaded } from '@/bonsai/lib/loadable';
 import { ComplianceResponse, ComplianceStatus } from '@/bonsai/types/summaryTypes';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
@@ -36,8 +35,8 @@ const setGeo = (payload: string) => setComplianceGeoRaw(loadableLoaded(payload))
 const usePreferenceMenu = () => {
   const dispatch = useAppDispatch();
 
-  const complianceStatus = useAppSelector(getComplianceStatus, shallowEqual);
-  const geo = useAppSelector(getGeo, shallowEqual);
+  const complianceStatus = useAppSelector(getComplianceStatus);
+  const geo = useAppSelector(getGeo);
   const geoRestricted = Boolean(
     geo && [...BLOCKED_COUNTRIES, ...OFAC_SANCTIONED_COUNTRIES].includes(geo as CountryCodes)
   );
@@ -86,7 +85,7 @@ const usePreferenceMenu = () => {
 
 export const ComplianceConfigDialog = ({ setIsOpen }: DialogProps<ComplianceConfigDialogProps>) => {
   const preferenceItems = usePreferenceMenu();
-  const complianceStatus = useAppSelector(getComplianceStatus, shallowEqual);
+  const complianceStatus = useAppSelector(getComplianceStatus);
 
   const { dydxAddress } = useAccounts();
   const { compositeClient } = useDydxClient();

--- a/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
+++ b/src/views/dialogs/DetailsDialog/OrderDetailsDialog.tsx
@@ -1,7 +1,6 @@
 import { accountTransactionManager } from '@/bonsai/AccountTransactionSupervisor';
 import { OrderFlags, OrderStatus } from '@/bonsai/types/summaryTypes';
 import BigNumber from 'bignumber.js';
-import { shallowEqual } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { AnalyticsEvents } from '@/constants/analytics';
@@ -46,7 +45,7 @@ export const OrderDetailsDialog = ({
   const stringGetter = useStringGetter();
   const isAccountViewOnly = useAppSelector(calculateIsAccountViewOnly);
 
-  const localCancelOrders = useAppSelector(getLocalCancelOrders, shallowEqual);
+  const localCancelOrders = useAppSelector(getLocalCancelOrders);
   const isOrderCanceling =
     Object.values(localCancelOrders).find(
       (order) => order.orderId === orderId && order.submissionStatus < CancelOrderStatuses.Canceled

--- a/src/views/dialogs/ExchangeOfflineDialog.tsx
+++ b/src/views/dialogs/ExchangeOfflineDialog.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import { ApiStatus } from '@/bonsai/types/summaryTypes';
-import { shallowEqual } from 'react-redux';
 
 import { DialogProps, DialogTypes, ExchangeOfflineDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -26,7 +25,7 @@ export const ExchangeOfflineDialog = ({
   const stringGetter = useStringGetter();
   const { status, statusErrorMessage } = useApiState();
   const selectedNetwork = useAppSelector(getSelectedNetwork);
-  const activeDialog = useAppSelector(getActiveDialog, shallowEqual);
+  const activeDialog = useAppSelector(getActiveDialog);
 
   useEffect(() => {
     if (
@@ -36,7 +35,7 @@ export const ExchangeOfflineDialog = ({
     ) {
       dispatch(closeDialog());
     }
-  }, [status, selectedNetwork]);
+  }, [status, selectedNetwork, activeDialog, dispatch]);
 
   return (
     <Dialog

--- a/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
+++ b/src/views/forms/AccountManagementForms/TestnetDepositForm.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react';
 
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
@@ -31,8 +30,8 @@ export const TestnetDepositForm = ({ onDeposit, onError }: DepositFormProps) => 
   const stringGetter = useStringGetter();
   const { dydxAddress, getSubaccounts } = useAccounts();
   const { requestFaucetFunds } = useSubaccount();
-  const subAccount = useAppSelector(getSubaccount, shallowEqual);
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const subAccount = useAppSelector(getSubaccount);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
   const dydxChainId = useEnvConfig('dydxChainId');
 
   const [isLoading, setIsLoading] = useState(false);

--- a/src/views/forms/ClosePositionForm.tsx
+++ b/src/views/forms/ClosePositionForm.tsx
@@ -5,7 +5,6 @@ import { OrderSizeInputs, TradeFormType } from '@/bonsai/forms/trade/types';
 import { isOperationSuccess } from '@/bonsai/lib/operationResult';
 import { ErrorType, getHighestPriorityAlert } from '@/bonsai/lib/validationErrors';
 import { BonsaiHelpers } from '@/bonsai/ontology';
-import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 
 import { AlertType } from '@/constants/alerts';
@@ -111,7 +110,7 @@ export const ClosePositionForm = ({
     onLimitPriceInput,
   } = useClosePositionFormInputs();
 
-  const currentPositionData = useAppSelector(getCurrentMarketPositionData, shallowEqual);
+  const currentPositionData = useAppSelector(getCurrentMarketPositionData);
   const { signedSize: currentPositionSize } = currentPositionData ?? {};
   const currentSizeBN = MustBigNumber(currentPositionSize).abs();
 

--- a/src/views/forms/NewMarketForm/index.tsx
+++ b/src/views/forms/NewMarketForm/index.tsx
@@ -7,8 +7,6 @@ import {
   useState,
 } from 'react';
 
-import { shallowEqual } from 'react-redux';
-
 import { AnalyticsEvents } from '@/constants/analytics';
 import { STRING_KEYS } from '@/constants/localization';
 import { DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH, NumberSign } from '@/constants/numbers';
@@ -56,7 +54,7 @@ export const NewMarketForm = ({
   const { mintscan: mintscanTxUrl } = useURLConfigs();
   const stringGetter = useStringGetter();
 
-  const subAccount = orEmptyObj(useAppSelector(getSubaccount, shallowEqual));
+  const subAccount = orEmptyObj(useAppSelector(getSubaccount));
   const { freeCollateral, marginUsage } = subAccount;
   const currentFreeCollateral = freeCollateral?.toNumber() ?? 0;
 

--- a/src/views/forms/StakingForms/shared/StakeConfirmationButtonRow.tsx
+++ b/src/views/forms/StakingForms/shared/StakeConfirmationButtonRow.tsx
@@ -1,7 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
 
-import { shallowEqual } from 'react-redux';
-
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
 import { StakeFormSteps } from '@/constants/stakingForms';
@@ -26,7 +24,7 @@ export const StakeConfirmationButtonRow = ({
   submitText,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
 
   return canAccountTrade ? (
     <div tw="inlineRow w-full gap-1">

--- a/src/views/forms/StakingForms/shared/StakeRewardButtonAndReceipt.tsx
+++ b/src/views/forms/StakingForms/shared/StakeRewardButtonAndReceipt.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { SelectedGasDenom } from '@dydxprotocol/v4-client-js';
-import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 import tw from 'twin.macro';
 
@@ -73,7 +72,7 @@ export const StakeRewardButtonAndReceipt = ({
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
 
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
   const { usdcBalance, nativeTokenBalance } = useAccountBalance();
   const { usdcLabel, chainTokenLabel } = useTokenConfigs();
   const [errorToDisplay, setErrorToDisplay] = useState(alert);

--- a/src/views/forms/TradeForm/MarketLeverageInput.tsx
+++ b/src/views/forms/TradeForm/MarketLeverageInput.tsx
@@ -1,5 +1,4 @@
 import { minBy } from 'lodash';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
@@ -40,9 +39,7 @@ export const MarketLeverageInput = ({
 }: ElementProps) => {
   const stringGetter = useStringGetter();
 
-  const { leverage: currentLeverage } = orEmptyObj(
-    useAppSelector(getCurrentMarketPositionData, shallowEqual)
-  );
+  const { leverage: currentLeverage } = orEmptyObj(useAppSelector(getCurrentMarketPositionData));
 
   const minLeverage = Math.min(leftLeverage, rightLeverage);
   const maxLeverage = Math.max(leftLeverage, rightLeverage);

--- a/src/views/forms/TradeForm/PositionPreview.tsx
+++ b/src/views/forms/TradeForm/PositionPreview.tsx
@@ -1,5 +1,4 @@
 import { BonsaiHelpers } from '@/bonsai/ontology';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
@@ -31,7 +30,7 @@ export const PositionPreview = ({ showNarrowVariation }: ElementProps) => {
     logo: imageUrl,
   } = orEmptyObj(useAppSelector(BonsaiHelpers.currentMarket.marketInfo));
   const { signedSize: positionSize, notional: notionalTotal } = orEmptyObj(
-    useAppSelector(getCurrentMarketPositionData, shallowEqual)
+    useAppSelector(getCurrentMarketPositionData)
   );
   const { signedSize: positionSizePostOrder } = orEmptyObj(
     useAppSelector(getCurrentSelectedFormPositionSummary)

--- a/src/views/forms/TransferForm/TransferButtonAndReceipt.tsx
+++ b/src/views/forms/TransferForm/TransferButtonAndReceipt.tsx
@@ -1,5 +1,4 @@
 import { TransferSummaryData, TransferToken } from '@/bonsai/forms/transfers';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction, ButtonSize, ButtonType } from '@/constants/buttons';
@@ -40,7 +39,7 @@ export const TransferButtonAndReceipt = ({
   slotLeft,
 }: ElementProps) => {
   const stringGetter = useStringGetter();
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
 
   const { tokensConfigs } = useTokenConfigs();
 

--- a/src/views/forms/TriggersForm/LimitPriceInputs.tsx
+++ b/src/views/forms/TriggersForm/LimitPriceInputs.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { shallowEqual, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { STRING_KEYS } from '@/constants/localization';
@@ -43,7 +43,7 @@ export const LimitPriceInputs = ({
   const stringGetter = useStringGetter();
 
   const triggerFormInputValues = useAppSelector(getTriggersFormState);
-  const triggerFormSummary = useAppSelector(getTriggersFormSummary, shallowEqual);
+  const triggerFormSummary = useAppSelector(getTriggersFormSummary);
 
   const [shouldShowLimitPrice, setShouldShowLimitPrice] = useState(existsLimitOrder);
 

--- a/src/views/forms/TriggersForm/TriggerOrdersInputs.tsx
+++ b/src/views/forms/TriggersForm/TriggerOrdersInputs.tsx
@@ -1,5 +1,3 @@
-import { shallowEqual } from 'react-redux';
-
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useAppSelector } from '@/state/appTypes';
@@ -23,7 +21,7 @@ export const TriggerOrdersInputs = ({
   onViewOrdersClick,
 }: ElementProps) => {
   const triggerFormInputValues = useAppSelector(getTriggersFormState);
-  const triggerFormSummary = useAppSelector(getTriggersFormSummary, shallowEqual);
+  const triggerFormSummary = useAppSelector(getTriggersFormSummary);
 
   return (
     <>

--- a/src/views/menus/AccountMenu.tsx
+++ b/src/views/menus/AccountMenu.tsx
@@ -3,7 +3,6 @@ import { ElementType, memo } from 'react';
 import { useMfaEnrollment, usePrivy } from '@privy-io/react-auth';
 import { Item } from '@radix-ui/react-dropdown-menu';
 import type { Dispatch } from '@reduxjs/toolkit';
-import { shallowEqual } from 'react-redux';
 import styled, { css } from 'styled-components';
 import tw from 'twin.macro';
 
@@ -48,7 +47,7 @@ import { WithTooltip } from '@/components/WithTooltip';
 import { OnboardingTriggerButton } from '@/views/dialogs/OnboardingTriggerButton';
 
 import { calculateIsAccountViewOnly } from '@/state/accountCalculators';
-import { getOnboardingState, getSubaccount } from '@/state/accountSelectors';
+import { getOnboardingState, getSubaccountFreeCollateral } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { AppTheme } from '@/state/appUiConfigs';
 import { getAppTheme } from '@/state/appUiConfigsSelectors';
@@ -69,7 +68,7 @@ export const AccountMenu = () => {
 
   const dispatch = useAppDispatch();
   const onboardingState = useAppSelector(getOnboardingState);
-  const { freeCollateral } = useAppSelector(getSubaccount, shallowEqual) ?? {};
+  const freeCollateral = useAppSelector(getSubaccountFreeCollateral);
 
   const { nativeTokenBalance, usdcBalance } = useAccountBalance();
 

--- a/src/views/tables/PositionsTable.tsx
+++ b/src/views/tables/PositionsTable.tsx
@@ -40,7 +40,6 @@ import { getSubaccountConditionalOrders } from '@/state/accountSelectors';
 import { useAppSelector } from '@/state/appTypes';
 
 import { getNumberSign, MaybeBigNumber, MaybeNumber, MustBigNumber } from '@/lib/numbers';
-import { safeAssign } from '@/lib/objectHelpers';
 import { orEmptyRecord } from '@/lib/typeUtils';
 
 import { CloseAllPositionsButton } from './PositionsTable/CloseAllPositionsButton';
@@ -481,20 +480,17 @@ export const PositionsTable = forwardRef(
       () =>
         positions.map((position: SubaccountPosition): PositionTableRow => {
           const marketSummary = marketSummaries[position.market];
-          return safeAssign(
-            {},
-            {
-              marketSummary,
-              stopLossOrders:
-                tpslOrdersByPositionUniqueId[position.uniqueId]?.stopLossOrders ?? EMPTY_ARR,
-              takeProfitOrders:
-                tpslOrdersByPositionUniqueId[position.uniqueId]?.takeProfitOrders ?? EMPTY_ARR,
-              stepSizeDecimals: marketSummary?.stepSizeDecimals ?? TOKEN_DECIMALS,
-              tickSizeDecimals: marketSummary?.tickSizeDecimals ?? USD_DECIMALS,
-              oraclePrice: MaybeNumber(marketSummary?.oraclePrice) ?? undefined,
-            },
-            position
-          );
+          return {
+            marketSummary,
+            stopLossOrders:
+              tpslOrdersByPositionUniqueId[position.uniqueId]?.stopLossOrders ?? EMPTY_ARR,
+            takeProfitOrders:
+              tpslOrdersByPositionUniqueId[position.uniqueId]?.takeProfitOrders ?? EMPTY_ARR,
+            stepSizeDecimals: marketSummary?.stepSizeDecimals ?? TOKEN_DECIMALS,
+            tickSizeDecimals: marketSummary?.tickSizeDecimals ?? USD_DECIMALS,
+            oraclePrice: MaybeNumber(marketSummary?.oraclePrice) ?? undefined,
+            ...position,
+          };
         }),
       [positions, tpslOrdersByPositionUniqueId, marketSummaries]
     );

--- a/src/views/tables/TransferHistoryTable.tsx
+++ b/src/views/tables/TransferHistoryTable.tsx
@@ -1,7 +1,6 @@
 import { BonsaiCore } from '@/bonsai/ontology';
 import { SubaccountTransfer } from '@/bonsai/types/summaryTypes';
 import type { ColumnSize } from '@react-types/table';
-import { shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import { ButtonAction } from '@/constants/buttons';
@@ -143,7 +142,7 @@ export const TransferHistoryTable = ({
   const dispatch = useAppDispatch();
   const { mintscan: mintscanTxUrl } = useURLConfigs();
 
-  const canAccountTrade = useAppSelector(calculateCanAccountTrade, shallowEqual);
+  const canAccountTrade = useAppSelector(calculateCanAccountTrade);
 
   const transfers = useAppSelector(BonsaiCore.account.transfers.data);
 


### PR DESCRIPTION
I didn't remove all shallowEqual, just the ones that are clearly doing nothing. 