### PR TITLE
fix: noble client init failure must not block trading

### DIFF
--- a/src/bonsai/rest/lib/compositeClientManager.ts
+++ b/src/bonsai/rest/lib/compositeClientManager.ts
@@ -103,7 +103,11 @@ function makeCompositeClient({
   }
 
   async function initializeNobleClient() {
-    return (await getLazyStargateClient()).connect(networkConfig.endpoints.nobleValidator);
+    const nobleUrl = networkConfig.endpoints.nobleValidator;
+    if (!nobleUrl) {
+      throw new Error('nobleValidator endpoint not configured');
+    }
+    return (await getLazyStargateClient()).connect(nobleUrl);
   }
 
   async function initializeIndexerClient() {
@@ -296,11 +300,14 @@ function initializeClientWrapper(
         })
       ),
     onError: (e) => {
+      // Noble client is optional: it is only needed for cross-chain (IBC) transfers.
+      // Do NOT set errorInitializing here — a missing/unconfigured noble validator
+      // (e.g. in local dev environments) must not prevent core trading functionality.
       logBonsaiError('CompositeClientManager', 'error initializing noble client', { error: e });
       dispatch(
         setNetworkStateRaw({
           networkId: network,
-          stateToMerge: { nobleClientReady: false, errorInitializing: true },
+          stateToMerge: { nobleClientReady: false },
         })
       );
     },


### PR DESCRIPTION
## Problem

When the `nobleValidator` endpoint is empty or unreachable (common in local dev environments that don't configure Noble cross-chain support), the noble `StargateClient` initialization throws an error.

Previously, this error set `errorInitializing: true` in Redux state, which propagated through the following chain:

```
errorInitializing: true
→ selectClientInitializationError → true
→ getConnectionError → CHAIN_DISRUPTION
→ tradingUnavailable → true
→ place-order button permanently disabled
```

This means **any developer running a local dYdX environment without a Noble validator configured cannot place any orders**, even though Noble is only needed for cross-chain IBC transfers — not core perpetuals trading.

## Root Cause

In `compositeClientManager.ts`, the noble client `onError` handler sets `errorInitializing: true`, which is the same flag used to signal that the **composite client** (the core trading client) has failed. Noble failure is incorrectly treated as a fatal initialization error.

## Fix

1. **Skip `StargateClient.connect()`** when `nobleValidator` URL is empty/falsy, rather than passing an empty string which causes an immediate connection error.
2. **Remove `errorInitializing: true`** from the noble client `onError` handler. Noble client failure now only sets `nobleClientReady: false`, which correctly disables cross-chain transfer UI without affecting trading.

## Impact

- Fixes place-order button being permanently disabled in local dev environments without Noble configured.
- No impact on production/testnet environments where Noble is properly configured.
- Cross-chain transfer features continue to be gated by `nobleClientReady`.