### PR TITLE
fix: bypass browser cache for affiliates metadata endpoint

### DIFF
--- a/src/hooks/useAffiliatesInfo.ts
+++ b/src/hooks/useAffiliatesInfo.ts
@@ -39,6 +39,7 @@ export const useAffiliateMetadata = (dydxAddress?: string) => {
           headers: {
             'Content-Type': 'application/json',
           },
+          cache: 'no-store',
         }),
         fetch(`${totalVolumeEndpoint}?address=${encodeURIComponent(dydxAddress)}`, {
           method: 'GET',


### PR DESCRIPTION
after updating a user’s referral code we invalidate `/affiliates/metadata` route and refetch. the refetch still serves cached data for ~10s due to response headers, so users don’t see updates immediately.