### PR TITLE
chore: rewrite client managers again

### DIFF
--- a/src/bonsai/AccountTransactionSupervisor.ts
+++ b/src/bonsai/AccountTransactionSupervisor.ts
@@ -131,7 +131,7 @@ export class AccountTransactionSupervisor {
         }
 
         // Wait for the composite client to be available
-        const compositeClient = await clientWrapper.compositeClientPromise;
+        const compositeClient = await clientWrapper.compositeClient.deferred.promise;
 
         // Execute the function with the client wallet pair
         return await fn({ compositeClient, localWallet }, ...args);

--- a/src/bonsai/rest/lib/compositeClientManager.ts
+++ b/src/bonsai/rest/lib/compositeClientManager.ts
@@ -25,16 +25,26 @@ import { setNetworkStateRaw } from '@/state/raw';
 
 import { identify } from '@/lib/analytics/analytics';
 import { browserTimeOffsetPromise } from '@/lib/timeOffset';
+import { sleep } from '@/lib/timeUtils';
+
+type ClientState<ClientType> = {
+  dead: boolean;
+  client: ClientType | undefined;
+  // contains awaitable promise
+  deferred: Deferred<ClientType>;
+  currentOperationId: number;
+};
 
 type CompositeClientWrapper = {
   dead?: boolean;
-  compositeClient?: CompositeClient;
-  indexer?: IndexerClient;
-  nobleClient?: StargateClient;
+  // makes dead
   tearDown: () => void;
-  compositeClientPromise: Promise<CompositeClient>;
-  indexerPromise: Promise<IndexerClient>;
-  nobleClientPromise: Promise<StargateClient>;
+  // only really refreshes the composite and noble clients
+  refreshConnections: () => void;
+
+  compositeClient: ClientState<CompositeClient>;
+  indexer: ClientState<IndexerClient>;
+  nobleClient: ClientState<StargateClient>;
 };
 
 function makeCompositeClient({
@@ -56,71 +66,59 @@ function makeCompositeClient({
     throw new Error(`Unknown chain id: ${chainId}`);
   }
 
-  const { clientWrapper, setCompositeClient, setIndexerClient, setNobleClient, setErrorAndReject } =
-    initializeClientWrapper(dispatch, network);
-
-  (async () => {
+  function getIndexerConfig() {
     const indexerUrl = networkConfig.endpoints.indexers[0];
     if (indexerUrl == null) {
       throw new Error('No indexer urls found');
     }
-    const indexerConfig = new IndexerConfig(indexerUrl.api, indexerUrl.socket);
-    setIndexerClient(new IndexerClient(indexerConfig));
+    return new IndexerConfig(indexerUrl.api, indexerUrl.socket);
+  }
 
-    try {
-      const validatorUrl = await getValidatorToUse(chainId, networkConfig.endpoints.validators);
+  async function initializeCompositeClient() {
+    const indexerConfig = getIndexerConfig();
+    const validatorUrl = await getValidatorToUse(chainId, networkConfig.endpoints.validators);
 
-      if (clientWrapper.dead) {
-        return;
-      }
-
-      const compositeClient = await CompositeClient.connect(
-        new Network(
+    const compositeClient = await CompositeClient.connect(
+      new Network(
+        chainId,
+        indexerConfig,
+        new ValidatorConfig(
+          validatorUrl,
           chainId,
-          indexerConfig,
-          new ValidatorConfig(
-            validatorUrl,
-            chainId,
-            {
-              USDC_DENOM: tokens.usdc.denom,
-              USDC_DECIMALS: tokens.usdc.decimals,
-              USDC_GAS_DENOM: tokens.usdc.gasDenom,
-              CHAINTOKEN_DENOM: tokens.chain.denom,
-              CHAINTOKEN_DECIMALS: tokens.chain.decimals,
-            },
-            {
-              broadcastPollIntervalMs: 3_000,
-              broadcastTimeoutMs: 60_000,
-            },
-            DEFAULT_TRANSACTION_MEMO,
-            true,
-            (await browserTimeOffsetPromise).offset
-          )
+          {
+            USDC_DENOM: tokens.usdc.denom,
+            USDC_DECIMALS: tokens.usdc.decimals,
+            USDC_GAS_DENOM: tokens.usdc.gasDenom,
+            CHAINTOKEN_DENOM: tokens.chain.denom,
+            CHAINTOKEN_DECIMALS: tokens.chain.decimals,
+          },
+          {
+            broadcastPollIntervalMs: 3000,
+            broadcastTimeoutMs: 60000,
+          },
+          DEFAULT_TRANSACTION_MEMO,
+          true,
+          (await browserTimeOffsetPromise).offset
         )
-      );
+      )
+    );
+    return compositeClient;
+  }
 
-      // this shouldn't be necessary - can actually be false
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (clientWrapper.dead) {
-        return;
-      }
+  async function initializeNobleClient() {
+    return StargateClient.connect(networkConfig.endpoints.nobleValidator);
+  }
 
-      setCompositeClient(compositeClient);
+  async function initializeIndexerClient() {
+    return new IndexerClient(getIndexerConfig());
+  }
 
-      const nobleClient = await StargateClient.connect(networkConfig.endpoints.nobleValidator);
+  const clientWrapper = initializeClientWrapper(dispatch, network, {
+    compositeClient: initializeCompositeClient,
+    indexer: initializeIndexerClient,
+    nobleClient: initializeNobleClient,
+  });
 
-      // this shouldn't be necessary - can actually be false
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (clientWrapper.dead) {
-        return;
-      }
-
-      setNobleClient(nobleClient);
-    } catch (e) {
-      logBonsaiError('CompositeClientManager', 'error initializing composite client', { error: e });
-      setErrorAndReject('error initializing clients');
-    }
-  })();
   return clientWrapper;
 }
 
@@ -162,19 +160,162 @@ async function getValidatorToUse(chainId: DydxChainId, validatorEndpoints: strin
   return validatorUrl;
 }
 
-function initializeClientWrapper(dispatch: AppDispatch, network: DydxNetwork) {
-  const indexerDeferred = createDeferred<IndexerClient>();
-  const compositeClientDeferred = createDeferred<CompositeClient>();
-  const nobleClientDeferred = createDeferred<StargateClient>();
+function makeClientManager<ClientType>(args: {
+  load: () => Promise<ClientType>;
+  onSuccess: () => void;
+  onError: (e?: any) => void;
+}): {
+  clientState: ClientState<ClientType>;
+  load: () => void;
+  tearDown: () => void;
+} {
+  // mutable, stable reference
+  const clientState: ClientState<ClientType> = {
+    dead: false,
+    client: undefined,
+    currentOperationId: 0,
+    deferred: createDeferred<ClientType>(),
+  };
+
+  const load = async () => {
+    if (clientState.dead) {
+      return;
+    }
+
+    clientState.currentOperationId += 1;
+    const myId = clientState.currentOperationId;
+
+    if (clientState.deferred.state.settled) {
+      clientState.deferred = createDeferred<ClientType>();
+    }
+
+    try {
+      const client = await withRetry(() => {
+        if (clientState.dead || clientState.currentOperationId !== myId) {
+          throw new Error('Client dead or operation preempted');
+        }
+        return args.load();
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (clientState.dead || clientState.currentOperationId !== myId) {
+        return;
+      }
+      clientState.client = client;
+      clientState.deferred.resolve(client);
+      args.onSuccess();
+    } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (clientState.dead || clientState.currentOperationId !== myId) {
+        return;
+      }
+      clientState.client = undefined;
+      clientState.deferred.reject(e);
+      args.onError(e);
+    }
+  };
+
+  return {
+    clientState,
+    load,
+    tearDown: () => {
+      clientState.dead = true;
+      const tearDownError = new Error('client tear down');
+      clientState.deferred.reject(tearDownError);
+      // we assume wrapper will manage this
+      // args.onError(tearDownError);
+    },
+  };
+}
+
+function initializeClientWrapper(
+  dispatch: AppDispatch,
+  network: DydxNetwork,
+  loads: {
+    compositeClient: () => Promise<CompositeClient>;
+    indexer: () => Promise<IndexerClient>;
+    nobleClient: () => Promise<StargateClient>;
+  }
+) {
+  dispatch(
+    setNetworkStateRaw({
+      networkId: network,
+      stateToMerge: {
+        compositeClientReady: false,
+        indexerClientReady: false,
+        nobleClientReady: false,
+      },
+    })
+  );
+
+  const compositeClient = makeClientManager({
+    load: loads.compositeClient,
+    onSuccess: () =>
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { compositeClientReady: true },
+        })
+      ),
+    onError: (e) => {
+      logBonsaiError('CompositeClientManager', 'error initializing composite client', { error: e });
+
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { compositeClientReady: false, errorInitializing: true },
+        })
+      );
+    },
+  });
+  const indexer = makeClientManager({
+    load: loads.indexer,
+    onSuccess: () =>
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { indexerClientReady: true },
+        })
+      ),
+    onError: (e) => {
+      logBonsaiError('CompositeClientManager', 'error iializing indexer client', { error: e });
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { indexerClientReady: false, errorInitializing: true },
+        })
+      );
+    },
+  });
+  const nobleClient = makeClientManager({
+    load: loads.nobleClient,
+    onSuccess: () =>
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { nobleClientReady: true },
+        })
+      ),
+    onError: (e) => {
+      logBonsaiError('CompositeClientManager', 'error initializing noble client', { error: e });
+      dispatch(
+        setNetworkStateRaw({
+          networkId: network,
+          stateToMerge: { nobleClientReady: true, errorInitializing: true },
+        })
+      );
+    },
+  });
+
+  const clients = [compositeClient, indexer, nobleClient];
+
   const clientWrapper: CompositeClientWrapper = {
-    compositeClientPromise: compositeClientDeferred.promise,
-    indexerPromise: indexerDeferred.promise,
-    nobleClientPromise: nobleClientDeferred.promise,
+    dead: false,
+    compositeClient: compositeClient.clientState,
+    indexer: indexer.clientState,
+    nobleClient: nobleClient.clientState,
     tearDown: () => {
       clientWrapper.dead = true;
-      indexerDeferred.reject();
-      compositeClientDeferred.reject();
-      nobleClientDeferred.reject();
+      clients.forEach((c) => c.tearDown());
       dispatch(
         setNetworkStateRaw({
           networkId: network,
@@ -186,86 +327,57 @@ function initializeClientWrapper(dispatch: AppDispatch, network: DydxNetwork) {
         })
       );
     },
+    refreshConnections: () => {
+      clients.forEach((c) => c.load());
+    },
   };
-  const setIndexerClient = (c: IndexerClient) => {
-    clientWrapper.indexer = c;
-    indexerDeferred.resolve(c);
-    dispatch(
-      setNetworkStateRaw({
-        networkId: network,
-        stateToMerge: { indexerClientReady: true },
-      })
-    );
-  };
-  const setCompositeClient = (c: CompositeClient) => {
-    clientWrapper.compositeClient = c;
-    compositeClientDeferred.resolve(c);
-    dispatch(
-      setNetworkStateRaw({
-        networkId: network,
-        stateToMerge: { compositeClientReady: true },
-      })
-    );
-  };
-  const setNobleClient = (c: StargateClient) => {
-    clientWrapper.nobleClient = c;
-    nobleClientDeferred.resolve(c);
-    dispatch(
-      setNetworkStateRaw({
-        networkId: network,
-        stateToMerge: { nobleClientReady: true },
-      })
-    );
-  };
-  const setErrorAndReject = (msg: string) => {
-    if (clientWrapper.compositeClient == null) {
-      compositeClientDeferred.reject(new Error(msg));
-    }
-
-    if (clientWrapper.nobleClient == null) {
-      nobleClientDeferred.reject(new Error(msg));
-    }
-
-    dispatch(
-      setNetworkStateRaw({
-        networkId: network,
-        stateToMerge: { errorInitializing: true },
-      })
-    );
-  };
-  dispatch(
-    setNetworkStateRaw({
-      networkId: network,
-      stateToMerge: {
-        compositeClientReady: false,
-        indexerClientReady: false,
-        nobleClientReady: false,
-      },
-    })
-  );
-  return {
-    clientWrapper,
-    setIndexerClient,
-    setCompositeClient,
-    setNobleClient,
-    setErrorAndReject,
-  };
+  clients.forEach((c) => c.load());
+  return clientWrapper;
 }
 
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
   reject: (error?: Error) => void;
