### PR TITLE
feat: Update FAQ to use new SURGE reward strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@datadog/browser-logs": "^5.23.3",
     "@dydxprotocol/v4-client-js": "3.0.3",
-    "@dydxprotocol/v4-localization": "1.1.325",
+    "@dydxprotocol/v4-localization": "1.1.327",
     "@dydxprotocol/v4-proto": "^7.0.0-dev.0",
     "@emotion/is-prop-valid": "^1.3.0",
     "@hugocxl/react-to-image": "^0.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 3.0.3
     version: 3.0.3
   '@dydxprotocol/v4-localization':
-    specifier: 1.1.325
-    version: 1.1.325
+    specifier: 1.1.327
+    version: 1.1.327
   '@dydxprotocol/v4-proto':
     specifier: ^7.0.0-dev.0
     version: 7.0.0-dev.0
@@ -1525,8 +1525,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@dydxprotocol/v4-localization@1.1.325:
-    resolution: {integrity: sha512-IAVnOLYrPHRQJLMEmfn0s6jcT2UkfAsTF0bkVZj8G08uMIawhrNnvRkIqk8ck320me5W1qrO0GYI7Nbagzfx0g==}
+  /@dydxprotocol/v4-localization@1.1.327:
+    resolution: {integrity: sha512-bmYOUj31gpbSK2PtYKisgVcI1uggJJm+hKV3YFxPsj7rX36HrHbcvqVDSE43dQ3uKX0F43fUvfS9B0A1GKKMxA==}
     dev: false
 
   /@dydxprotocol/v4-proto@7.0.0-dev.0:
@@ -4539,6 +4539,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.3
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -17947,6 +17948,10 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /napi-wasm@1.1.3:
+    resolution: {integrity: sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==}
+    dev: false
 
   /native-abort-controller@1.0.4(abort-controller@3.0.0):
     resolution: {integrity: sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==}

--- a/src/pages/token/RewardsHelpPanel.tsx
+++ b/src/pages/token/RewardsHelpPanel.tsx
@@ -40,21 +40,20 @@ export const RewardsHelpPanel = () => {
       <Accordion
         items={[
           {
-            header: stringGetter({ key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_QUESTION }),
-            content: stringGetter({ key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_ANSWER }),
-          },
-          {
-            header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_TRADING_REWARDS_WORK_QUESTION }),
+            header: stringGetter({
+              key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_FOR_SURGE_REWARDS_QUESTION,
+            }),
             content: stringGetter({
-              key: STRING_KEYS.FAQ_HOW_DO_TRADING_REWARDS_WORK_ANSWER,
-              params: {
-                HERE_LINK: hereLink(tradingRewardsLearnMore),
-              },
+              key: STRING_KEYS.FAQ_WHO_IS_ELIGIBLE_FOR_SURGE_REWARDS_ANSWER,
             }),
           },
           {
-            header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_QUESTION }),
-            content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_REWARDS_ANSWER }),
+            header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_SURGE_REWARDS_WORK_QUESTION }),
+            content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_SURGE_REWARDS_WORK_ANSWER }),
+          },
+          {
+            header: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_SURGE_REWARDS_QUESTION }),
+            content: stringGetter({ key: STRING_KEYS.FAQ_HOW_DO_I_CLAIM_MY_SURGE_REWARDS_ANSWER }),
           },
           {
             header: stringGetter({ key: STRING_KEYS.FAQ_WHAT_IS_STAKING_QUESTION }),

--- a/src/views/MarketsStats.tsx
+++ b/src/views/MarketsStats.tsx
@@ -83,8 +83,8 @@ export const MarketsStats = (props: MarketsStatsProps) => {
       <$FreeDepositBanner>
         <div tw="flex items-center justify-between gap-0.75">
           <div tw="relative z-10 mr-auto flex max-w-10 flex-col">
-            <span tw="mb-0.75 leading-[1.2] font-extra-large-bold">
-              <span tw="mr-0.25 rounded-0 bg-color-layer-1 px-0.25 text-color-accent">
+            <span tw="mb-0.75 !leading-tight font-extra-large-bold">
+              <span tw="mr-0.25 rounded-0 bg-color-text-2 px-0.25 text-color-accent">
                 {stringGetter({ key: STRING_KEYS.FREE_DEPOSIT_BANNER_TITLE_FREE })}
               </span>
               <span tw="text-color-text-2">
@@ -110,7 +110,7 @@ export const MarketsStats = (props: MarketsStatsProps) => {
           <img
             src="/free-deposit-hedgie.png"
             alt="free deposit hedgie"
-            tw="absolute bottom-0 left-7 z-0 h-14 object-contain mobile:hidden"
+            tw="absolute bottom-0 left-6 z-0 h-full object-contain mobile:hidden"
           />
         </div>
       </$FreeDepositBanner>


### PR DESCRIPTION
Update the first 3 FAQ items to use SURGE-specific strings instead of general trading rewards.