### PR TITLE
fix: allow unsafe withdrawals

### DIFF
--- a/src/views/dialogs/TransferDialogs/WithdrawDialog2/queries.ts
+++ b/src/views/dialogs/TransferDialogs/WithdrawDialog2/queries.ts
@@ -29,6 +29,7 @@ async function getSkipWithdrawalRoutes(
     amountIn: parseUnits(amount, token.decimals).toString(),
     smartRelay: true,
     smartSwapOptions: { evmSwaps: true, splitRoutes: true },
+    allowUnsafe: true,
   };
 
   const [slow, fast] = await Promise.all([


### PR DESCRIPTION
I thought about adding a warning when the amount you're getting is low but it doesn't seem to be a huge issue