### PR TITLE
fix: show empty market cap instead of zero for markets with 0 market cap because untrusted source on cmc

### DIFF
--- a/src/views/tables/MarketsTable.tsx
+++ b/src/views/tables/MarketsTable.tsx
@@ -233,7 +233,10 @@ export const MarketsTable = forwardRef(
                 getCellValue: (row) => row.marketCap,
                 label: stringGetter({ key: STRING_KEYS.MARKET_CAP }),
                 renderCell: (row) => (
-                  <$NumberOutput type={OutputType.CompactFiat} value={row.marketCap} />
+                  <$NumberOutput
+                    type={OutputType.CompactFiat}
+                    value={row.marketCap === 0 ? undefined : row.marketCap}
+                  />
                 ),
               },
               {


### PR DESCRIPTION
<img width="1354" height="268" alt="image" src="https://github.com/user-attachments/assets/75c3775e-d042-46bf-9d89-0a94ad09b742" />
For markets like:
<img width="669" height="222" alt="image" src="https://github.com/user-attachments/assets/34f18593-caaa-4e27-ad15-4cb57fc3a69c" />
