### PR TITLE
feat(simple-ui): Scaffold Position + Order cards and simplify TvChart

### DIFF
--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -312,6 +312,7 @@ type ElementProps = {
 type StyleProps = {
   className?: string;
   withBaseFont?: boolean;
+  withSignColor?: boolean;
 };
 
 export type OutputProps = ElementProps & StyleProps;
@@ -334,6 +335,7 @@ export const Output = ({
   withSubscript = false,
   withParentheses,
   showSign = ShowSign.Negative,
+  withSignColor = false,
 
   dateOptions,
   relativeTimeOptions = {
@@ -455,6 +457,12 @@ export const Output = ({
         [ShowSign.None]: undefined,
       }[showSign];
 
+      const signColor = withSignColor
+        ? isNegative
+          ? 'var(--color-negative)'
+          : 'var(--color-positive)'
+        : 'currentColor';
+
       return (
         <$Number
           key={value?.toString()}
@@ -474,7 +482,15 @@ export const Output = ({
           withBaseFont={withBaseFont}
         >
           {slotLeft}
-          {sign && <span tw="text-[color:--output-sign-color]">{sign}</span>}
+          {sign && (
+            <span
+              css={{
+                color: `var(--output-sign-color, ${signColor})`,
+              }}
+            >
+              {sign}
+            </span>
+          )}
           {hasValue && renderedNumber}
           {slotRight}
           {tag && <Tag tw="ml-[0.5ch]">{tag}</Tag>}
@@ -489,7 +505,7 @@ export const Output = ({
 const $Text = styled.output<{ withParentheses?: boolean }>`
   --output-beforeString: '';
   --output-afterString: '';
-  --output-sign-color: currentColor;
+  --output-sign-color: ;
 
   ${layoutMixins.inlineRow}
   gap: 0;

--- a/src/components/PositionSideTag.tsx
+++ b/src/components/PositionSideTag.tsx
@@ -1,4 +1,5 @@
 import { POSITION_SIDE_STRINGS, PositionSide } from '@/constants/trade';
+import { IndexerPositionSide } from '@/types/indexer/indexerApiGen';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -16,6 +17,16 @@ const positionSideTagSign: Record<PositionSide, TagSign> = {
   [PositionSide.Long]: TagSign.Positive,
   [PositionSide.Short]: TagSign.Negative,
   [PositionSide.None]: TagSign.Neutral,
+};
+
+export const getPositionSideFromIndexerPositionSide = (
+  positionSide: IndexerPositionSide | null
+) => {
+  if (positionSide == null) {
+    return PositionSide.None;
+  }
+
+  return positionSide === IndexerPositionSide.LONG ? PositionSide.Long : PositionSide.Short;
 };
 
 export const PositionSideTag = ({ positionSide, size }: ElementProps & StyleProps) => {

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -112,7 +112,6 @@ export const useTradingView = ({
   useEffect(() => {
     if (marketId) {
       const isSimpleUi = isTablet && testFlags.simpleUi;
-      console.log('isSimpleUi', isSimpleUi);
       const widgetOptions = getWidgetOptions(false, isSimpleUi);
       const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode, isSimpleUi });
       const languageCode = SUPPORTED_LOCALE_MAP[selectedLocale].baseTag;

--- a/src/hooks/tradingView/useTradingView.ts
+++ b/src/hooks/tradingView/useTradingView.ts
@@ -23,10 +23,12 @@ import { getSelectedLocale } from '@/state/localizationSelectors';
 import { updateChartConfig } from '@/state/tradingView';
 import { getTvChartConfig } from '@/state/tradingViewSelectors';
 
+import { testFlags } from '@/lib/testFlags';
 import { getDydxDatafeed } from '@/lib/tradingView/dydxfeed';
 import { getSavedResolution, getWidgetOptions, getWidgetOverrides } from '@/lib/tradingView/utils';
 import { orEmptyObj } from '@/lib/typeUtils';
 
+import { useBreakpoints } from '../useBreakpoints';
 import { useDydxClient } from '../useDydxClient';
 import { useLocaleSeparators } from '../useLocaleSeparators';
 import { useStringGetter } from '../useStringGetter';
@@ -57,6 +59,7 @@ export const useTradingView = ({
 
   const { group, decimal } = useLocaleSeparators();
 
+  const { isTablet } = useBreakpoints();
   const appTheme = useAppSelector(getAppTheme);
   const appColorMode = useAppSelector(getAppColorMode);
 
@@ -108,8 +111,10 @@ export const useTradingView = ({
 
   useEffect(() => {
     if (marketId) {
-      const widgetOptions = getWidgetOptions();
-      const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
+      const isSimpleUi = isTablet && testFlags.simpleUi;
+      console.log('isSimpleUi', isSimpleUi);
+      const widgetOptions = getWidgetOptions(false, isSimpleUi);
+      const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode, isSimpleUi });
       const languageCode = SUPPORTED_LOCALE_MAP[selectedLocale].baseTag;
 
       const options: TradingTerminalWidgetOptions = {
@@ -190,5 +195,6 @@ export const useTradingView = ({
     setOrderLinesToggleOn,
     setTvWidget,
     !!marketId,
+    isTablet,
   ]);
 };

--- a/src/hooks/tradingView/useTradingViewLaunchable.ts
+++ b/src/hooks/tradingView/useTradingViewLaunchable.ts
@@ -21,8 +21,11 @@ import { getSelectedLocale } from '@/state/localizationSelectors';
 import { updateLaunchableMarketsChartConfig } from '@/state/tradingView';
 import { getTvChartConfig } from '@/state/tradingViewSelectors';
 
+import { testFlags } from '@/lib/testFlags';
 import { getLaunchableMarketDatafeed } from '@/lib/tradingView/launchableMarketFeed';
 import { getSavedResolution, getWidgetOptions, getWidgetOverrides } from '@/lib/tradingView/utils';
+
+import { useBreakpoints } from '../useBreakpoints';
 
 /**
  * @description Hook to initialize TradingView Chart
@@ -37,6 +40,7 @@ export const useTradingViewLaunchable = ({
   marketId: string;
 }) => {
   const dispatch = useDispatch();
+  const { isTablet } = useBreakpoints();
   const appTheme = useAppSelector(getAppTheme);
   const appColorMode = useAppSelector(getAppColorMode);
 
@@ -52,8 +56,9 @@ export const useTradingViewLaunchable = ({
 
   useEffect(() => {
     if (marketId && !assetDataLoading && !tvWidget) {
-      const widgetOptions = getWidgetOptions(true);
-      const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode });
+      const isSimpleUi = isTablet && testFlags.simpleUi;
+      const widgetOptions = getWidgetOptions(true, isSimpleUi);
+      const widgetOverrides = getWidgetOverrides({ appTheme, appColorMode, isSimpleUi });
       const languageCode = SUPPORTED_LOCALE_MAP[selectedLocale].baseTag;
 
       const options: TradingTerminalWidgetOptions = {
@@ -83,5 +88,5 @@ export const useTradingViewLaunchable = ({
     return () => {
       tvWidget?.remove();
     };
-  }, [dispatch, !!marketId, selectedLocale, assetDataLoading, tvWidget, setTvWidget]);
+  }, [dispatch, !!marketId, selectedLocale, assetDataLoading, tvWidget, setTvWidget, isTablet]);
 };

--- a/src/hooks/tradingView/useTradingViewTheme.ts
+++ b/src/hooks/tradingView/useTradingViewTheme.ts
@@ -8,7 +8,10 @@ import { AppColorMode, AppTheme } from '@/state/appUiConfigs';
 import { getAppColorMode, getAppTheme } from '@/state/appUiConfigsSelectors';
 
 import { assertNever } from '@/lib/assertNever';
+import { testFlags } from '@/lib/testFlags';
 import { getChartLineColors, getWidgetOverrides } from '@/lib/tradingView/utils';
+
+import { useBreakpoints } from '../useBreakpoints';
 
 /**
  * @description Method to define a type guard and check that an element is an IFRAME
@@ -32,6 +35,7 @@ export const useTradingViewTheme = ({
 }) => {
   const appTheme: AppTheme = useAppSelector(getAppTheme);
   const appColorMode: AppColorMode = useAppSelector(getAppColorMode);
+  const { isTablet } = useBreakpoints();
 
   useEffect(() => {
     if (!tvWidget) return;
@@ -64,8 +68,13 @@ export const useTradingViewTheme = ({
           }
         }
 
+        const isSimpleUi = isTablet && testFlags.simpleUi;
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const { overrides, studies_overrides } = getWidgetOverrides({ appTheme, appColorMode });
+        const { overrides, studies_overrides } = getWidgetOverrides({
+          appTheme,
+          appColorMode,
+          isSimpleUi,
+        });
         tvWidget.applyOverrides(overrides);
         tvWidget.applyStudiesOverrides(studies_overrides);
 

--- a/src/lib/tradingView/utils.ts
+++ b/src/lib/tradingView/utils.ts
@@ -17,7 +17,6 @@ import { Themes } from '@/styles/themes';
 import { AppTheme, type AppColorMode } from '@/state/appUiConfigs';
 
 import { getDisplayableTickerFromMarket } from '../assetUtils';
-import { testFlags } from '../testFlags';
 
 // Show order book candles instead of trade candles if there are no trades in that time period
 const MAX_NUM_TRADES_FOR_ORDERBOOK_PRICES = 1;
@@ -147,9 +146,11 @@ const timezone = DateTime.local().get('zoneName') as unknown as Timezone;
 export const getWidgetOverrides = ({
   appTheme,
   appColorMode,
+  isSimpleUi,
 }: {
   appTheme: AppTheme;
   appColorMode: AppColorMode;
+  isSimpleUi?: boolean;
 }) => {
   const theme = Themes[appTheme][appColorMode];
 
@@ -162,7 +163,7 @@ export const getWidgetOverrides = ({
       'paneProperties.crossHairProperties.style': 1,
       'paneProperties.legendProperties.showBarChange': false,
       'paneProperties.backgroundType': 'solid' as const,
-
+      priceScaleSelectionStrategyName: isSimpleUi ? 'left' : undefined,
       'mainSeriesProperties.style': 1,
       'mainSeriesProperties.candleStyle.upColor': theme.positive,
       'mainSeriesProperties.candleStyle.borderUpColor': theme.positive,
@@ -193,7 +194,8 @@ export const getWidgetOverrides = ({
 };
 
 export const getWidgetOptions = (
-  isViewingUnlaunchedMarket?: boolean
+  isViewingUnlaunchedMarket?: boolean,
+  isSimpleUi?: boolean
 ): Partial<TradingTerminalWidgetOptions> & Pick<TradingTerminalWidgetOptions, 'container'> => {
   const disabledFeaturesForUnlaunchedMarket: TradingTerminalFeatureset[] = [
     'chart_scroll',
@@ -203,6 +205,8 @@ export const getWidgetOptions = (
   const disabledFeaturesForSimpleUi: TradingTerminalFeatureset[] = [
     'header_widget',
     'left_toolbar',
+    'display_market_status',
+    'legend_widget',
   ];
 
   const disabledFeatures: TradingTerminalFeatureset[] = [
@@ -215,7 +219,7 @@ export const getWidgetOptions = (
     'header_layouttoggle',
     'trading_account_manager',
     ...(isViewingUnlaunchedMarket ? disabledFeaturesForUnlaunchedMarket : []),
-    ...(testFlags.simpleUi ? disabledFeaturesForSimpleUi : []),
+    ...(isSimpleUi ? disabledFeaturesForSimpleUi : []),
   ];
 
   return {

--- a/src/pages/trade/simple-ui/AssetPage.tsx
+++ b/src/pages/trade/simple-ui/AssetPage.tsx
@@ -29,7 +29,7 @@ const AssetPage = () => {
     <div>Launch on Desktop</div>
   ) : (
     <>
-      <div tw="mb-2 h-[18.75rem] font-small-book">
+      <div tw="mb-1.5 h-[20rem] font-small-book">
         <TvChart />
       </div>
       <div tw="flexColumn gap-2 px-1.25 pb-[5.25rem]">

--- a/src/pages/trade/simple-ui/AssetPosition.tsx
+++ b/src/pages/trade/simple-ui/AssetPosition.tsx
@@ -1,17 +1,35 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import { BonsaiCore, BonsaiHelpers } from '@/bonsai/ontology';
 
 import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
+import {
+  getPositionSideFromIndexerPositionSide,
+  PositionSideTag,
+} from '@/components/PositionSideTag';
 import { VerticalSeparator } from '@/components/Separator';
-import { Tag } from '@/components/Tag';
+import { Tag, TagType } from '@/components/Tag';
+
+import { useAppSelector } from '@/state/appTypes';
+
+import { MarketOrderCard } from './MarketOrderCard';
+import { MarketPositionCard } from './MarketPositionCard';
 
 export const AssetPosition = () => {
   const stringGetter = useStringGetter();
   const [tab, setTab] = useState<'position' | 'orders'>('position');
-  // const position = useAppSelector(BonsaiCore.account.parentSubaccountPositions.data);
-  // const orders = useAppSelector(BonsaiHelpers.currentMarket.account.openOrders);
+  const positions = useAppSelector(BonsaiCore.account.parentSubaccountPositions.data);
+  const openOrders = useAppSelector(BonsaiHelpers.currentMarket.account.openOrders);
+  const currentMarketId = useAppSelector(BonsaiHelpers.currentMarket.stableMarketInfo)?.ticker;
+
+  const position = useMemo(() => {
+    return positions?.find((p) => p.market === currentMarketId);
+  }, [positions, currentMarketId]);
+
+  const numOpenOrders = openOrders.length;
 
   return (
     <div tw="grid">
@@ -24,10 +42,18 @@ export const AssetPosition = () => {
             }}
             onClick={() => setTab('position')}
           >
-            <span>{stringGetter({ key: STRING_KEYS.POSITION })}</span>
+            <span tw="row gap-0.5">
+              {stringGetter({ key: STRING_KEYS.POSITION })}
+
+              {position ? (
+                <PositionSideTag
+                  positionSide={getPositionSideFromIndexerPositionSide(position.side)}
+                />
+              ) : (
+                <Tag>{stringGetter({ key: STRING_KEYS.NONE })}</Tag>
+              )}
+            </span>
           </button>
-          <VerticalSeparator tw="flex h-full" fullHeight />
-          <Tag>{stringGetter({ key: STRING_KEYS.NONE })}</Tag>
         </div>
 
         <VerticalSeparator tw="flex h-full" fullHeight />
@@ -39,9 +65,25 @@ export const AssetPosition = () => {
           }}
           onClick={() => setTab('orders')}
         >
-          <span>{stringGetter({ key: STRING_KEYS.ORDERS })}</span>
+          <span tw="row gap-0.5">
+            {stringGetter({ key: STRING_KEYS.ORDERS })}
+            {numOpenOrders > 0 && <Tag type={TagType.Number}>{numOpenOrders}</Tag>}
+          </span>
         </button>
       </div>
+
+      {tab === 'position' && position && (
+        <div tw="mt-1">
+          <MarketPositionCard position={position} />
+        </div>
+      )}
+      {tab === 'orders' && openOrders.length > 0 && (
+        <div tw="flexColumn mt-1 gap-1">
+          {openOrders.map((order) => (
+            <MarketOrderCard key={order.id} order={order} />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/trade/simple-ui/MarketOrderCard.tsx
+++ b/src/pages/trade/simple-ui/MarketOrderCard.tsx
@@ -1,0 +1,67 @@
+import { BonsaiHelpers } from '@/bonsai/ontology';
+import { SubaccountOrder } from '@/bonsai/types/summaryTypes';
+
+import { STRING_KEYS } from '@/constants/localization';
+import { TOKEN_DECIMALS } from '@/constants/numbers';
+import { ORDER_TYPE_STRINGS } from '@/constants/trade';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { OrderSideTag } from '@/components/OrderSideTag';
+import { Output, OutputType } from '@/components/Output';
+import { TagSize } from '@/components/Tag';
+
+import { useAppSelector } from '@/state/appTypes';
+
+import { orEmptyObj } from '@/lib/typeUtils';
+
+export const MarketOrderCard = ({ order }: { order: SubaccountOrder }) => {
+  const stringGetter = useStringGetter();
+  const { stepSizeDecimals = TOKEN_DECIMALS, tickSizeDecimals } = orEmptyObj(
+    useAppSelector(BonsaiHelpers.currentMarket.stableMarketInfo)
+  );
+
+  const orderLabel = ORDER_TYPE_STRINGS[order.type].orderTypeKey;
+
+  const orderInfo = [
+    {
+      label: stringGetter({ key: STRING_KEYS.LIMIT_PRICE }),
+      value: (
+        <Output type={OutputType.Fiat} value={order.price} fractionDigits={tickSizeDecimals} />
+      ),
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.SIZE }),
+      value: (
+        <Output type={OutputType.Number} value={order.size} fractionDigits={stepSizeDecimals} />
+      ),
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.AMOUNT_FILLED }),
+      value: (
+        <Output
+          type={OutputType.Number}
+          value={order.totalFilled}
+          fractionDigits={stepSizeDecimals}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div tw="flexColumn gap-[0.125rem] overflow-hidden rounded-1">
+      <div tw="row gap-0.5 bg-color-layer-3 p-0.75">
+        <div>{stringGetter({ key: orderLabel })}</div>
+        <OrderSideTag size={TagSize.Medium} orderSide={order.side} />
+      </div>
+      <div tw="grid grid-cols-3 gap-0.5 bg-color-layer-3 p-0.75">
+        {orderInfo.map((info) => (
+          <div key={info.label}>
+            <div tw="text-color-text-0 font-mini-book">{info.label}</div>
+            <div tw="text-color-text-2">{info.value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/trade/simple-ui/MarketPositionCard.tsx
+++ b/src/pages/trade/simple-ui/MarketPositionCard.tsx
@@ -1,0 +1,174 @@
+import { BonsaiHelpers } from '@/bonsai/ontology';
+import { SubaccountPosition } from '@/bonsai/types/summaryTypes';
+
+import { DialogTypes } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
+import { TOKEN_DECIMALS } from '@/constants/numbers';
+import { EMPTY_ARR } from '@/constants/objects';
+
+import { useEnvFeatures } from '@/hooks/useEnvFeatures';
+import { useAppSelectorWithArgs } from '@/hooks/useParameterizedSelector';
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { Button } from '@/components/Button';
+import { Icon, IconName } from '@/components/Icon';
+import { Output, OutputType, ShowSign } from '@/components/Output';
+
+import { getSubaccountConditionalOrders } from '@/state/accountSelectors';
+import { useAppDispatch, useAppSelector } from '@/state/appTypes';
+import { openDialog } from '@/state/dialogs';
+
+import { orEmptyObj } from '@/lib/typeUtils';
+
+export const MarketPositionCard = ({ position }: { position: SubaccountPosition }) => {
+  const dispatch = useAppDispatch();
+  const stringGetter = useStringGetter();
+  const { isSlTpLimitOrdersEnabled } = useEnvFeatures();
+
+  const { stepSizeDecimals = TOKEN_DECIMALS } = orEmptyObj(
+    useAppSelector(BonsaiHelpers.currentMarket.stableMarketInfo)
+  );
+
+  const tpslOrdersByPositionUniqueId = useAppSelectorWithArgs(
+    getSubaccountConditionalOrders,
+    isSlTpLimitOrdersEnabled
+  );
+
+  const {
+    signedSize,
+    netFunding,
+    unrealizedPnl,
+    entryPrice,
+    liquidationPrice,
+    notional,
+    assetId,
+    market,
+    uniqueId,
+  } = position;
+
+  const tpOrder = (tpslOrdersByPositionUniqueId[uniqueId]?.takeProfitOrders ?? EMPTY_ARR).at(0);
+  const slOrder = (tpslOrdersByPositionUniqueId[uniqueId]?.stopLossOrders ?? EMPTY_ARR).at(0);
+
+  const positionInfo = [
+    {
+      label: stringGetter({ key: STRING_KEYS.SIZE }),
+      value: (
+        <Output
+          type={OutputType.Number}
+          showSign={ShowSign.None}
+          value={signedSize}
+          fractionDigits={stepSizeDecimals}
+        />
+      ),
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.VALUE }),
+      value: <Output type={OutputType.Fiat} value={notional} />,
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.PROFIT }),
+      value: <Output withSignColor type={OutputType.Fiat} value={unrealizedPnl} />,
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.FUNDING_PAID }),
+      value: <Output withSignColor type={OutputType.Fiat} value={netFunding} />,
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.ENTRY }),
+      value: <Output type={OutputType.Fiat} value={entryPrice} />,
+    },
+    {
+      label: stringGetter({ key: STRING_KEYS.LIQUIDATION }),
+      value: <Output type={OutputType.Fiat} value={liquidationPrice} />,
+    },
+  ];
+
+  const onTriggerClicked = () => {
+    dispatch(
+      openDialog(
+        DialogTypes.Triggers({
+          marketId: market,
+          assetId,
+          positionUniqueId: uniqueId,
+          navigateToMarketOrders: () => {},
+        })
+      )
+    );
+  };
+
+  const renderTriggerOrderButtons = () => {
+    if (tpOrder == null && slOrder == null) {
+      return (
+        <Button tw="flex-1 py-0.75" onClick={onTriggerClicked}>
+          <div tw="row size-1.5 max-w-1.5 flex-1 justify-center rounded-[50%] bg-color-layer-4">
+            <Icon tw="font-tiny-book" iconName={IconName.Plus} />
+          </div>
+          {stringGetter({ key: STRING_KEYS.ADD_TRIGGERS })}
+        </Button>
+      );
+    }
+
+    const tpButtonContent = tpOrder ? (
+      <span tw="row flex-1 justify-between gap-0.5">
+        <span tw="row gap-0.5">
+          TP: <Output type={OutputType.Fiat} value={tpOrder.triggerPrice} />
+        </span>
+        <div tw="row size-1.5 max-w-1.5 flex-1 justify-center rounded-[50%] bg-color-layer-4">
+          <Icon tw="font-tiny-book" iconName={IconName.Pencil} />
+        </div>
+      </span>
+    ) : (
+      <span tw="row justify-between gap-0.5">
+        TP
+        <div tw="row size-1.5 flex-1 justify-center rounded-[50%] bg-color-layer-4">
+          <Icon tw="font-tiny-book" iconName={IconName.Plus} />
+        </div>
+      </span>
+    );
+
+    const slButtonContent = slOrder ? (
+      <span tw="row flex-1 justify-between gap-0.5">
+        <span tw="row gap-0.5">
+          {stringGetter({ key: STRING_KEYS.STOP_LOSS })}:
+          <Output type={OutputType.Fiat} value={slOrder.triggerPrice} />
+        </span>
+        <div tw="row size-1.5 max-w-1.5 flex-1 justify-center rounded-[50%] bg-color-layer-4">
+          <Icon tw="font-tiny-book" iconName={IconName.Pencil} />
+        </div>
+      </span>
+    ) : (
+      <span tw="row flex-1 justify-between gap-0.5">
+        {stringGetter({ key: STRING_KEYS.STOP_LOSS })}
+        <div tw="row size-1.5 justify-center rounded-[50%] bg-color-layer-4">
+          <Icon tw="font-tiny-book" iconName={IconName.Plus} />
+        </div>
+      </span>
+    );
+
+    return (
+      <div tw="row gap-0.5">
+        <Button tw="flex-1 justify-normal py-0.75" onClick={onTriggerClicked}>
+          {tpButtonContent}
+        </Button>
+        <Button tw="flex-1 justify-normal py-0.75" onClick={onTriggerClicked}>
+          {slButtonContent}
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <div tw="flexColumn gap-1">
+      <div tw="grid grid-cols-3 grid-rows-2 gap-y-0.75 p-0">
+        {positionInfo.map((info) => (
+          <div key={info.label}>
+            <div tw="text-color-text-0 font-mini-book">{info.label}</div>
+            <div tw="text-color-text-2">{info.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {renderTriggerOrderButtons()}
+    </div>
+  );
+};

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -56,24 +56,26 @@ export const BaseTvChart = ({
           <div id="tv-price-chart" />
         </$PriceChart>
 
-        <div tw="row justify-evenly gap-0.5">
-          {objectKeys(isLaunchable ? LAUNCHABLE_MARKET_RESOLUTION_CONFIGS : RESOLUTION_MAP).map(
-            (resolution) => (
-              <button
-                tw="size-2.75 max-w-2.75 flex-1 border-t-2 border-solid border-color-accent"
-                type="button"
-                css={{
-                  borderColor:
-                    currentResolution !== resolution ? 'transparent' : 'var(--color-accent)',
-                }}
-                key={resolution}
-                onClick={() => onResolutionChange(resolution)}
-              >
-                {resolution}
-              </button>
-            )
-          )}
-        </div>
+        {isChartReady && (
+          <div tw="row justify-evenly gap-0.5">
+            {objectKeys(isLaunchable ? LAUNCHABLE_MARKET_RESOLUTION_CONFIGS : RESOLUTION_MAP).map(
+              (resolution) => (
+                <button
+                  tw="size-2.75 max-w-2.75 flex-1 border-t-2 border-solid border-color-accent"
+                  type="button"
+                  css={{
+                    borderColor:
+                      currentResolution !== resolution ? 'transparent' : 'var(--color-accent)',
+                  }}
+                  key={resolution}
+                  onClick={() => onResolutionChange(resolution)}
+                >
+                  {resolution}
+                </button>
+              )
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -1,15 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { ResolutionString } from 'public/tradingview/charting_library';
 import styled, { css } from 'styled-components';
 
+import { LAUNCHABLE_MARKET_RESOLUTION_CONFIGS, RESOLUTION_MAP } from '@/constants/candles';
 import { TvWidget } from '@/constants/tvchart';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 
-export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
+import { objectKeys } from '@/lib/objectHelpers';
+
+export const BaseTvChart = ({
+  tvWidget,
+  isLaunchable,
+  isSimpleUi,
+}: {
+  tvWidget?: TvWidget | null;
+  isLaunchable?: boolean;
+  isSimpleUi?: boolean;
+}) => {
   const [isChartReady, setIsChartReady] = useState(false);
+  const [currentResolution, setCurrentResolution] = useState<ResolutionString>();
 
   useEffect(() => {
     setIsChartReady(false);
@@ -17,11 +30,53 @@ export const BaseTvChart = ({ tvWidget }: { tvWidget?: TvWidget | null }) => {
     tvWidget?.onChartReady(() => {
       if (dead) return;
       setIsChartReady(true);
+      setCurrentResolution(tvWidget.activeChart().resolution());
     });
     return () => {
       dead = true;
     };
   }, [tvWidget]);
+
+  const onResolutionChange = useCallback(
+    (resolution: ResolutionString) => {
+      if (isChartReady) {
+        tvWidget?.activeChart().setResolution(resolution);
+        setCurrentResolution(resolution);
+      }
+    },
+    [isChartReady, tvWidget]
+  );
+
+  if (isSimpleUi) {
+    return (
+      <div tw="flexColumn h-full">
+        <$PriceChart isChartReady={isChartReady}>
+          {!isChartReady && <LoadingSpace id="tv-chart-loading" />}
+
+          <div id="tv-price-chart" />
+        </$PriceChart>
+
+        <div tw="row justify-evenly gap-0.5">
+          {objectKeys(isLaunchable ? LAUNCHABLE_MARKET_RESOLUTION_CONFIGS : RESOLUTION_MAP).map(
+            (resolution) => (
+              <button
+                tw="size-2.75 max-w-2.75 flex-1 border-t-2 border-solid border-color-accent"
+                type="button"
+                css={{
+                  borderColor:
+                    currentResolution !== resolution ? 'transparent' : 'var(--color-accent)',
+                }}
+                key={resolution}
+                onClick={() => onResolutionChange(resolution)}
+              >
+                {resolution}
+              </button>
+            )
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <$PriceChart isChartReady={isChartReady}>

--- a/src/views/charts/TradingView/TvChart.tsx
+++ b/src/views/charts/TradingView/TvChart.tsx
@@ -9,9 +9,12 @@ import { useChartMarketAndResolution } from '@/hooks/tradingView/useChartMarketA
 import { useTradingView } from '@/hooks/tradingView/useTradingView';
 import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
 import { useTradingViewToggles } from '@/hooks/tradingView/useTradingViewToggles';
+import { useBreakpoints } from '@/hooks/useBreakpoints';
 
 import { useAppSelector } from '@/state/appTypes';
 import { getCurrentMarketId } from '@/state/currentMarketSelectors';
+
+import { testFlags } from '@/lib/testFlags';
 
 import { BaseTvChart } from './BaseTvChart';
 
@@ -19,6 +22,9 @@ export const TvChart = () => {
   const currentMarketId: string = useAppSelector(getCurrentMarketId) ?? DEFAULT_MARKETID;
 
   const [tvWidget, setTvWidget] = useState<TvWidget>();
+
+  const { isTablet } = useBreakpoints();
+  const isSimpleUi = isTablet && testFlags.simpleUi;
 
   const orderLineToggleRef = useRef<HTMLElement | null>(null);
   const orderLineToggle = orderLineToggleRef.current;
@@ -58,5 +64,5 @@ export const TvChart = () => {
   });
   useTradingViewTheme({ tvWidget, chartLines });
 
-  return <BaseTvChart tvWidget={tvWidget} />;
+  return <BaseTvChart tvWidget={tvWidget} isSimpleUi={isSimpleUi} />;
 };

--- a/src/views/charts/TradingView/TvChartLaunchable.tsx
+++ b/src/views/charts/TradingView/TvChartLaunchable.tsx
@@ -5,10 +5,16 @@ import type { TvWidget } from '@/constants/tvchart';
 import { useChartMarketAndResolution } from '@/hooks/tradingView/useChartMarketAndResolution';
 import { useTradingViewLaunchable } from '@/hooks/tradingView/useTradingViewLaunchable';
 import { useTradingViewTheme } from '@/hooks/tradingView/useTradingViewTheme';
+import { useBreakpoints } from '@/hooks/useBreakpoints';
+
+import { testFlags } from '@/lib/testFlags';
 
 import { BaseTvChart } from './BaseTvChart';
 
 export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
+  const { isTablet } = useBreakpoints();
+  const isSimpleUi = isTablet && testFlags.simpleUi;
+
   const [tvWidget, setTvWidget] = useState<TvWidget>();
 
   useTradingViewLaunchable({
@@ -27,5 +33,5 @@ export const TvChartLaunchable = ({ marketId }: { marketId: string }) => {
     tvWidget,
   });
 
-  return <BaseTvChart tvWidget={tvWidget} />;
+  return <BaseTvChart isLaunchable tvWidget={tvWidget} isSimpleUi={isSimpleUi} />;
 };

--- a/src/views/dialogs/TriggersDialog.tsx
+++ b/src/views/dialogs/TriggersDialog.tsx
@@ -3,15 +3,18 @@ import { BonsaiHelpers } from '@/bonsai/ontology';
 import { DialogProps, TriggersDialogProps } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 
+import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useAppSelectorWithArgs } from '@/hooks/useParameterizedSelector';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
 import { AssetIcon } from '@/components/AssetIcon';
-import { Dialog } from '@/components/Dialog';
+import { Dialog, DialogPlacement } from '@/components/Dialog';
 import { TriggersForm } from '@/views/forms/TriggersForm/TriggersForm';
 
 import { useAppDispatch } from '@/state/appTypes';
 import { closeDialog } from '@/state/dialogs';
+
+import { testFlags } from '@/lib/testFlags';
 
 export const TriggersDialog = ({
   positionUniqueId,
@@ -23,6 +26,8 @@ export const TriggersDialog = ({
   const stringGetter = useStringGetter();
   const dispatch = useAppDispatch();
   const logoUrl = useAppSelectorWithArgs(BonsaiHelpers.assets.selectAssetLogo, assetId);
+  const { isMobile } = useBreakpoints();
+  const isSimpleUi = testFlags.simpleUi && isMobile;
 
   return (
     <Dialog
@@ -30,6 +35,7 @@ export const TriggersDialog = ({
       setIsOpen={setIsOpen}
       title={stringGetter({ key: STRING_KEYS.PRICE_TRIGGERS })}
       slotIcon={<AssetIcon logoUrl={logoUrl} symbol={assetId} />}
+      placement={isSimpleUi ? DialogPlacement.FullScreen : DialogPlacement.Default}
     >
       <TriggersForm
         positionUniqueId={positionUniqueId}


### PR DESCRIPTION
## Overview
- Add `<MarketPositionCard>` and `<MarketOrderCard>` (maybe rename this)
- Disable features on tradingView and add custom Resolution Selector

## Misc
- Update Output to be smart about coloring the sign