### PR TITLE
feat: add account management/export to simple ui

### DIFF
--- a/src/views/menus/UserMenuContent.tsx
+++ b/src/views/menus/UserMenuContent.tsx
@@ -26,6 +26,7 @@ import { calculateCanAccountTrade } from '@/state/accountCalculators';
 import { getOnboardingState } from '@/state/accountSelectors';
 import { useAppDispatch, useAppSelector } from '@/state/appTypes';
 import { openDialog } from '@/state/dialogs';
+import { selectIsTurnkeyConnected } from '@/state/walletSelectors';
 
 import { isTruthy } from '@/lib/isTruthy';
 import { orEmptyObj } from '@/lib/typeUtils';
@@ -38,6 +39,7 @@ export const UserMenuContent = () => {
   const onboardingState = useAppSelector(getOnboardingState);
   const { complianceState } = useComplianceState();
   const canAccountTrade = useAppSelector(calculateCanAccountTrade);
+  const isTurnkeyConnected = useAppSelector(selectIsTurnkeyConnected);
   const { equity, freeCollateral } = orEmptyObj(
     useAppSelector(BonsaiCore.account.parentSubaccountSummary.data)
   );
@@ -93,6 +95,24 @@ export const UserMenuContent = () => {
         dispatch(openDialog(DialogTypes.Help()));
       },
     },
+    onboardingState === OnboardingState.AccountConnected &&
+      (isTurnkeyConnected
+        ? {
+            key: 'export-turnkey',
+            label: stringGetter({ key: STRING_KEYS.ACCOUNT_MANAGEMENT }),
+            icon: <Icon iconName={IconName.User} />,
+            onClick: () => {
+              dispatch(openDialog(DialogTypes.ManageAccount()));
+            },
+          }
+        : {
+            key: 'export-keys',
+            label: stringGetter({ key: STRING_KEYS.EXPORT_DYDX_WALLET }),
+            icon: <Icon iconName={IconName.ExportKeys} />,
+            onClick: () => {
+              dispatch(openDialog(DialogTypes.MnemonicExport()));
+            },
+          }),
     onboardingState !== OnboardingState.Disconnected && {
       key: 'disconnect-wallet',
       label: stringGetter({ key: STRING_KEYS.SIGN_OUT }),


### PR DESCRIPTION
<img width="514" height="989" alt="Screenshot 2025-09-29 at 4 38 20 PM" src="https://github.com/user-attachments/assets/1aec94ab-0443-4b94-a887-91a82d4d9f1a" />
