### PR TITLE
chore: abstract component into resolution selector and fix labels

### DIFF
--- a/src/constants/candles.ts
+++ b/src/constants/candles.ts
@@ -1,6 +1,7 @@
 import { ResolutionString } from 'public/tradingview/charting_library';
 
 import { MetadataServiceCandlesTimeframes } from './assetMetadata';
+import { STRING_KEYS } from './localization';
 import { timeUnits } from './time';
 
 export interface Candle {
@@ -118,3 +119,13 @@ export const RESOLUTION_CHART_CONFIGS = {
   '240': { defaultRange: 12 * timeUnits.day },
   '1D': { defaultRange: 2 * timeUnits.month },
 } as Record<ResolutionString, { defaultRange: number }>;
+
+export const RESOLUTION_STRING_TO_LABEL = {
+  '1': { value: '1' },
+  '5': { value: '5' },
+  '15': { value: '15' },
+  '30': { value: '30' },
+  '60': { value: '1', unitStringKey: STRING_KEYS.HOURS_ABBREVIATED },
+  '240': { value: '4', unitStringKey: STRING_KEYS.HOURS_ABBREVIATED },
+  '1D': { value: '1', unitStringKey: STRING_KEYS.DAYS_ABBREVIATED },
+} as Record<ResolutionString, { value: string; unitStringKey?: string }>;

--- a/src/views/charts/TradingView/BaseTvChart.tsx
+++ b/src/views/charts/TradingView/BaseTvChart.tsx
@@ -3,14 +3,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { ResolutionString } from 'public/tradingview/charting_library';
 import styled, { css } from 'styled-components';
 
-import { LAUNCHABLE_MARKET_RESOLUTION_CONFIGS, RESOLUTION_MAP } from '@/constants/candles';
 import { TvWidget } from '@/constants/tvchart';
 
 import { layoutMixins } from '@/styles/layoutMixins';
 
 import { LoadingSpace } from '@/components/Loading/LoadingSpinner';
 
-import { objectKeys } from '@/lib/objectHelpers';
+import { ResolutionSelector } from './ResolutionSelector';
 
 export const BaseTvChart = ({
   tvWidget,
@@ -57,24 +56,11 @@ export const BaseTvChart = ({
         </$PriceChart>
 
         {isChartReady && (
-          <div tw="row justify-evenly gap-0.5">
-            {objectKeys(isLaunchable ? LAUNCHABLE_MARKET_RESOLUTION_CONFIGS : RESOLUTION_MAP).map(
-              (resolution) => (
-                <button
-                  tw="size-2.75 max-w-2.75 flex-1 border-b-0 border-l-0 border-r-0 border-t-2 border-solid border-color-accent"
-                  type="button"
-                  css={{
-                    borderColor:
-                      currentResolution !== resolution ? 'transparent' : 'var(--color-accent)',
-                  }}
-                  key={resolution}
-                  onClick={() => onResolutionChange(resolution)}
-                >
-                  {resolution}
-                </button>
-              )
-            )}
-          </div>
+          <ResolutionSelector
+            isLaunchable={isLaunchable}
+            onResolutionChange={onResolutionChange}
+            currentResolution={currentResolution}
+          />
         )}
       </div>
     );

--- a/src/views/charts/TradingView/ResolutionSelector.tsx
+++ b/src/views/charts/TradingView/ResolutionSelector.tsx
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+
+import { ResolutionString } from 'public/tradingview/charting_library';
+
+import {
+  LAUNCHABLE_MARKET_RESOLUTION_CONFIGS,
+  RESOLUTION_MAP,
+  RESOLUTION_STRING_TO_LABEL,
+} from '@/constants/candles';
+
+import { useStringGetter } from '@/hooks/useStringGetter';
+
+import { objectKeys } from '@/lib/objectHelpers';
+
+export const ResolutionSelector = ({
+  isLaunchable,
+  onResolutionChange,
+  currentResolution,
+}: {
+  isLaunchable?: boolean;
+  onResolutionChange: (resolution: ResolutionString) => void;
+  currentResolution?: ResolutionString;
+}) => {
+  const stringGetter = useStringGetter();
+
+  const getLabel = useCallback(
+    (resolution: ResolutionString) => {
+      const resolutionLabelInfo = RESOLUTION_STRING_TO_LABEL[resolution];
+      if (resolutionLabelInfo == null) return undefined;
+
+      if (resolutionLabelInfo.unitStringKey) {
+        return `${resolutionLabelInfo.value}${stringGetter({ key: resolutionLabelInfo.unitStringKey })}`;
+      }
+
+      return resolutionLabelInfo.value;
+    },
+    [stringGetter]
+  );
+
+  return (
+    <div tw="row justify-evenly gap-0.5">
+      {objectKeys(isLaunchable ? LAUNCHABLE_MARKET_RESOLUTION_CONFIGS : RESOLUTION_MAP).map(
+        (resolution) => (
+          <button
+            tw="size-2.75 max-w-2.75 flex-1 border-b-0 border-l-0 border-r-0 border-t-2 border-solid border-color-accent"
+            type="button"
+            css={{
+              borderColor: currentResolution !== resolution ? 'transparent' : 'var(--color-accent)',
+            }}
+            key={resolution}
+            onClick={() => onResolutionChange(resolution)}
+          >
+            {getLabel(resolution)}
+          </button>
+        )
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Use unitStringKeys to clean up the ResolutionSelector
- before it would read `60` instead of `1h` or `240` instead of `4h`

<img width="375" alt="Screenshot 2025-06-09 at 2 37 10 PM" src="https://github.com/user-attachments/assets/1ce2760c-f71a-4d70-8aab-b98a6271b9a0" />