+  state: { settled: boolean };
 }
 
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (error?: Error) => void;
+  const state = { settled: false };
 
   const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
+    resolve = (value: T) => {
+      state.settled = true;
+      res(value);
+    };
+    reject = (error?: Error) => {
+      state.settled = true;
+      rej(error);
+    };
   });
 
-  return { promise, resolve, reject };
+  return { promise, resolve, reject, state };
+}
+
+async function withRetry<T>(
+  operation: () => Promise<T>,
+  options = { maxRetries: 3, initialDelay: 1000 }
+): Promise<T> {
+  for (let attempt = 0; attempt <= options.maxRetries; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await operation();
+    } catch (error) {
+      if (attempt < options.maxRetries) {
+        const delay = options.initialDelay * 2 ** attempt;
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(delay);
+      } else {
+        throw error;
+      }
+    }
+  }
+  throw new Error('Failed to complete operation - this should be unreachable');
 }

--- a/src/bonsai/rest/lib/compositeClientManager.ts
+++ b/src/bonsai/rest/lib/compositeClientManager.ts
@@ -303,7 +303,7 @@ function initializeClientWrapper(
       dispatch(
         setNetworkStateRaw({
           networkId: network,
-          stateToMerge: { nobleClientReady: true, errorInitializing: true },
+          stateToMerge: { nobleClientReady: false, errorInitializing: true },
         })
       );
     },

