### PR TITLE
fix: log errors correctly by reconstructing an error and shoving a message in

### DIFF
--- a/src/bonsai/AccountTransactionSupervisor.ts
+++ b/src/bonsai/AccountTransactionSupervisor.ts
@@ -1418,6 +1418,7 @@ function bonsaiLoggingMiddleware() {
         payload,
         parsed: result.result.displayInfo,
         errorString: result.result.errorString,
+        error: new Error(result.result.errorString),
         source: context.fnName,
         timeToSubmit: startTime.elapsed(),
       });


### PR DESCRIPTION
TURNS OUT datadog doesn't index any field other than error.message so search totally fails now 