### PR TITLE
feat: create compliance banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { parseLocationHash } from '@/lib/urlUtils';
 import { config, privyConfig } from '@/lib/wagmi';
 
 import { BonsaiCore } from './bonsai/ontology';
+import { ComplianceBanner } from './components/ComplianceBanner';
 import { RestrictionWarning } from './components/RestrictionWarning';
 import { DialogTypes } from './constants/dialogs';
 import { LocalStorageKey } from './constants/localStorage';
@@ -100,7 +101,7 @@ const Content = () => {
   const isSimpleUi = testFlags.simpleUi && isTablet;
   const abDefaultToMarkets = useStatsigGateValue(StatsigFlags.abDefaultToMarkets);
 
-  const { showRestrictionWarning } = useComplianceState();
+  const { showComplianceBanner } = useComplianceState();
 
   const pathFromHash = useMemo(() => {
     if (location.hash === '') {
@@ -115,7 +116,9 @@ const Content = () => {
     return (
       <>
         <GlobalStyle />
-        <$SimpleUiGrid>
+        <$SimpleUiGrid showRestrictionBanner={showComplianceBanner}>
+          <ComplianceBanner />
+
           <$SimpleUiMain>
             <Suspense fallback={<LoadingSpace id="main" tw="h-full w-full" />}>
               <Routes>
@@ -146,10 +149,10 @@ const Content = () => {
       <$Content
         isShowingHeader={isShowingHeader}
         isShowingFooter={isShowingFooter}
-        showRestrictionWarning={showRestrictionWarning}
+        showRestrictionWarning={showComplianceBanner}
       >
         {isShowingHeader && <HeaderDesktop />}
-        {showRestrictionWarning && <RestrictionWarning />}
+        <RestrictionWarning />
         <$Main>
           <Suspense fallback={<LoadingSpace id="main" />}>
             <Routes>
@@ -381,11 +384,22 @@ const $Main = styled.main`
   position: relative;
 `;
 
-const $SimpleUiGrid = styled.div`
+const $SimpleUiGrid = styled.div<{ showRestrictionBanner?: boolean }>`
   display: grid;
-  grid-template-areas: 'Main';
-  grid-template-columns: 100vw;
-  grid-template-rows: 100vh;
+
+  ${({ showRestrictionBanner }) =>
+    showRestrictionBanner
+      ? css`
+          grid-template:
+            'RestrictionWarning' minmax(min-content, auto)
+            'Main' 1fr
+            / 100vw;
+        `
+      : css`
+          grid-template:
+            'Main' 100vh
+            / 100vw;
+        `}
 `;
 
 const $SimpleUiMain = styled.main`

--- a/src/components/AlertMessage.tsx
+++ b/src/components/AlertMessage.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { AlertType } from '@/constants/alerts';
@@ -16,19 +18,16 @@ type ElementProps = {
 
 export type AlertMessageProps = ElementProps & StyleProps;
 
-export const AlertMessage: React.FC<AlertMessageProps> = ({
-  className,
-  children,
-  type,
-  withAccentText,
-}: AlertMessageProps) => {
-  return (
-    <$AlertContainer type={type} className={className} withAccentText={withAccentText}>
-      <$AlertAccent />
-      {children}
-    </$AlertContainer>
-  );
-};
+export const AlertMessage = forwardRef<HTMLDivElement, AlertMessageProps>(
+  ({ className, children, type, withAccentText }, ref) => {
+    return (
+      <$AlertContainer ref={ref} type={type} className={className} withAccentText={withAccentText}>
+        <$AlertAccent />
+        {children}
+      </$AlertContainer>
+    );
+  }
+);
 
 const $AlertContainer = styled.div<StyleProps>`
   ${layoutMixins.column}

--- a/src/components/ComplianceBanner.tsx
+++ b/src/components/ComplianceBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { ComplianceStatus } from '@/bonsai/types/summaryTypes';
 import styled from 'styled-components';
@@ -11,6 +11,7 @@ import { AppRoute, BASE_ROUTE } from '@/constants/routes';
 
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useComplianceState } from '@/hooks/useComplianceState';
+import { useResizeObserver } from '@/hooks/useResizeObserver';
 import { useStringGetter } from '@/hooks/useStringGetter';
 import { useURLConfigs } from '@/hooks/useURLConfigs';
 
@@ -29,6 +30,7 @@ import { Link } from './Link';
 
 export const ComplianceBanner = ({ className }: { className?: string }) => {
   const [showLess, setShowLess] = useState(false);
+  const complianceBannerRef = useRef<HTMLDivElement>(null);
   const dispatch = useAppDispatch();
   const stringGetter = useStringGetter();
   const { complianceMessage, complianceStatus, showComplianceBanner, showRestrictionWarning } =
@@ -36,6 +38,16 @@ export const ComplianceBanner = ({ className }: { className?: string }) => {
   const { help } = useURLConfigs();
   const { isTablet } = useBreakpoints();
   const isSimpleUi = isTablet && testFlags.simpleUi;
+
+  useResizeObserver({
+    box: 'border-box',
+    ref: complianceBannerRef,
+    onResize: (size) => {
+      if (size.height) {
+        document.documentElement.style.setProperty('--complianceBanner-height', `${size.height}px`);
+      }
+    },
+  });
 
   if (!showComplianceBanner) {
     return null;
@@ -85,7 +97,7 @@ export const ComplianceBanner = ({ className }: { className?: string }) => {
 
   if (isSimpleUi) {
     return (
-      <$AlertMessage withAccentText type={AlertType.Error}>
+      <$AlertMessage ref={complianceBannerRef} withAccentText type={AlertType.Error}>
         {canHide && (
           <IconButton
             tw="absolute right-0.25 top-0.25 text-color-text-2"

--- a/src/components/ComplianceBanner.tsx
+++ b/src/components/ComplianceBanner.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+
+import { ComplianceStatus } from '@/bonsai/types/summaryTypes';
+import styled from 'styled-components';
+
+import { ButtonSize, ButtonStyle, ButtonType } from '@/constants/buttons';
+import { DialogTypes } from '@/constants/dialogs';
+import { STRING_KEYS } from '@/constants/localization';
+import { AppRoute, BASE_ROUTE } from '@/constants/routes';
+
+import { useBreakpoints } from '@/hooks/useBreakpoints';
+import { useComplianceState } from '@/hooks/useComplianceState';
+import { useStringGetter } from '@/hooks/useStringGetter';
+import { useURLConfigs } from '@/hooks/useURLConfigs';
+
+import breakpoints from '@/styles/breakpoints';
+
+import { useAppDispatch } from '@/state/appTypes';
+import { openDialog } from '@/state/dialogs';
+
+import { Button } from './Button';
+import { IconName } from './Icon';
+import { IconButton } from './IconButton';
+import { Link } from './Link';
+
+export const ComplianceBanner = ({ className }: { className?: string }) => {
+  const [showLess, setShowLess] = useState(false);
+  const dispatch = useAppDispatch();
+  const stringGetter = useStringGetter();
+  const { complianceMessage, complianceStatus, showComplianceBanner, showRestrictionWarning } =
+    useComplianceState();
+  const { help } = useURLConfigs();
+  const { isTablet } = useBreakpoints();
+
+  if (!showComplianceBanner) {
+    return null;
+  }
+
+  const complianceContent = showRestrictionWarning ? (
+    <span>
+      {stringGetter({
+        key: STRING_KEYS.BLOCKED_BANNER_MESSAGE_SHORT,
+        params: {
+          CONTACT_SUPPORT_LINK: (
+            <Link href={help} isInline>
+              {stringGetter({ key: STRING_KEYS.CONTACT_SUPPORT })}
+            </Link>
+          ),
+        },
+      })}{' '}
+      <Link href={`${BASE_ROUTE}${AppRoute.Terms}`} isInline>
+        {stringGetter({
+          key: STRING_KEYS.LEARN_MORE,
+        })}{' '}
+        →
+      </Link>
+    </span>
+  ) : (
+    <span>{complianceMessage}</span>
+  );
+
+  const action =
+    complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY ? (
+      <Button
+        tw="w-fit"
+        size={isTablet ? ButtonSize.XSmall : ButtonSize.Small}
+        onClick={() => {
+          dispatch(openDialog(DialogTypes.GeoCompliance()));
+        }}
+      >
+        {stringGetter({ key: STRING_KEYS.ACTION_REQUIRED })} →
+      </Button>
+    ) : null;
+
+  const toggleShowLess = () => {
+    setShowLess((prev) => !prev);
+  };
+
+  const canHide = isTablet && action == null;
+
+  return (
+    <$ComplianceBanner className={className}>
+      <div tw="absolute inset-0 z-[-1] bg-color-gradient-error" />
+      {canHide && (
+        <IconButton
+          tw="absolute right-0.25 top-0.25 text-color-text-2"
+          type={ButtonType.Button}
+          onClick={toggleShowLess}
+          iconName={showLess ? IconName.Caret : IconName.Close}
+          buttonStyle={ButtonStyle.WithoutBackground}
+        />
+      )}
+
+      {showLess && canHide ? (
+        stringGetter({ key: STRING_KEYS.COMPLIANCE_WARNING })
+      ) : (
+        <>
+          {complianceContent}
+          {action}
+        </>
+      )}
+    </$ComplianceBanner>
+  );
+};
+
+const $ComplianceBanner = styled.div`
+  height: var(--restriction-warning-currentHeight);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  grid-area: RestrictionWarning;
+  z-index: 1;
+  padding: 0.5rem 1rem;
+
+  font: var(--font-small-book);
+  border-left: 4px solid var(--color-error);
+  background-color: var(--color-layer-2);
+  color: var(--color-error);
+
+  @media ${breakpoints.tablet} {
+    position: relative;
+  }
+
+  a {
+    color: var(--color-text-2);
+    text-decoration: underline;
+  }
+`;

--- a/src/components/ComplianceBanner.tsx
+++ b/src/components/ComplianceBanner.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { ComplianceStatus } from '@/bonsai/types/summaryTypes';
 import styled from 'styled-components';
 
+import { AlertType } from '@/constants/alerts';
 import { ButtonSize, ButtonStyle, ButtonType } from '@/constants/buttons';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
@@ -18,6 +19,9 @@ import breakpoints from '@/styles/breakpoints';
 import { useAppDispatch } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
 
+import { testFlags } from '@/lib/testFlags';
+
+import { AlertMessage } from './AlertMessage';
 import { Button } from './Button';
 import { IconName } from './Icon';
 import { IconButton } from './IconButton';
@@ -31,6 +35,7 @@ export const ComplianceBanner = ({ className }: { className?: string }) => {
     useComplianceState();
   const { help } = useURLConfigs();
   const { isTablet } = useBreakpoints();
+  const isSimpleUi = isTablet && testFlags.simpleUi;
 
   if (!showComplianceBanner) {
     return null;
@@ -78,6 +83,31 @@ export const ComplianceBanner = ({ className }: { className?: string }) => {
 
   const canHide = isTablet && action == null;
 
+  if (isSimpleUi) {
+    return (
+      <$AlertMessage withAccentText type={AlertType.Error}>
+        {canHide && (
+          <IconButton
+            tw="absolute right-0.25 top-0.25 text-color-text-2"
+            type={ButtonType.Button}
+            onClick={toggleShowLess}
+            iconName={showLess ? IconName.Caret : IconName.Close}
+            buttonStyle={ButtonStyle.WithoutBackground}
+          />
+        )}
+
+        {showLess && canHide ? (
+          stringGetter({ key: STRING_KEYS.COMPLIANCE_WARNING })
+        ) : (
+          <>
+            {complianceContent}
+            {action}
+          </>
+        )}
+      </$AlertMessage>
+    );
+  }
+
   return (
     <$ComplianceBanner className={className}>
       <div tw="absolute inset-0 z-[-1] bg-color-gradient-error" />
@@ -102,6 +132,13 @@ export const ComplianceBanner = ({ className }: { className?: string }) => {
     </$ComplianceBanner>
   );
 };
+
+const $AlertMessage = styled(AlertMessage)`
+  border-radius: 0.5rem;
+  max-width: 100%;
+  margin: 0.75rem 0.75rem 0 0.75rem;
+  font: var(--font-base-book);
+`;
 
 const $ComplianceBanner = styled.div`
   height: var(--restriction-warning-currentHeight);

--- a/src/components/RestrictionWarning.tsx
+++ b/src/components/RestrictionWarning.tsx
@@ -1,55 +1,15 @@
 import styled from 'styled-components';
 
-import { STRING_KEYS } from '@/constants/localization';
-
-import { useStringGetter } from '@/hooks/useStringGetter';
-import { useURLConfigs } from '@/hooks/useURLConfigs';
-
 import { layoutMixins } from '@/styles/layoutMixins';
 
-import { Link } from './Link';
-import { TermsOfUseLink } from './TermsOfUseLink';
+import { ComplianceBanner } from './ComplianceBanner';
 
 export const RestrictionWarning = () => {
-  const stringGetter = useStringGetter();
-  const { help } = useURLConfigs();
-
-  return (
-    <$RestrictedWarning>
-      <span>
-        {stringGetter({
-          key: STRING_KEYS.BLOCKED_BANNER_MESSAGE,
-          params: {
-            TERMS_OF_USE_LINK: <TermsOfUseLink isInline />,
-            HELP_LINK: (
-              <Link href={help} isInline>
-                {stringGetter({ key: STRING_KEYS.HELP_CENTER })}
-              </Link>
-            ),
-          },
-        })}
-      </span>
-    </$RestrictedWarning>
-  );
+  return <$RestrictedWarning />;
 };
 
-const $RestrictedWarning = styled.div`
+const $RestrictedWarning = styled(ComplianceBanner)`
   ${layoutMixins.sticky}
   --stickyArea-totalInsetTop: var(--page-currentHeaderHeight);
   height: var(--restriction-warning-currentHeight);
-  display: flex;
-  align-items: center;
-
-  grid-area: RestrictionWarning;
-  z-index: 1;
-  padding: 0.5rem 1rem;
-
-  font: var(--font-small-book);
-  background-color: var(--color-red);
-  color: var(--color-text-2);
-
-  a {
-    color: var(--color-text-2);
-    text-decoration: underline;
-  }
 `;

--- a/src/hooks/useComplianceState.tsx
+++ b/src/hooks/useComplianceState.tsx
@@ -60,7 +60,7 @@ export const useComplianceState = () => {
     updatedAtDate?.setDate(updatedAtDate.getDate() + CLOSE_ONLY_GRACE_PERIOD);
 
     if (complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY) {
-      message = `${stringGetter({ key: STRING_KEYS.CLICK_TO_VIEW })} →`;
+      message = `${stringGetter({ key: STRING_KEYS.COMPLIANCE_WARNING })}`;
     } else if (complianceStatus === ComplianceStatus.CLOSE_ONLY) {
       message = stringGetter({
         key: STRING_KEYS.CLOSE_ONLY_MESSAGE_WITH_HELP,
@@ -111,5 +111,7 @@ export const useComplianceState = () => {
     complianceMessage,
     disableConnectButton,
     showRestrictionWarning: complianceState === ComplianceStates.READ_ONLY,
+    showComplianceBanner:
+      complianceMessage != null || complianceState === ComplianceStates.READ_ONLY,
   };
 };

--- a/src/hooks/useNotificationTypes.tsx
+++ b/src/hooks/useNotificationTypes.tsx
@@ -1,21 +1,19 @@
 import { useEffect, useMemo } from 'react';
 
 import { BonsaiCore } from '@/bonsai/ontology';
-import { ComplianceStatus, OrderStatus, SubaccountFillType } from '@/bonsai/types/summaryTypes';
+import { OrderStatus, SubaccountFillType } from '@/bonsai/types/summaryTypes';
 import { useQuery } from '@tanstack/react-query';
 import { groupBy, isNumber, max, pick } from 'lodash';
 import { shallowEqual } from 'react-redux';
 import tw from 'twin.macro';
 
 import { AMOUNT_RESERVED_FOR_GAS_USDC, AMOUNT_USDC_BEFORE_REBALANCE } from '@/constants/account';
-import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import {
   CosmosWalletNotificationTypes,
   DEFAULT_TOAST_AUTO_CLOSE_MS,
   FeedbackRequestNotificationIds,
-  NotificationDisplayData,
   NotificationStatus,
   NotificationType,
   type NotificationTypeConfig,
@@ -34,8 +32,6 @@ import { IndexerOrderSide, IndexerOrderType } from '@/types/indexer/indexerApiGe
 
 import { Icon, IconName } from '@/components/Icon';
 import { Link } from '@/components/Link';
-// eslint-disable-next-line import/no-cycle
-import { Notification } from '@/components/Notification';
 import { formatNumberOutput, Output, OutputType } from '@/components/Output';
 import { BlockRewardNotificationRow } from '@/views/Lists/Alerts/BlockRewardNotificationRow';
 import { FillWithNoOrderNotificationRow } from '@/views/Lists/Alerts/FillWithNoOrderNotificationRow';
@@ -43,6 +39,7 @@ import { OrderCancelNotificationRow } from '@/views/Lists/Alerts/OrderCancelNoti
 import { OrderNotificationRow } from '@/views/Lists/Alerts/OrderNotificationRow';
 import { OrderStatusNotificationRow } from '@/views/Lists/Alerts/OrderStatusNotificationRow';
 import { SkipTransferNotificationRow } from '@/views/Lists/Alerts/SkipTransferNotificationRow';
+// eslint-disable-next-line import/no-cycle
 import { BlockRewardNotification } from '@/views/notifications/BlockRewardNotification';
 import { CancelAllNotification } from '@/views/notifications/CancelAllNotification';
 import { CloseAllPositionsNotification } from '@/views/notifications/CloseAllPositionsNotification';
@@ -83,7 +80,6 @@ import { isPresent, orEmptyRecord } from '@/lib/typeUtils';
 
 import { useAccounts } from './useAccounts';
 import { useApiState } from './useApiState';
-import { useComplianceState } from './useComplianceState';
 import { useLocaleSeparators } from './useLocaleSeparators';
 import { useAppSelectorWithArgs } from './useParameterizedSelector';
 import { useAllStatsigDynamicConfigValues } from './useStatsig';
@@ -793,48 +789,6 @@ export const notificationTypes: NotificationTypeConfig[] = [
     },
     useNotificationAction: () => {
       return () => {};
-    },
-  },
-  {
-    type: NotificationType.ComplianceAlert,
-    useTrigger: ({ trigger }) => {
-      const stringGetter = useStringGetter();
-      const { complianceMessage, complianceState, complianceStatus } = useComplianceState();
-
-      useEffect(() => {
-        if (complianceState !== ComplianceStates.FULL_ACCESS) {
-          const displayData: NotificationDisplayData = {
-            icon: <$WarningIcon iconName={IconName.Warning} />,
-            title: stringGetter({ key: STRING_KEYS.COMPLIANCE_WARNING }),
-            renderCustomBody: ({ isToast, notification }) => (
-              <Notification
-                isToast={isToast}
-                notification={notification}
-                slotDescription={complianceMessage}
-              />
-            ),
-            toastSensitivity: 'foreground',
-            groupKey: NotificationType.ComplianceAlert,
-            withClose: false,
-          };
-
-          trigger({
-            id: `${NotificationType.ComplianceAlert}-${complianceStatus}`,
-            displayData,
-            updateKey: [],
-          });
-        }
-      }, [stringGetter, complianceMessage, complianceState, complianceStatus, trigger]);
-    },
-    useNotificationAction: () => {
-      const dispatch = useAppDispatch();
-      const { complianceStatus } = useComplianceState();
-
-      return () => {
-        if (complianceStatus === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY) {
-          dispatch(openDialog(DialogTypes.GeoCompliance()));
-        }
-      };
     },
   },
   {

--- a/src/pages/markets/simple-ui/MarketsMobile.tsx
+++ b/src/pages/markets/simple-ui/MarketsMobile.tsx
@@ -4,6 +4,8 @@ import { STRING_KEYS } from '@/constants/localization';
 
 import { useStringGetter } from '@/hooks/useStringGetter';
 
+import { layoutMixins } from '@/styles/layoutMixins';
+
 import { Dialog, DialogPlacement } from '@/components/Dialog';
 import { UserMenuContent } from '@/views/menus/UserMenuContent';
 
@@ -24,7 +26,7 @@ const MarketsMobile = () => {
   };
 
   return (
-    <div tw="flexColumn relative h-[100vh]">
+    <$MarketsMobile>
       <div tw="h-full flex-1">
         <MarketList
           slotTop={{
@@ -42,9 +44,15 @@ const MarketsMobile = () => {
       >
         <UserMenuContent />
       </$Dialog>
-    </div>
+    </$MarketsMobile>
   );
 };
+
+const $MarketsMobile = styled.div`
+  ${layoutMixins.flexColumn}
+  position: relative;
+  height: calc(100vh - calc(var(--complianceBanner-height, 0px) + 0.75rem));
+`;
 
 const $Dialog = styled(Dialog)`
   --dialog-backgroundColor: var(--color-layer-1);

--- a/src/pages/markets/simple-ui/markets-view/MarketList.tsx
+++ b/src/pages/markets/simple-ui/markets-view/MarketList.tsx
@@ -13,7 +13,6 @@ import { ListItem, MarketsSortType, PositionSortType } from '@/constants/marketL
 import { MarketData, MarketFilters } from '@/constants/markets';
 import { EMPTY_ARR } from '@/constants/objects';
 
-import { useComplianceState } from '@/hooks/useComplianceState';
 import { useMarketsData } from '@/hooks/useMarketsData';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -139,7 +138,6 @@ export const MarketList = ({
   const sortType = useAppSelector(getSimpleUISortMarketsBy);
   const positionSortType = useAppSelector(getSimpleUISortPositionsBy);
   const subaccountEquity = useAppSelector(getSubaccountEquity);
-  const { showComplianceBanner } = useComplianceState();
 
   const setSortType = useCallback(
     (newSortType: MarketsSortType) => {
@@ -424,7 +422,8 @@ export const MarketList = ({
       ref={parentRef}
       tw="relative h-full max-h-full w-full max-w-full overflow-auto"
       css={{
-        paddingBottom: showComplianceBanner ? '12rem' : isSearchOpen ? '1rem' : '6rem',
+        '--marketList-search-height': isSearchOpen ? '0' : '5.5rem',
+        paddingBottom: 'var(--marketList-search-height)',
       }}
     >
       <div
@@ -460,7 +459,7 @@ export const MarketList = ({
       </div>
 
       <div
-        tw="fixed bottom-0 left-0 right-0 z-[1] flex h-[5.5rem]"
+        tw="fixed bottom-0 left-0 right-0 z-[1] flex h-[var(--marketList-search-height)]"
         css={{
           display: isSearchOpen ? 'none' : 'flex',
           background: 'linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--color-layer-1))',

--- a/src/pages/markets/simple-ui/markets-view/MarketList.tsx
+++ b/src/pages/markets/simple-ui/markets-view/MarketList.tsx
@@ -13,6 +13,7 @@ import { ListItem, MarketsSortType, PositionSortType } from '@/constants/marketL
 import { MarketData, MarketFilters } from '@/constants/markets';
 import { EMPTY_ARR } from '@/constants/objects';
 
+import { useComplianceState } from '@/hooks/useComplianceState';
 import { useMarketsData } from '@/hooks/useMarketsData';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -138,6 +139,8 @@ export const MarketList = ({
   const sortType = useAppSelector(getSimpleUISortMarketsBy);
   const positionSortType = useAppSelector(getSimpleUISortPositionsBy);
   const subaccountEquity = useAppSelector(getSubaccountEquity);
+  const { showComplianceBanner } = useComplianceState();
+
   const setSortType = useCallback(
     (newSortType: MarketsSortType) => {
       dispatch(setSimpleUISortMarketsBy(newSortType));
@@ -421,7 +424,7 @@ export const MarketList = ({
       ref={parentRef}
       tw="relative h-full max-h-full w-full max-w-full overflow-auto"
       css={{
-        paddingBottom: isSearchOpen ? '1rem' : '6rem',
+        paddingBottom: showComplianceBanner ? '12rem' : isSearchOpen ? '1rem' : '6rem',
       }}
     >
       <div

--- a/src/pages/portfolio/SimpleUiHistory.tsx
+++ b/src/pages/portfolio/SimpleUiHistory.tsx
@@ -80,4 +80,5 @@ export const SimpleUiHistory = () => {
 
 const $TableContainer = styled.div`
   display: grid;
+  min-height: 12.5rem;
 `;

--- a/src/pages/trade/simple-ui/AssetHeader.tsx
+++ b/src/pages/trade/simple-ui/AssetHeader.tsx
@@ -55,7 +55,7 @@ export const AssetHeader = ({ isLaunchableMarket }: { isLaunchableMarket?: boole
   );
 
   return (
-    <div tw="inlineRow fixed left-0 right-0 top-0 h-[4rem] justify-between gap-[1ch] bg-color-layer-2 pl-0.5 pr-1.25">
+    <div tw="inlineRow h-[4rem] justify-between gap-[1ch] bg-color-layer-2 pl-0.5 pr-1.25">
       <div tw="inlineRow">
         <BackButton tw="text-color-text-0" onClick={() => navigate(AppRoute.Markets)} />
         <AssetIcon

--- a/src/pages/trade/simple-ui/AssetPage.tsx
+++ b/src/pages/trade/simple-ui/AssetPage.tsx
@@ -1,10 +1,12 @@
 import { OrderSide } from '@/bonsai/forms/trade/types';
 
-import { ButtonShape, ButtonSize } from '@/constants/buttons';
+import { ButtonShape, ButtonSize, ButtonState } from '@/constants/buttons';
+import { ComplianceStates } from '@/constants/compliance';
 import { DialogTypes } from '@/constants/dialogs';
 import { STRING_KEYS } from '@/constants/localization';
 import { DEFAULT_VAULT_DEPOSIT_FOR_LAUNCH } from '@/constants/numbers';
 
+import { useComplianceState } from '@/hooks/useComplianceState';
 import { useCurrentMarketId } from '@/hooks/useCurrentMarketId';
 import { useStringGetter } from '@/hooks/useStringGetter';
 
@@ -33,6 +35,7 @@ const AssetPage = () => {
   const currentMarketId = useAppSelector(getCurrentMarketId);
   const { isViewingUnlaunchedMarket } = useCurrentMarketId();
   const canAccountTrade = useAppSelector(calculateCanAccountTrade);
+  const { complianceState } = useComplianceState();
 
   if (currentMarketId == null) {
     return <LoadingSpace id="asset-page-loading" />;
@@ -101,7 +104,17 @@ const AssetPage = () => {
     </>
   );
 
-  const footerContent = canAccountTrade ? (
+  const isDisabled = complianceState !== ComplianceStates.FULL_ACCESS;
+
+  const footerContent = isDisabled ? (
+    <Button
+      tw="flex-1 border border-solid border-color-layer-6"
+      shape={ButtonShape.Pill}
+      state={ButtonState.Disabled}
+    >
+      {stringGetter({ key: STRING_KEYS.UNAVAILABLE })}
+    </Button>
+  ) : canAccountTrade ? (
     <>
       <Button
         tw="flex-1 bg-color-negative-dark text-color-negative"
@@ -140,7 +153,7 @@ const AssetPage = () => {
         <div tw="mt-[5.5rem] grid gap-1.5 overflow-auto pb-1.5">{pageContent}</div>
       ) : (
         <>
-          <div tw="mt-[4rem] overflow-auto">{pageContent}</div>
+          <div tw="overflow-auto">{pageContent}</div>
           <div
             tw="row fixed bottom-0 left-0 right-0 gap-1.25 px-1.25 py-1.25"
             css={{


### PR DESCRIPTION
### Description
- Overhaul Restriction Warning by bundling everything into a Compliance Banner
- Remove compliance toast notifications completely
- Disable Long/Short button when not FULL_ACCESS

### Screenshots
- Desktop

<img width="1497" alt="Screenshot 2025-06-23 at 11 31 07 AM" src="https://github.com/user-attachments/assets/a8957b72-12d9-46dc-b6eb-4852609cd6d4" />

<img width="1494" alt="Screenshot 2025-06-23 at 11 31 20 AM" src="https://github.com/user-attachments/assets/6bd66e30-5a70-4b58-b7f5-79a79a7d8ded" />

<img width="1494" alt="Screenshot 2025-06-23 at 11 31 37 AM" src="https://github.com/user-attachments/assets/49873b8f-4e72-4923-8615-20dc97993d52" />

<img width="1496" alt="Screenshot 2025-06-23 at 11 31 44 AM" src="https://github.com/user-attachments/assets/87ed9376-d76d-4994-b7b3-6ba4e6a9f7f9" />

- Mobile
- 
<img width="405" alt="Screenshot 2025-06-23 at 11 32 00 AM" src="https://github.com/user-attachments/assets/c8f3a769-08da-4341-ba6e-b2c21416ff52" />

<img width="401" alt="Screenshot 2025-06-23 at 11 32 18 AM" src="https://github.com/user-attachments/assets/26fe169b-da17-4549-ba78-f0ff12b6add4" />

<img width="403" alt="Screenshot 2025-06-23 at 11 32 29 AM" src="https://github.com/user-attachments/assets/5a9054cf-0838-40dd-9ec5-b5167a703e13" />

- Simple UI
<img width="306" alt="Screenshot 2025-06-23 at 11 33 46 AM" src="https://github.com/user-attachments/assets/ea08be42-5a38-4bdf-8d10-0711a59c735e" />

<img width="302" alt="Screenshot 2025-06-23 at 11 34 02 AM" src="https://github.com/user-attachments/assets/997c021b-8863-46ac-9367-96c5d1bedb0c" />

<img width="310" alt="Screenshot 2025-06-23 at 11 34 13 AM" src="https://github.com/user-attachments/assets/54127e02-3180-4723-8110-a9a1bf78c96a" />
