### PR TITLE
feat: remove subtitle from rebate banner

### DIFF
--- a/src/pages/markets/MarketsBanners.tsx
+++ b/src/pages/markets/MarketsBanners.tsx
@@ -129,9 +129,6 @@ export const MarketsBanners = ({
           >
             {stringGetter({ key: STRING_KEYS.GET_STARTED })}
           </Button>
-          <span tw="text-color-text-2 font-base-book">
-            {stringGetter({ key: STRING_KEYS.REBATE_BANNER_SUBTITLE })}
-          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Remove the "Front-end only" subtitle text from the rebate banner to simplify the layout.