### PR TITLE
fix: update surge banner URL to dydx.trade/DYDX

### DIFF
--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -121,7 +121,7 @@ export const MarketsBanners = ({
           <Button
             action={ButtonAction.Primary}
             type={ButtonType.Link}
-            href="https://www.dydx.xyz/surge?utm_source=markets&utm_medium=markets-banner&utm_campaign=13082025-markets-surge-banner-dydx&utm_term=&utm_content=surge-banner-learn-more"
+            href="https://dydx.trade/DYDX?utm_source=markets&utm_medium=markets-banner&utm_campaign=13082025-markets-surge-banner-dydx&utm_term=&utm_content=surge-banner"
             tw="relative z-10 w-12"
           >
             {stringGetter({ key: STRING_KEYS.LEARN_MORE })}

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -122,7 +122,7 @@ export const MarketsBanners = ({
             action={ButtonAction.Primary}
             type={ButtonType.Link}
             href="https://dydx.trade/DYDX?utm_source=markets&utm_medium=markets-banner&utm_campaign=13082025-markets-surge-banner-dydx&utm_term=&utm_content=surge-banner"
-            tw="relative z-10 w-12" 
+            tw="relative z-10 w-12"
           >
             {stringGetter({ key: STRING_KEYS.LEARN_MORE })}
           </Button>

--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -122,7 +122,7 @@ export const MarketsBanners = ({
             action={ButtonAction.Primary}
             type={ButtonType.Link}
             href="https://dydx.trade/DYDX?utm_source=markets&utm_medium=markets-banner&utm_campaign=13082025-markets-surge-banner-dydx&utm_term=&utm_content=surge-banner"
-            tw="relative z-10 w-12"
+            tw="relative z-10 w-12" 
           >
             {stringGetter({ key: STRING_KEYS.LEARN_MORE })}
           </Button>


### PR DESCRIPTION
Updated url to point to https://dydx.trade/DYDX?utm_source=markets&utm_medium=markets-banner&utm_campaign=13082025-markets-surge-banner-dydx&utm_term=&utm_content=surge-banner
