### PR TITLE
fix: asset icon background a tiny bit smaller

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -87,7 +87,7 @@ const $AssetIcon = styled.img`
   width: 100%;
   min-width: 100%;
   object-fit: cover;
-  z-index: 2;
+  transform: scale(1);
   border-radius: 50%;
 `;
 
@@ -98,7 +98,6 @@ const $ContainerBackground = styled.div`
   width: 100%;
   min-width: 100%;
   transform: scale(0.99); // Scale in order to hide outline from '--asset-icon-backgroundColor'
-  z-index: 1;
   background-color: var(--asset-icon-backgroundColor, var(--color-white));
   border-radius: 50%;
 `;

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -37,6 +37,7 @@ export const AssetIcon = ({
 
   return logoUrl ? (
     <$Container className={className}>
+      <$ContainerBackground />
       <$AssetIcon
         src={logoUrl}
         alt={symbol ?? 'logo'}
@@ -53,6 +54,7 @@ export const AssetIcon = ({
     </$Container>
   ) : isAssetSymbol(symbol) ? (
     <$Container className={className} $hasChainIcon={!!chainId}>
+      <$ContainerBackground />
       <$AssetIcon src={ASSET_ICON_MAP[symbol]} alt={symbol} />
       {chainId && <$ChainIcon src={CHAIN_INFO[chainId]?.icon} alt={CHAIN_INFO[chainId]?.name} />}
     </$Container>
@@ -66,7 +68,6 @@ const $Container = styled.div<{ $hasChainIcon?: boolean }>`
   min-height: var(--asset-icon-size, 1em);
   width: var(--asset-icon-size, 1em);
   min-width: var(--asset-icon-size, 1em);
-  background-color: var(--asset-icon-backgroundColor, var(--color-white));
   border-radius: 50%;
   position: relative;
   display: flex;
@@ -87,7 +88,17 @@ const $AssetIcon = styled.img`
   min-width: 100%;
   object-fit: cover;
   transform: scale(1.05); // Scale in order to hide outline from '--asset-icon-backgroundColor'
+  border-radius: 50%;
+`;
 
+const $ContainerBackground = styled.div`
+  position: absolute;
+  height: 100%;
+  min-height: 100%;
+  width: 100%;
+  min-width: 100%;
+  transform: scale(0.99); // Scale in order to hide outline from '--asset-icon-backgroundColor'
+  background-color: var(--asset-icon-backgroundColor, var(--color-white));
   border-radius: 50%;
 `;
 

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -87,7 +87,7 @@ const $AssetIcon = styled.img`
   width: 100%;
   min-width: 100%;
   object-fit: cover;
-  transform: scale(1.05); // Scale in order to hide outline from '--asset-icon-backgroundColor'
+  z-index: 2;
   border-radius: 50%;
 `;
 
@@ -98,6 +98,7 @@ const $ContainerBackground = styled.div`
   width: 100%;
   min-width: 100%;
   transform: scale(0.99); // Scale in order to hide outline from '--asset-icon-backgroundColor'
+  z-index: 1;
   background-color: var(--asset-icon-backgroundColor, var(--color-white));
   border-radius: 50%;
 `;


### PR DESCRIPTION
before:
<img width="884" height="572" alt="image" src="https://github.com/user-attachments/assets/dbd7a316-5785-4cc2-a5e6-f0400c789862" />

after:
<img width="1358" height="589" alt="image" src="https://github.com/user-attachments/assets/c0e17b91-b6f9-4f44-a4b1-440240666740" />
