### PR TITLE
fix: simplify triggers - stop orders subsume take profit

### DIFF
--- a/src/bonsai/forms/trade/fields.ts
+++ b/src/bonsai/forms/trade/fields.ts
@@ -166,8 +166,7 @@ export function getTradeFormFieldStates(
         }
 
         return result;
-      case TradeFormType.STOP_LIMIT:
-      case TradeFormType.TAKE_PROFIT_LIMIT:
+      case TradeFormType.TRIGGER_LIMIT:
         makeVisible(result, [
           'marketId',
           'side',
@@ -188,8 +187,7 @@ export function getTradeFormFieldStates(
           forceValueAndDisable(result.reduceOnly, false);
         }
         return result;
-      case TradeFormType.STOP_MARKET:
-      case TradeFormType.TAKE_PROFIT_MARKET:
+      case TradeFormType.TRIGGER_MARKET:
         makeVisible(result, [
           'marketId',
           'side',

--- a/src/bonsai/forms/trade/tradeInfo.ts
+++ b/src/bonsai/forms/trade/tradeInfo.ts
@@ -44,9 +44,7 @@ import {
 
 const MARKET_ORDER_MAX_SLIPPAGE = 0.05;
 const STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05;
-const TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05;
 const STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1;
-const TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1;
 const MAX_TARGET_LEVERAGE_BUFFER_PERCENT = 0.98;
 const MAX_LEVERAGE_BUFFER_PERCENT = 0.98;
 const DEFAULT_TARGET_LEVERAGE = 2.0;
@@ -155,8 +153,7 @@ export function calculateTradeInfo(
             ),
           };
         });
-      case TradeFormType.STOP_MARKET:
-      case TradeFormType.TAKE_PROFIT_MARKET:
+      case TradeFormType.TRIGGER_MARKET:
         return calc((): TradeSummary => {
           const calculated = calculateMarketOrder(trade, baseAccount, accountData, subaccountToUse);
           const orderbookBase = accountData.currentTradeMarketOrderbook;
@@ -176,13 +173,9 @@ export function calculateTradeInfo(
               const isMajorMarket = MAJOR_MARKETS.has(marketId);
               const additionalBuffer = calc(() => {
                 if (isMajorMarket) {
-                  return trade.type === TradeFormType.STOP_MARKET
-                    ? STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
-                    : TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET;
+                  return STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET;
                 }
-                return trade.type === TradeFormType.STOP_MARKET
-                  ? STOP_MARKET_ORDER_SLIPPAGE_BUFFER
-                  : TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER;
+                return STOP_MARKET_ORDER_SLIPPAGE_BUFFER;
               });
 
               return slippage + additionalBuffer;
@@ -267,8 +260,7 @@ export function calculateTradeInfo(
           };
         });
       case TradeFormType.LIMIT:
-      case TradeFormType.STOP_LIMIT:
-      case TradeFormType.TAKE_PROFIT_LIMIT:
+      case TradeFormType.TRIGGER_LIMIT:
         return calc((): TradeSummary => {
           const timeInForce = trade.timeInForce;
           const execution = trade.execution;
@@ -1020,11 +1012,9 @@ function calculateIsolatedMarginTransferAmount(
       case TradeFormType.MARKET:
         return oraclePrice;
       case TradeFormType.LIMIT:
-      case TradeFormType.STOP_LIMIT:
-      case TradeFormType.TAKE_PROFIT_LIMIT:
+      case TradeFormType.TRIGGER_LIMIT:
         return tradePrice;
-      case TradeFormType.STOP_MARKET:
-      case TradeFormType.TAKE_PROFIT_MARKET:
+      case TradeFormType.TRIGGER_MARKET:
         return MustNumber(trade.triggerPrice);
       default:
         assertNever(trade.type);

--- a/src/bonsai/forms/trade/types.ts
+++ b/src/bonsai/forms/trade/types.ts
@@ -69,10 +69,8 @@ export type OrderSizeInput = UnionOf<typeof OrderSizeInputs>;
 export enum TradeFormType {
   MARKET = 'MARKET',
   LIMIT = 'LIMIT',
-  STOP_MARKET = 'STOP_MARKET',
-  STOP_LIMIT = 'STOP_LIMIT',
-  TAKE_PROFIT_MARKET = 'TAKE_PROFIT_MARKET',
-  TAKE_PROFIT_LIMIT = 'TAKE_PROFIT_LIMIT',
+  TRIGGER_MARKET = 'TRIGGER_MARKET',
+  TRIGGER_LIMIT = 'TRIGGER_LIMIT',
 }
 
 type OrderMatcher<T> = {

--- a/src/constants/trade.ts
+++ b/src/constants/trade.ts
@@ -46,22 +46,27 @@ export const ORDER_TYPE_STRINGS: Record<
     orderTypeKey: STRING_KEYS.MARKET_ORDER,
     descriptionKey: STRING_KEYS.MARKET_ORDER_DESCRIPTION,
   },
-  [TradeFormType.STOP_LIMIT]: {
+  [TradeFormType.TRIGGER_LIMIT]: {
     orderTypeKeyShort: STRING_KEYS.STOP_LIMIT,
     orderTypeKey: STRING_KEYS.STOP_LIMIT,
     descriptionKey: STRING_KEYS.STOP_LIMIT_DESCRIPTION,
   },
-  [TradeFormType.STOP_MARKET]: {
+  [TradeFormType.TRIGGER_MARKET]: {
     orderTypeKeyShort: STRING_KEYS.STOP_MARKET,
     orderTypeKey: STRING_KEYS.STOP_MARKET,
     descriptionKey: STRING_KEYS.STOP_MARKET_DESCRIPTION,
   },
-  [TradeFormType.TAKE_PROFIT_LIMIT]: {
-    orderTypeKeyShort: STRING_KEYS.TAKE_PROFIT_LIMIT_SHORT,
-    orderTypeKey: STRING_KEYS.TAKE_PROFIT_LIMIT,
-    descriptionKey: STRING_KEYS.TAKE_PROFIT_LIMIT_DESCRIPTION,
+  [IndexerOrderType.STOPMARKET]: {
+    orderTypeKeyShort: STRING_KEYS.STOP_MARKET,
+    orderTypeKey: STRING_KEYS.STOP_MARKET,
+    descriptionKey: STRING_KEYS.STOP_MARKET_DESCRIPTION,
   },
-  [TradeFormType.TAKE_PROFIT_MARKET]: {
+  [IndexerOrderType.STOPLIMIT]: {
+    orderTypeKeyShort: STRING_KEYS.STOP_LIMIT,
+    orderTypeKey: STRING_KEYS.STOP_LIMIT,
+    descriptionKey: STRING_KEYS.STOP_LIMIT_DESCRIPTION,
+  },
+  [IndexerOrderType.TAKEPROFITMARKET]: {
     orderTypeKeyShort: STRING_KEYS.TAKE_PROFIT_MARKET_SHORT,
     orderTypeKey: STRING_KEYS.TAKE_PROFIT_MARKET,
     descriptionKey: STRING_KEYS.TAKE_PROFIT_MARKET_DESCRIPTION,

--- a/src/views/forms/TradeForm/useTradeTypeOptions.tsx
+++ b/src/views/forms/TradeForm/useTradeTypeOptions.tsx
@@ -56,13 +56,10 @@ export const useTradeTypeOptions = (opts?: { showAssetIcon?: boolean; showAll?: 
       allTradeTypeItems.length > 2
         ? {
             label:
-              selectedTradeType === TradeFormType.TAKE_PROFIT_LIMIT ||
-              selectedTradeType === TradeFormType.TAKE_PROFIT_MARKET
-                ? stringGetter({ key: STRING_KEYS.TAKE_PROFIT })
-                : selectedTradeType === TradeFormType.STOP_LIMIT ||
-                    selectedTradeType === TradeFormType.STOP_MARKET
-                  ? stringGetter({ key: STRING_KEYS.STOP_ORDER_SHORT })
-                  : stringGetter({ key: STRING_KEYS.ADVANCED }),
+              selectedTradeType === TradeFormType.TRIGGER_LIMIT ||
+              selectedTradeType === TradeFormType.TRIGGER_MARKET
+                ? stringGetter({ key: STRING_KEYS.STOP_ORDER_SHORT })
+                : stringGetter({ key: STRING_KEYS.ADVANCED }),
             value: '' as TradeFormType,
             subitems: allTradeTypeItems.slice(2),
           }


### PR DESCRIPTION
We just infer TP/SL based on the relationship between current oracle price and trigger price. 

<img width="330" alt="image" src="https://github.com/user-attachments/assets/066f7b18-82f9-4791-bcd1-849fffd755e4" />
