### PR TITLE
fix: hacky fix for turnkey recovery phrase styling

### DIFF
--- a/src/views/dialogs/ManageAccountDialog/RevealPhrase.tsx
+++ b/src/views/dialogs/ManageAccountDialog/RevealPhrase.tsx
@@ -283,6 +283,7 @@ export const RevealPhrase = ({
                 tw="font-small-book"
                 css={{
                   opacity: !isIframeVisible && !loading ? 1 : 0,
+                  pointerEvents: isIframeVisible ? 'none' : 'auto',
                 }}
               >
                 {Array.from({ length: 12 }).map((_, idx) => (


### PR DESCRIPTION
light mode already looks fine, this fix only applies to dark mode

<img width="452" height="341" alt="image" src="https://github.com/user-attachments/assets/4b6ba514-2c34-4813-a6b1-43a4a40f4375" />