--- a/src/bonsai/rest/lib/compositeClientManager.ts
+++ b/src/bonsai/rest/lib/compositeClientManager.ts
@@ -280,7 +280,7 @@ function initializeClientWrapper(
         })
       ),
     onError: (e) => {
-      logBonsaiError('CompositeClientManager', 'error iializing indexer client', { error: e });
+      logBonsaiError('CompositeClientManager', 'error initializing indexer client', { error: e });
       dispatch(
         setNetworkStateRaw({
           networkId: network,

--- a/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
+++ b/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
@@ -1,6 +1,7 @@
 import { logBonsaiError, wrapAndLogBonsaiError } from '@/bonsai/logs';
 import {
   selectCompositeClientReady,
+  selectCompositeClientUrl,
   selectIndexerReady,
   selectNobleClientReady,
 } from '@/bonsai/socketSelectors';
@@ -154,9 +155,9 @@ export function createValidatorStoreEffect<T>(
   config: InfraSetupConfig<CompositeClient, T>
 ) {
   const fullSelector = createAppSelector(
-    [getSelectedNetwork, selectCompositeClientReady, config.selector],
-    (network, compositeClientReady, selectorResult) => ({
-      infrastructure: { network, compositeClientReady },
+    [getSelectedNetwork, selectCompositeClientReady, selectCompositeClientUrl, config.selector],
+    (network, compositeClientReady, compositeClientUrl, selectorResult) => ({
+      infrastructure: { network, compositeClientReady, compositeClientUrl },
       selectorResult,
     })
   );
@@ -175,7 +176,8 @@ export function createValidatorStoreEffect<T>(
     const compositeClient = CompositeClientManager.use(clientConfig).compositeClient.client!;
 
     const unsubscribe = config.handle(
-      `${infrastructure.network}-${infrastructure.compositeClientReady}`,
+      // we want to trigger refreshes when we switch validator url too
+      `${infrastructure.network}-${infrastructure.compositeClientReady}-${infrastructure.compositeClientUrl}`,
       compositeClient,
       selectorResult
     );

--- a/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
+++ b/src/bonsai/rest/lib/indexerQueryStoreEffect.ts
@@ -83,7 +83,7 @@ export function createIndexerStoreEffect<T>(
       network: infrastructure.network,
       dispatch: store.dispatch,
     };
-    const indexerClient = CompositeClientManager.use(clientConfig).indexer!;
+    const indexerClient = CompositeClientManager.use(clientConfig).indexer.client!;
 
     const unsubscribe = config.handle(
       `${infrastructure.network}-${infrastructure.indexerReady}`,
@@ -172,7 +172,7 @@ export function createValidatorStoreEffect<T>(
       network: infrastructure.network,
       dispatch: store.dispatch,
     };
-    const compositeClient = CompositeClientManager.use(clientConfig).compositeClient!;
+    const compositeClient = CompositeClientManager.use(clientConfig).compositeClient.client!;
 
     const unsubscribe = config.handle(
       `${infrastructure.network}-${infrastructure.compositeClientReady}`,
@@ -262,7 +262,7 @@ export function createNobleQueryStoreEffect<T, R>(
       dispatch: store.dispatch,
     };
 
-    const nobleClient = CompositeClientManager.use(clientConfig).nobleClient!;
+    const nobleClient = CompositeClientManager.use(clientConfig).nobleClient.client!;
 
     const queryFn = config.getQueryFn(nobleClient, queryData);
     if (!queryFn) {

--- a/src/bonsai/rest/lib/useIndexer.ts
+++ b/src/bonsai/rest/lib/useIndexer.ts
@@ -23,7 +23,7 @@ export function useIndexerClient() {
       network: selectedNetwork,
       dispatch,
     };
-    setClient(CompositeClientManager.use(clientConfig).indexer!);
+    setClient(CompositeClientManager.use(clientConfig).indexer.client!);
     return () => {
       setClient(undefined);
       CompositeClientManager.markDone(clientConfig);
@@ -48,7 +48,7 @@ export function useCompositeClient() {
       network: selectedNetwork,
       dispatch,
     };
-    setClient(CompositeClientManager.use(clientConfig).compositeClient!);
+    setClient(CompositeClientManager.use(clientConfig).compositeClient.client!);
     return () => {
       setClient(undefined);
       CompositeClientManager.markDone(clientConfig);

--- a/src/bonsai/socketSelectors.ts
+++ b/src/bonsai/socketSelectors.ts
@@ -41,6 +41,13 @@ export const selectCompositeClientReady = createAppSelector(
   }
 );
 
+export const selectCompositeClientUrl = createAppSelector(
+  [getSelectedNetwork, (state: RootState) => state.raw.network],
+  (network, networks) => {
+    return networks[network]?.compositeClientUrl;
+  }
+);
+
 export const selectNobleClientReady = createAppSelector(
   [getSelectedNetwork, (state: RootState) => state.raw.network],
   (network, networks) => {

--- a/src/hooks/useInitializePage.ts
+++ b/src/hooks/useInitializePage.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { logBonsaiInfo } from '@/bonsai/logs';
 // eslint-disable-next-line no-restricted-imports
+import { CompositeClientManager } from '@/bonsai/rest/lib/compositeClientManager';
+// eslint-disable-next-line no-restricted-imports
 import { IndexerWebsocketManager } from '@/bonsai/websocket/lib/indexerWebsocketManager';
 
 import { LocalStorageKey } from '@/constants/localStorage';
@@ -43,6 +45,7 @@ export const useInitializePage = () => {
           if (hiddenDuration >= RECONNECT_AFTER_HIDDEN_THRESHOLD) {
             // reconnect (reestablish connections to indexer, validator etc.) if app was hidden for more than 10 seconds
             IndexerWebsocketManager.getActiveResources().forEach((r) => r.restart());
+            CompositeClientManager.getActiveResources().forEach((r) => r.refreshConnections());
             logBonsaiInfo('useInitializePage', 'restarting because visibility change');
           }
           hiddenTimeRef.current = null;
@@ -59,6 +62,7 @@ export const useInitializePage = () => {
   useEffect(() => {
     const handleOnline = () => {
       IndexerWebsocketManager.getActiveResources().forEach((r) => r.restart());
+      CompositeClientManager.getActiveResources().forEach((r) => r.refreshConnections());
       logBonsaiInfo('useInitializePage', 'restarting because network status change');
     };
     window.addEventListener('online', handleOnline);

--- a/src/state/raw.ts
+++ b/src/state/raw.ts
@@ -37,6 +37,7 @@ import { autoBatchAllReducers } from './autoBatchHelpers';
 interface NetworkState {
   indexerClientReady: boolean;
   compositeClientReady: boolean;
+  compositeClientUrl: string | undefined;
   nobleClientReady: boolean;
   errorInitializing: boolean;
 }
@@ -204,6 +205,7 @@ export const rawSlice = createSlice({
       state.network[networkId] = {
         ...(state.network[networkId] ?? {
           compositeClientReady: false,
+          compositeClientUrl: undefined,
           indexerClientReady: false,
           nobleClientReady: false,
           errorInitializing: false,


### PR DESCRIPTION
New features:
* retry initialization for all clients up to 3 times with exponential backoff starting at 1s and doubling each retry
* refresh client initialization on visible/network status change in case best network changes - but only trigger query refresh when the actual validator url changes
* parallelize client initialization for speed and so we can be in partial success states (not all or nothing)