### PR TITLE
fix: estimate chain height

### DIFF
--- a/src/bonsai/AccountTransactionSupervisor.ts
+++ b/src/bonsai/AccountTransactionSupervisor.ts
@@ -65,6 +65,7 @@ import { isPresent } from '@/lib/typeUtils';
 import { getSimpleOrderStatus } from './calculators/orders';
 import { PlaceOrderMarketInfo, PlaceOrderPayload } from './forms/triggers/types';
 import { CompositeClientManager } from './rest/lib/compositeClientManager';
+import { estimateLiveValidatorHeight } from './selectors/apiStatus';
 
 interface ClientWalletPair {
   compositeClient: CompositeClient;
@@ -368,15 +369,14 @@ export class AccountTransactionSupervisor {
     }
 
     // Get current blockchain height for goodTilBlock
-    const validatorHeight = BonsaiCore.network.validatorHeight.data(state);
-    if (validatorHeight == null) {
+    const currentHeight = estimateLiveValidatorHeight(state);
+    if (currentHeight == null) {
       logBonsaiError(
         'AccountTransactionSupervisor/getCloseAllPositionsPayloads',
         'cannot generate close all positions payload because validatorHeight is null'
       );
       return undefined;
     }
-    const currentHeight = validatorHeight.height;
 
     const markets = BonsaiCore.markets.markets.data(state);
     if (markets == null) {
@@ -604,15 +604,14 @@ export class AccountTransactionSupervisor {
       );
     }
 
-    const validatorHeight = BonsaiCore.network.validatorHeight.data(this.store.getState());
-    if (validatorHeight == null) {
+    const currentHeight = estimateLiveValidatorHeight(this.store.getState());
+    if (currentHeight == null) {
       return wrapSimpleError(
         'AccountTransactionSupervisor/placeOrder',
         'validator height unknown',
         STRING_KEYS.UNKNOWN_VALIDATOR_HEIGHT
       );
     }
-    const currentHeight = validatorHeight.height;
     const isShortTermOrder = calc(() => {
       if (payloadBase.type === OrderType.MARKET) {
         return true;

--- a/src/bonsai/calculators/apiState.ts
+++ b/src/bonsai/calculators/apiState.ts
@@ -3,7 +3,7 @@ import { HeightResponse } from '@dydxprotocol/v4-client-js';
 
 import { timeUnits } from '@/constants/time';
 
-import { HeightState } from '@/state/raw';
+import { HeightEntry, HeightState } from '@/state/raw';
 
 import { assertNever } from '@/lib/assertNever';
 
@@ -129,8 +129,12 @@ function getApiState({
   assertNever(validatorState);
 }
 
+export function getLatestHeightEntry(heightState: HeightState): HeightEntry | undefined {
+  return heightState.lastFewResults.find((s) => s.data?.response != null)?.data;
+}
+
 export function getLatestHeight(heightState: HeightState): HeightResponse | undefined {
-  return heightState.lastFewResults.find((s) => s.data?.response != null)?.data?.response;
+  return getLatestHeightEntry(heightState)?.response;
 }
 
 let lastLoggedStatus: ApiStatus | undefined;

--- a/src/bonsai/selectors/apiStatus.ts
+++ b/src/bonsai/selectors/apiStatus.ts
@@ -1,8 +1,11 @@
 import { HeightResponse } from '@dydxprotocol/v4-client-js';
 
+import { ESTIMATED_BLOCK_TIME } from '@/constants/numbers';
+
+import { type RootState } from '@/state/_store';
 import { createAppSelector } from '@/state/appTypes';
 
-import { computeApiState, getLatestHeight } from '../calculators/apiState';
+import { computeApiState, getLatestHeight, getLatestHeightEntry } from '../calculators/apiState';
 import { selectRawIndexerHeightData, selectRawValidatorHeightData } from './base';
 
 export const selectApiState = createAppSelector(
@@ -20,3 +23,20 @@ export const selectLatestValidatorHeight = createAppSelector(
   [selectRawValidatorHeightData],
   (height): HeightResponse | undefined => getLatestHeight(height)
 );
+
+// not a selector since we use current time
+// we return a very conservative estimate, aiming to return the smallest reasonable block height estimate
+export const estimateLiveValidatorHeight = (state: RootState) => {
+  const latestEntry = getLatestHeightEntry(selectRawValidatorHeightData(state));
+  const heightAtRequest = latestEntry?.response?.height;
+  if (latestEntry == null || heightAtRequest == null) {
+    return undefined;
+  }
+  // note: height response has time on it but we don't know if it's in sync with local system time so we can't use it
+  const responseTime = new Date(latestEntry.receivedTime).getTime();
+  const now = new Date().getTime();
+  const elapsedTime = now - responseTime;
+
+  const elapsedBlocksEst = Math.floor(elapsedTime / ESTIMATED_BLOCK_TIME);
+  return heightAtRequest + elapsedBlocksEst;
+};

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,3 +1,5 @@
+import { isMainnet } from './networks';
+
 export const USD_DECIMALS = 2;
 export const SMALL_USD_DECIMALS = 4;
 
@@ -32,3 +34,5 @@ export const MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 0.05;
 
 // Launch Market
 export const DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH = 10_000;
+
+export const ESTIMATED_BLOCK_TIME = isMainnet ? 1_000 : 1_100;

--- a/src/hooks/useWithdrawalInfo.ts
+++ b/src/hooks/useWithdrawalInfo.ts
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 
 import { DialogTypes } from '@/constants/dialogs';
-import { isMainnet } from '@/constants/networks';
+import { ESTIMATED_BLOCK_TIME } from '@/constants/numbers';
 
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { closeDialog, openDialog } from '@/state/dialogs';
@@ -21,8 +21,6 @@ import { useApiState } from './useApiState';
 import { useDydxClient } from './useDydxClient';
 import { useEnvFeatures } from './useEnvFeatures';
 import { useTokenConfigs } from './useTokenConfigs';
-
-const BLOCK_TIME = isMainnet ? 1_000 : 1_500;
 
 export const useWithdrawalInfo = ({
   transferType,
@@ -89,7 +87,7 @@ export const useWithdrawalInfo = ({
     ) {
       return {
         estimatedUnblockTime: formatRelativeTime(
-          Date.now() + (withdrawalsAndTransfersUnblockedAtBlock - height) * BLOCK_TIME,
+          Date.now() + (withdrawalsAndTransfersUnblockedAtBlock - height) * ESTIMATED_BLOCK_TIME,
           {
             locale: selectedLocale,
             largestUnit: 'day',

--- a/src/pages/vaults/VaultLockedSharesTable.tsx
+++ b/src/pages/vaults/VaultLockedSharesTable.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import { ButtonShape, ButtonSize } from '@/constants/buttons';
 import { STRING_KEYS } from '@/constants/localization';
+import { ESTIMATED_BLOCK_TIME } from '@/constants/numbers';
 import { timeUnits } from '@/constants/time';
 
 import { useApiState } from '@/hooks/useApiState';
@@ -80,7 +81,8 @@ const VaultLockedSharesTable = ({
               unlockBlockHeight,
               height,
               // add a day so users don't get confused about why their money isn't unlocked when the day arrives
-              (unblock, actual) => new Date().getTime() + (unblock - actual) * 1000 + timeUnits.day
+              (unblock, actual) =>
+                new Date().getTime() + (unblock - actual) * ESTIMATED_BLOCK_TIME + timeUnits.day
             );
             return (
               <Output


### PR DESCRIPTION
To fix issues with some users submitting market orders that are already expired. This happens if the validatorHeight in the state gets old or fails once or twice or is slow. 