### PR TITLE
feat(withdraw-ui): match deposit refresh

### DIFF
--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/AddressInput.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/AddressInput.tsx
@@ -1,7 +1,8 @@
 import { EventHandler, useState } from 'react';
 
 import { SyntheticInputEvent } from 'react-number-format/types/types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import tw from 'twin.macro';
 
 import { CHAIN_INFO } from '@/constants/chains';
 import { STRING_KEYS } from '@/constants/localization';
@@ -10,11 +11,14 @@ import { WalletNetworkType } from '@/constants/wallets';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
+import breakpoints from '@/styles/breakpoints';
+
 import { AssetIcon } from '@/components/AssetIcon';
 import { CopyButton } from '@/components/CopyButton';
 import { Icon, IconName } from '@/components/Icon';
 import { WithTooltip } from '@/components/WithTooltip';
 
+import { testFlags } from '@/lib/testFlags';
 import { truncateAddress } from '@/lib/wallet';
 
 import { isValidWithdrawalAddress } from '../utils';
@@ -51,7 +55,7 @@ export const AddressInput = ({
   };
 
   return (
-    <div tw="flex items-center justify-between gap-0.5 rounded-0.75 border border-solid border-color-border bg-color-layer-4 px-1.25 py-0.75">
+    <$WithdrawAmountInputContainer>
       <div tw="flex min-w-0 flex-1 flex-col gap-0.5 text-small">
         <div>
           {stringGetter({ key: STRING_KEYS.ADDRESS })}{' '}
@@ -61,11 +65,10 @@ export const AddressInput = ({
             </WithTooltip>
           )}
         </div>
-        <input
+        <$Input
           onBlur={onBlur}
           onFocus={onFocus}
           placeholder={sourceAccount.address}
-          tw="flex-1 text-ellipsis bg-color-layer-4 text-large font-medium outline-none"
           value={value}
           onChange={onValueChange}
         />
@@ -76,9 +79,7 @@ export const AddressInput = ({
           </span>
         )}
       </div>
-      <button
-        tw="flex items-center gap-0.75 rounded-0.75 border border-solid border-color-layer-6 bg-color-layer-5 px-0.5 py-0.375"
-        type="button"
+      <$ChainButton
         disabled={sourceAccount.chain === WalletNetworkType.Solana}
         onClick={onDestinationClicked}
       >
@@ -89,10 +90,44 @@ export const AddressInput = ({
         {sourceAccount.chain !== WalletNetworkType.Solana && (
           <$CaretIcon size="10px" iconName={IconName.Caret} />
         )}
-      </button>
-    </div>
+      </$ChainButton>
+    </$WithdrawAmountInputContainer>
   );
 };
+
+const $WithdrawAmountInputContainer = styled.div`
+  ${tw`flex items-center justify-between gap-0.5 rounded-0.75 px-1.25 py-0.75`}
+  background-color: var(--withdraw-dialog-amount-bgColor, var(--color-layer-4));
+  border: 1px solid var(--color-border);
+
+  @media ${breakpoints.tablet} {
+    ${() =>
+      testFlags.simpleUi &&
+      css`
+        --withdraw-dialog-amount-bgColor: var(--color-layer-2);
+        border-color: transparent;
+      `}
+  }
+`;
+
+const $Input = styled.input`
+  ${tw`flex-1 text-ellipsis text-large font-medium outline-none`}
+  background-color: var(--withdraw-dialog-amount-bgColor, var(--color-layer-4));
+`;
+
+const $ChainButton = styled.button.attrs({
+  type: 'button',
+})`
+  ${tw`flex items-center gap-0.75 rounded-0.75 border border-solid border-color-layer-6 bg-color-layer-5 px-0.5 py-0.375`}
+
+  @media ${breakpoints.tablet} {
+    ${() =>
+      testFlags.simpleUi &&
+      css`
+        border-color: transparent;
+      `}
+  }
+`;
 
 const $CaretIcon = styled(Icon)`
   transform: rotate(-90deg);

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawDialog2.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawDialog2.tsx
@@ -91,8 +91,8 @@ export const WithdrawDialog2 = ({ setIsOpen }: DialogProps<DepositDialog2Props>)
         <WithdrawStatus id={currentWithdrawId} onClose={() => setIsOpen(false)} />
       )}
       {!currentWithdrawId && (
-        <div tw="w-[100%] overflow-hidden">
-          <div tw="flex w-[200%]">
+        <div tw="h-full w-full overflow-hidden">
+          <div tw="flex h-full w-[200%]">
             <div
               tw="w-[50%]"
               style={{ marginLeft: formState === 'form' ? 0 : '-50%', transition: 'margin 500ms' }}

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -234,18 +234,22 @@ export const WithdrawForm = ({
         onSelectSpeed={setSelectedSpeed}
         type="withdraw"
       />
-      <Button
-        tw="mt-auto w-full"
-        state={{
-          isLoading: isFetching || isLoading,
-          isDisabled: withdrawDisabled,
-        }}
-        onClick={onWithdrawClick}
-        action={ButtonAction.Primary}
-      >
-        {buttonInner}
-      </Button>
-      {receipt}
+
+      <div tw="flexColumn mt-auto gap-0.5">
+        {receipt}
+
+        <Button
+          tw="w-full"
+          state={{
+            isLoading: isFetching || isLoading,
+            isDisabled: withdrawDisabled,
+          }}
+          onClick={onWithdrawClick}
+          action={ButtonAction.Primary}
+        >
+          {buttonInner}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawForm.tsx
@@ -216,7 +216,7 @@ export const WithdrawForm = ({
   };
 
   return (
-    <div tw="flex min-h-10 flex-col gap-1 p-1.25">
+    <div tw="flex h-full min-h-10 flex-col gap-1 p-1.25">
       <AddressInput
         value={destinationAddress}
         onChange={setDestinationAddress}
@@ -235,7 +235,7 @@ export const WithdrawForm = ({
         type="withdraw"
       />
       <Button
-        tw="mt-1 w-full"
+        tw="mt-auto w-full"
         state={{
           isLoading: isFetching || isLoading,
           isDisabled: withdrawDisabled,

--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawStatus.tsx
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/WithdrawStatus.tsx
@@ -93,7 +93,7 @@ export const WithdrawStatus = ({ id = '', onClose }: WithdrawStatusProps) => {
           <div tw="text-color-text-0">{statusDescription}</div>
         </div>
       </div>
-      <div tw="flex items-center justify-between self-stretch">
+      <div tw="mt-auto flex items-center justify-between self-stretch">
         <div tw="text-color-text-0">{stringGetter({ key: STRING_KEYS.YOUR_WITHDRAWAL })}</div>
         <div tw="flex items-center gap-0.125">
           {withdrawalOutput}


### PR DESCRIPTION
- CTA button and receipts moved  to the bottom
- Update input styling

<img width="307" alt="Screenshot 2025-06-18 at 4 33 01 PM" src="https://github.com/user-attachments/assets/83411de3-445c-4de9-b7ed-6c5e7172f465" />
