### PR TITLE
fix: don't allow trades that are taking you from invalid account state to MORE invalid

### DIFF
--- a/src/bonsai/calculators/subaccount.ts
+++ b/src/bonsai/calculators/subaccount.ts
@@ -71,6 +71,7 @@ export function calculateParentSubaccountSummary(
     marginUsage: parentSummary.marginUsage,
     leverage: parentSummary.leverage,
     freeCollateral: parentSummary.freeCollateral,
+    rawFreeCollateral: parentSummary.rawFreeCollateral,
     parentSubaccountEquity: parentSummary.equity,
     equity: Object.values(summaries)
       .filter(isPresent)
@@ -151,7 +152,8 @@ function calculateSubaccountSummaryDerived(core: SubaccountSummaryCore): Subacco
   const { initialRiskTotal, notionalTotal, quoteBalance, valueTotal } = core;
   const equity = BigNumber.max(valueTotal.plus(quoteBalance), BIG_NUMBERS.ZERO);
 
-  const freeCollateral = BigNumber.max(equity.minus(initialRiskTotal), BIG_NUMBERS.ZERO);
+  const rawFreeCollateral = equity.minus(initialRiskTotal);
+  const freeCollateral = BigNumber.max(rawFreeCollateral, BIG_NUMBERS.ZERO);
 
   let leverage = null;
   let marginUsage = null;
@@ -163,6 +165,7 @@ function calculateSubaccountSummaryDerived(core: SubaccountSummaryCore): Subacco
 
   return {
     freeCollateral,
+    rawFreeCollateral,
     equity,
     leverage,
     marginUsage,

--- a/src/bonsai/forms/trade/errors.ts
+++ b/src/bonsai/forms/trade/errors.ts
@@ -710,9 +710,23 @@ function validateParentSubaccountMarginUsage(
   // Check if margin usage is invalid
   const isInvalidAfter = equityAfter <= 0 || marginUsageAfter == null || marginUsageAfter >= 1;
   const wasInvalidBefore = equityBefore <= 0 || marginUsageBefore == null || marginUsageBefore >= 1;
+
   // only error if they're going from valid->invalid
   // invalid->invalid is fine and invalid->valid is fine
   if (isInvalidAfter && !wasInvalidBefore) {
+    return simpleValidationError({
+      code: 'INVALID_NEW_ACCOUNT_MARGIN_USAGE',
+      type: ErrorType.error,
+      fields: ['size.size'],
+      titleKey: STRING_KEYS.MODIFY_SIZE_FIELD,
+      textKey: STRING_KEYS.INVALID_NEW_ACCOUNT_MARGIN_USAGE,
+    });
+  }
+
+  const rawFreeCollateralBefore = accountBefore.rawFreeCollateral.toNumber();
+  const rawFreeCollateralAfter = accountAfter.rawFreeCollateral.toNumber();
+
+  if (rawFreeCollateralBefore <= 0 && rawFreeCollateralAfter < rawFreeCollateralBefore) {
     return simpleValidationError({
       code: 'INVALID_NEW_ACCOUNT_MARGIN_USAGE',
       type: ErrorType.error,

--- a/src/bonsai/types/summaryTypes.ts
+++ b/src/bonsai/types/summaryTypes.ts
@@ -58,7 +58,11 @@ export type SubaccountSummaryCore = {
 };
 
 export type SubaccountSummaryDerived = {
+  // clamped at 0
   freeCollateral: BigNumber;
+  // allowed to be negative
+  rawFreeCollateral: BigNumber;
+  // clamped at 0
   equity: BigNumber;
   leverage: BigNumber | null;
   marginUsage: BigNumber | null;


### PR DESCRIPTION
Main case is preventing users who just made their account and have 0 funds from placing trades