### PR TITLE
fix: misc trade fixes 3

### DIFF
--- a/src/bonsai/forms/trade/types.ts
+++ b/src/bonsai/forms/trade/types.ts
@@ -201,13 +201,13 @@ export type TradeSummary = {
   total: number | undefined;
   reward: number | undefined;
   filled: boolean;
+  feeRate: number | undefined;
 
   // if this trade is effectively closing the position, for simulation purposes
   isPositionClosed: boolean;
 
   // only for market orders
   indexSlippage: number | undefined;
-  feeRate: number | undefined;
 };
 
 export type TradeFormSummary = {

--- a/src/bonsai/forms/trade/types.ts
+++ b/src/bonsai/forms/trade/types.ts
@@ -205,6 +205,7 @@ export type TradeSummary = {
   // if this trade is effectively closing the position, for simulation purposes
   isPositionClosed: boolean;
 
+  // only for market orders
   indexSlippage: number | undefined;
   feeRate: number | undefined;
 };

--- a/src/views/forms/TradeForm/AmountCloseInput.tsx
+++ b/src/views/forms/TradeForm/AmountCloseInput.tsx
@@ -45,7 +45,7 @@ export const AmountCloseInput = ({
   return (
     <$InputContainer>
       {/* TODO: localize */}
-      <$WithLabel label={<div tw="flex">Amount Close</div>}>
+      <$WithLabel label={<div tw="mb-0.25 flex">Amount Close</div>}>
         <$AmountCloseSlider
           label="AmountClose"
           min={0}


### PR DESCRIPTION
Most important change: we don't use current oracle price to determine slippage equity impact, we use estimated (worst case) oracle price at execution time. 